### PR TITLE
Restrict release uploads to installer artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,10 +124,20 @@ jobs:
       - name: Verify release artifacts fit GitHub
         shell: pwsh
         run: |
-          $artifacts = Get-ChildItem "app\release" -Recurse -File | Where-Object {
-            $_.Extension -in ".exe", ".7z", ".zip", ".blockmap", ".yml"
+          $releaseDir = "app\release\nsis-web"
+          $artifacts = Get-ChildItem $releaseDir -File | Where-Object {
+            $_.Extension -in ".exe", ".7z", ".blockmap", ".yml"
           }
           if (-not $artifacts) { throw "No release artifacts were produced." }
+          if (-not ($artifacts | Where-Object Extension -eq ".exe")) {
+            throw "No web installer executable was produced."
+          }
+          if (-not ($artifacts | Where-Object Extension -eq ".7z")) {
+            throw "No offline installer payload was produced."
+          }
+          if (-not ($artifacts | Where-Object Name -eq "latest.yml")) {
+            throw "No update manifest was produced."
+          }
           # Keep margin below GitHub's 2 GiB per-file release limit.
           $maxAssetBytes = 2100000000
           $oversized = $artifacts | Where-Object Length -ge $maxAssetBytes
@@ -142,8 +152,7 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
-            app/release/**/*.exe
-            app/release/**/*.7z
-            app/release/**/*.zip
-            app/release/**/*.blockmap
-            app/release/**/*.yml
+            app/release/nsis-web/*.exe
+            app/release/nsis-web/*.7z
+            app/release/nsis-web/*.blockmap
+            app/release/nsis-web/*.yml

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -82,10 +82,12 @@ def test_release_workflow_installs_extras_and_uploads_payloads() -> None:
     assert "uv run --no-sync pytest" in contents
     assert "--group dev" in contents
     assert "GH_TOKEN" not in contents
-    assert 'Get-ChildItem "app\\release" -Recurse -File' in contents
-    assert "app/release/**/*.yml" in contents
-    assert "app/release/**/*.blockmap" in contents
-    assert "app/release/**/*.7z" in contents or "app/release/**/*.zip" in contents
+    assert '$releaseDir = "app\\release\\nsis-web"' in contents
+    assert "app/release/nsis-web/*.exe" in contents
+    assert "app/release/nsis-web/*.yml" in contents
+    assert "app/release/nsis-web/*.blockmap" in contents
+    assert "app/release/nsis-web/*.7z" in contents
+    assert "app/release/**/*.exe" not in contents
 
 
 def test_packaging_includes_relocatable_runtime() -> None:


### PR DESCRIPTION
## Summary
- limit release verification and upload to the actual pp/release/nsis-web output
- require the web installer, offline payload, and update manifest before publication
- prevent packaged runtime executables and configuration files from becoming release assets

## Validation
- git diff --check`n- v0.6.0 release build already passed server tests, app tests, portable runtime smoke, packaged runtime imports, and artifact size verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows release validation to confirm all required installer artifacts are generated.
  * Updated GitHub release publishing to upload only the intended Windows installer files and update manifest.
  * Prevented unrelated archive files from being included in Windows releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->