### PR TITLE
Fix v0.6.1 web installer download source

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/v0.6.0-orange?style=flat-square" alt="v0.6.0">
+  <img src="https://img.shields.io/badge/v0.6.1-orange?style=flat-square" alt="v0.6.1">
 </p>
 
 <!-- TODO: add a demo gif here once one exists -->

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",
@@ -97,7 +97,9 @@
     },
     "publish": [
       {
-        "provider": "github"
+        "provider": "github",
+        "owner": "burntcookiedough",
+        "repo": "murmur"
       }
     ]
   }

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.6.0"
+version = "0.6.1"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.6.0"
+SERVER_VERSION = "0.6.1"

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -61,6 +61,23 @@ def test_electron_builder_publish_includes_github() -> None:
     assert "github" in providers
 
 
+def test_electron_builder_publish_targets_release_repository() -> None:
+    package_json = _load_package_json()
+    publish = package_json.get("build", {}).get("publish")
+    github_publishers = [
+        entry
+        for entry in publish
+        if isinstance(entry, dict) and entry.get("provider") == "github"
+    ]
+    assert github_publishers == [
+        {
+            "provider": "github",
+            "owner": "burntcookiedough",
+            "repo": "murmur",
+        }
+    ]
+
+
 def test_windows_packaging_never_publishes_implicitly() -> None:
     package_json = _load_package_json()
     package_script = package_json.get("scripts", {}).get("package:win", "")


### PR DESCRIPTION
## Summary
- pin electron-builder's GitHub publisher to urntcookiedough/murmur`n- add a regression test for the exact release owner/repository
- bump the hotfix version to 0.6.1

## Root cause
The v0.6.0 web installer inferred dikkadev/murmur from the inherited package repository metadata and received a 404 while fetching its NSIS payload.

## Validation
- version consistency check for v0.6.1
- 11 release-configuration tests
- 43 Electron app tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application, server, and documentation version to **0.6.1**.
  * Improved release publishing configuration to target the correct repository.
* **Tests**
  * Added validation to ensure release publishing uses the expected repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->