### PR TITLE
Show model download progress and ETA

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/v0.6.1-orange?style=flat-square" alt="v0.6.1">
+  <img src="https://img.shields.io/badge/v0.6.2-orange?style=flat-square" alt="v0.6.2">
 </p>
 
 <!-- TODO: add a demo gif here once one exists -->

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -13,6 +13,7 @@ import { getSettings, getSetting } from './services/settings.js';
 import type { TextFrameFinal } from '../shared/protocol.js';
 import { IPC_CHANNELS } from '../shared/constants.js';
 import { buildHotwordsPrompt } from '../shared/hotwords.js';
+import { getModelProgressShortSummary } from '../shared/model-progress.js';
 import type {
   RecordingStatePayload,
   ConnectionStatePayload,
@@ -184,9 +185,10 @@ async function startRecording(source: 'lab' | 'normal', sessionMode: DictationSe
     serverState?.engineStatus?.status !== 'ready'
   ) {
     const engineStatus = serverState?.engineStatus;
+    const progressSummary = getModelProgressShortSummary(serverState?.modelDownload);
     const message = engineStatus?.status === 'error'
       ? (engineStatus.message ?? 'The transcription engine failed to load. Open Server settings for details.')
-      : 'The speech model is still loading. Keep Murmur open and try again when the Server status is ready.';
+      : progressSummary ?? 'The speech model is still loading. Keep Murmur open and try again when the Server status is ready.';
     log.warn('Cannot start recording: transcription engine is not ready', {
       engine: engineStatus?.current,
       engineStatus: engineStatus?.status ?? 'unknown',

--- a/app/src/main/services/server-health.ts
+++ b/app/src/main/services/server-health.ts
@@ -12,6 +12,65 @@ export interface HealthState {
   engineStatus?: EngineStatus;
 }
 
+const MODEL_DOWNLOAD_STATUSES = new Set(['missing', 'partial', 'downloading', 'ready', 'error']);
+const MODEL_DOWNLOAD_PHASES = new Set(['checking', 'downloading', 'loading', 'ready', 'error']);
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function optionalNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function optionalStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+    ? value
+    : undefined;
+}
+
+function parseModelDownloadState(value: unknown): ModelDownloadState | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Record<string, unknown>;
+  if (
+    typeof raw.model !== 'string' ||
+    typeof raw.size_gb !== 'number' ||
+    !Number.isFinite(raw.size_gb) ||
+    raw.size_gb < 0 ||
+    typeof raw.status !== 'string' ||
+    !MODEL_DOWNLOAD_STATUSES.has(raw.status)
+  ) {
+    return undefined;
+  }
+
+  const progress = optionalNonNegativeNumber(raw.progress_percent);
+  const phase =
+    typeof raw.phase === 'string' && MODEL_DOWNLOAD_PHASES.has(raw.phase)
+      ? (raw.phase as ModelDownloadState['phase'])
+      : undefined;
+
+  return {
+    model: raw.model,
+    size_gb: raw.size_gb,
+    status: raw.status as ModelDownloadState['status'],
+    cached: typeof raw.cached === 'boolean' ? raw.cached : undefined,
+    detail: optionalString(raw.detail),
+    repo_id: optionalString(raw.repo_id),
+    path: optionalString(raw.path),
+    missing_files: optionalStringArray(raw.missing_files),
+    partial_files: optionalStringArray(raw.partial_files),
+    updated_at: optionalString(raw.updated_at),
+    phase,
+    progress_percent: progress === undefined ? undefined : Math.min(100, progress),
+    downloaded_bytes: optionalNonNegativeNumber(raw.downloaded_bytes),
+    total_bytes: optionalNonNegativeNumber(raw.total_bytes),
+    bytes_per_second: optionalNonNegativeNumber(raw.bytes_per_second),
+    eta_seconds: optionalNonNegativeNumber(raw.eta_seconds),
+    current_file: optionalString(raw.current_file),
+    started_at: optionalString(raw.started_at),
+  };
+}
+
 export function parseHealthyResponse(data: unknown): HealthState {
   if (!data || typeof data !== 'object') return { healthy: false };
 
@@ -35,9 +94,7 @@ export function parseHealthyResponse(data: unknown): HealthState {
         ? (payload.diagnostics as ServerDiagnostics)
         : undefined,
     modelDownload:
-      payload.model_download && typeof payload.model_download === 'object'
-        ? (payload.model_download as ModelDownloadState)
-        : undefined,
+      parseModelDownloadState(payload.model_download),
     engineStatus,
   };
 }

--- a/app/src/renderer/app/App.svelte
+++ b/app/src/renderer/app/App.svelte
@@ -6,6 +6,7 @@
   import SettingsView from './views/SettingsView.svelte';
   import TestView from './views/TestView.svelte';
   import ServerView from './views/ServerView.svelte';
+  import ModelProgressBanner from './components/ModelProgressBanner.svelte';
 
   type View = 'history' | 'insights' | 'settings' | 'test' | 'server';
 
@@ -46,6 +47,8 @@
       {/each}
     </nav>
   </header>
+
+  <ModelProgressBanner visible={activeView !== 'server'} />
 
   <!-- Main Content -->
   <main class="flex-1 overflow-hidden">

--- a/app/src/renderer/app/components/ModelProgressBanner.svelte
+++ b/app/src/renderer/app/components/ModelProgressBanner.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { ServerStatePayload } from '$shared/types';
+  import { shouldShowModelProgress } from '$shared/model-progress';
   import ModelProgressCard from './ModelProgressCard.svelte';
 
   let { visible = true }: { visible?: boolean } = $props();
   let serverState = $state<ServerStatePayload | null>(null);
   let modelDownload = $derived(serverState?.modelDownload);
   let showBanner = $derived(
-    modelDownload?.status === 'error' ||
-    modelDownload?.status === 'downloading' ||
-    modelDownload?.phase === 'checking' ||
-    modelDownload?.phase === 'loading'
+    modelDownload?.status === 'error' || shouldShowModelProgress(modelDownload)
   );
 
   async function refreshServerState() {

--- a/app/src/renderer/app/components/ModelProgressBanner.svelte
+++ b/app/src/renderer/app/components/ModelProgressBanner.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { ServerStatePayload } from '$shared/types';
+  import ModelProgressCard from './ModelProgressCard.svelte';
+
+  let { visible = true }: { visible?: boolean } = $props();
+  let serverState = $state<ServerStatePayload | null>(null);
+  let modelDownload = $derived(serverState?.modelDownload);
+  let showBanner = $derived(
+    modelDownload?.status === 'error' ||
+    modelDownload?.status === 'downloading' ||
+    modelDownload?.phase === 'checking' ||
+    modelDownload?.phase === 'loading'
+  );
+
+  async function refreshServerState() {
+    try {
+      serverState = await window.murmurMain.getServerStatus();
+    } catch {
+      // The managed server can be unavailable briefly while the app starts.
+    }
+  }
+
+  onMount(() => {
+    void refreshServerState();
+    const timer = window.setInterval(refreshServerState, 3000);
+    return () => window.clearInterval(timer);
+  });
+</script>
+
+{#if visible && modelDownload && showBanner}
+  <div
+    class="pointer-events-none fixed left-1/2 top-[calc(env(safe-area-inset-top)+7rem)] z-20 w-[calc(100%-2rem)] max-w-2xl -translate-x-1/2"
+  >
+    {#if modelDownload.status === 'error'}
+      <section aria-live="assertive" class="rounded-xl border border-red-900/60 bg-zinc-950/95 p-4 shadow-lg">
+        <p class="text-sm font-medium text-red-300 text-pretty">Speech model setup failed</p>
+        <p class="mt-1 text-xs text-red-300/80 text-pretty">
+          {modelDownload.detail ?? 'Check your connection.'} Open Server and use Restart to retry.
+        </p>
+      </section>
+    {:else}
+      <ModelProgressCard state={modelDownload} />
+    {/if}
+  </div>
+{/if}

--- a/app/src/renderer/app/components/ModelProgressCard.svelte
+++ b/app/src/renderer/app/components/ModelProgressCard.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { ModelDownloadState } from '$shared/types';
+  import { getModelProgressView } from '$shared/model-progress';
+
+  let { state }: { state?: ModelDownloadState } = $props();
+  let view = $derived(getModelProgressView(state));
+</script>
+
+{#if view}
+  <section
+    aria-live="polite"
+    aria-atomic="true"
+    class="rounded-xl border border-amber-900/60 bg-zinc-950/95 p-4 shadow-lg"
+  >
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <p class="text-sm font-medium text-amber-200 text-pretty">{view.title}</p>
+        <p class="mt-1 text-xs text-amber-200/75 text-pretty">{view.summary}</p>
+      </div>
+      <span class="shrink-0 rounded-full bg-amber-950 px-2 py-1 text-xs text-amber-200/80 tabular-nums">
+        {view.stepLabel}
+      </span>
+    </div>
+
+    {#if view.progressPercent !== null}
+      <progress
+        class="mt-3 h-1.5 w-full overflow-hidden rounded-full accent-amber-400"
+        max="100"
+        value={view.progressPercent}
+        aria-label={`${view.title}: ${Math.round(view.progressPercent)}%`}
+      ></progress>
+    {/if}
+
+    {#if view.metrics}
+      <p class="mt-2 text-xs text-zinc-400 text-pretty tabular-nums">{view.metrics}</p>
+    {/if}
+  </section>
+{/if}

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -3,6 +3,7 @@
   import Toggle from '../components/Toggle.svelte';
   import SettingsRow from '../components/SettingsRow.svelte';
   import SettingsSection from '../components/SettingsSection.svelte';
+  import ModelProgressCard from '../components/ModelProgressCard.svelte';
   import type { ServerStatePayload, ServerLogEntry, Settings } from '$shared/types';
 
   // Server state
@@ -44,7 +45,11 @@
   let engineReady = $derived(serverState.engineStatus?.status === 'ready');
   let diagnosticWarnings = $derived(serverState.diagnostics?.warnings ?? []);
   let modelDownload = $derived(serverState.modelDownload);
-  let isDownloadingModel = $derived(modelDownload?.status === 'downloading');
+  let showModelProgress = $derived(
+    modelDownload?.status === 'downloading' ||
+    modelDownload?.phase === 'checking' ||
+    modelDownload?.phase === 'loading'
+  );
   let modelDownloadError = $derived(modelDownload?.status === 'error');
 
   // Format uptime as human-readable string
@@ -64,12 +69,6 @@
   function formatLogTime(timestamp: number): string {
     const date = new Date(timestamp);
     return date.toLocaleTimeString('en-US', { hour12: false });
-  }
-
-  function formatModelSize(sizeGb?: number): string {
-    if (!sizeGb || Number.isNaN(sizeGb)) return '';
-    const rounded = Math.round(sizeGb * 10) / 10;
-    return `${rounded} GB`;
   }
 
   // Can start/stop based on status and management mode
@@ -304,20 +303,9 @@
           </div>
         {/if}
 
-        {#if isDownloadingModel}
-          <div class="mb-4 rounded-lg border border-amber-900/60 bg-amber-950/30 p-3">
-            <p class="text-sm text-amber-200">
-              Downloading {modelDownload?.model ?? 'model'}
-              {#if modelDownload?.size_gb}
-                <span class="text-amber-300/80">({formatModelSize(modelDownload.size_gb)})</span>
-              {/if}
-            </p>
-            <p class="mt-1 text-xs text-amber-300/80">
-              First run downloads can take a few minutes. Keep the app open while the model is fetched.
-            </p>
-            <p class="mt-2 text-xs text-amber-300/80">
-              If the download stalls, check your connection and use Restart to retry.
-            </p>
+        {#if modelDownload && showModelProgress}
+          <div class="mx-auto mb-4 max-w-2xl">
+            <ModelProgressCard state={modelDownload} />
           </div>
         {/if}
 

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -5,6 +5,7 @@
   import SettingsSection from '../components/SettingsSection.svelte';
   import ModelProgressCard from '../components/ModelProgressCard.svelte';
   import type { ServerStatePayload, ServerLogEntry, Settings } from '$shared/types';
+  import { shouldShowModelProgress } from '$shared/model-progress';
 
   // Server state
   let serverState = $state<ServerStatePayload>({
@@ -45,11 +46,7 @@
   let engineReady = $derived(serverState.engineStatus?.status === 'ready');
   let diagnosticWarnings = $derived(serverState.diagnostics?.warnings ?? []);
   let modelDownload = $derived(serverState.modelDownload);
-  let showModelProgress = $derived(
-    modelDownload?.status === 'downloading' ||
-    modelDownload?.phase === 'checking' ||
-    modelDownload?.phase === 'loading'
-  );
+  let showModelProgress = $derived(shouldShowModelProgress(modelDownload));
   let modelDownloadError = $derived(modelDownload?.status === 'error');
 
   // Format uptime as human-readable string

--- a/app/src/shared/model-progress.ts
+++ b/app/src/shared/model-progress.ts
@@ -37,6 +37,10 @@ function activePhase(
   return state.status === 'downloading' ? 'downloading' : null;
 }
 
+export function shouldShowModelProgress(state?: ModelDownloadState): boolean {
+  return state !== undefined && activePhase(state) !== null;
+}
+
 export function getModelProgressView(
   state?: ModelDownloadState
 ): ModelProgressView | null {

--- a/app/src/shared/model-progress.ts
+++ b/app/src/shared/model-progress.ts
@@ -1,0 +1,141 @@
+import type { ModelDownloadState } from './types.js';
+
+export interface ModelProgressView {
+  phase: 'checking' | 'downloading' | 'loading';
+  stepLabel: string;
+  title: string;
+  summary: string;
+  metrics: string | null;
+  progressPercent: number | null;
+}
+
+export function formatProgressBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const unitIndex = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** unitIndex;
+  const digits = unitIndex >= 3 ? 2 : unitIndex >= 1 ? 1 : 0;
+  return `${value.toFixed(digits)} ${units[unitIndex]}`;
+}
+
+export function formatProgressDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return 'less than a minute';
+  if (seconds < 60) return 'less than a minute';
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
+}
+
+function activePhase(
+  state: ModelDownloadState
+): ModelProgressView['phase'] | null {
+  if (state.phase === 'checking' || state.phase === 'downloading' || state.phase === 'loading') {
+    return state.phase;
+  }
+  return state.status === 'downloading' ? 'downloading' : null;
+}
+
+export function getModelProgressView(
+  state?: ModelDownloadState
+): ModelProgressView | null {
+  if (!state) return null;
+  const phase = activePhase(state);
+  if (!phase) return null;
+
+  const rawPercent = state.progress_percent;
+  const progressPercent =
+    typeof rawPercent === 'number' && Number.isFinite(rawPercent)
+      ? Math.max(0, Math.min(100, rawPercent))
+      : null;
+
+  if (phase === 'checking') {
+    return {
+      phase,
+      stepLabel: 'Step 1 of 3',
+      title: `Checking ${state.model}`,
+      summary: 'Looking for an existing model download.',
+      metrics: null,
+      progressPercent: null,
+    };
+  }
+
+  if (phase === 'loading') {
+    return {
+      phase,
+      stepLabel: 'Step 3 of 3',
+      title: `Preparing ${state.model}`,
+      summary: 'Download complete. Loading the speech model into memory.',
+      metrics: 'This step depends on disk and GPU speed.',
+      progressPercent: 100,
+    };
+  }
+
+  const downloaded = state.downloaded_bytes;
+  const total = state.total_bytes;
+  const metricParts: string[] = [];
+  if (
+    typeof downloaded === 'number' &&
+    Number.isFinite(downloaded) &&
+    typeof total === 'number' &&
+    Number.isFinite(total) &&
+    total > 0
+  ) {
+    metricParts.push(`${formatProgressBytes(downloaded)} of ${formatProgressBytes(total)}`);
+  }
+  if (progressPercent !== null) {
+    metricParts.push(`${Math.round(progressPercent)}%`);
+  }
+  if (
+    typeof state.bytes_per_second === 'number' &&
+    Number.isFinite(state.bytes_per_second) &&
+    state.bytes_per_second > 0
+  ) {
+    metricParts.push(`${formatProgressBytes(state.bytes_per_second)}/s`);
+  }
+  if (
+    typeof state.eta_seconds === 'number' &&
+    Number.isFinite(state.eta_seconds) &&
+    state.eta_seconds >= 0
+  ) {
+    metricParts.push(`About ${formatProgressDuration(state.eta_seconds)} remaining`);
+  } else {
+    metricParts.push('Estimating time remaining…');
+  }
+
+  return {
+    phase,
+    stepLabel: 'Step 2 of 3',
+    title: `Downloading ${state.model}`,
+    summary: state.current_file
+      ? `Fetching ${state.current_file}. Keep Murmur open.`
+      : 'Fetching the speech model. Keep Murmur open.',
+    metrics: metricParts.join(' • '),
+    progressPercent,
+  };
+}
+
+export function getModelProgressShortSummary(
+  state?: ModelDownloadState
+): string | null {
+  const view = getModelProgressView(state);
+  if (!view) return null;
+  if (view.phase === 'checking') return 'Checking speech model files.';
+  if (view.phase === 'loading') return 'Download complete — loading the speech model into memory.';
+
+  const details: string[] = [];
+  if (view.progressPercent !== null) {
+    details.push(`${Math.round(view.progressPercent)}%`);
+  }
+  if (
+    state?.eta_seconds !== undefined &&
+    Number.isFinite(state.eta_seconds) &&
+    state.eta_seconds >= 0
+  ) {
+    details.push(`about ${formatProgressDuration(state.eta_seconds)} remaining`);
+  }
+  return details.length > 0
+    ? `Downloading speech model — ${details.join(', ')}.`
+    : 'Downloading speech model — estimating time remaining.';
+}

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -89,6 +89,14 @@ export interface ModelDownloadState {
   missing_files?: string[];
   partial_files?: string[];
   updated_at?: string;
+  phase?: 'checking' | 'downloading' | 'loading' | 'ready' | 'error';
+  progress_percent?: number;
+  downloaded_bytes?: number;
+  total_bytes?: number;
+  bytes_per_second?: number;
+  eta_seconds?: number;
+  current_file?: string;
+  started_at?: string;
 }
 
 // IPC State payloads

--- a/app/tests/model-progress.test.ts
+++ b/app/tests/model-progress.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  formatProgressBytes,
+  formatProgressDuration,
+  getModelProgressShortSummary,
+  getModelProgressView,
+} from '../src/shared/model-progress';
+
+describe('model progress presentation', () => {
+  test('formats download metrics and ETA', () => {
+    const view = getModelProgressView({
+      model: 'large-v3-turbo',
+      size_gb: 1.5,
+      status: 'downloading',
+      phase: 'downloading',
+      progress_percent: 74.4,
+      downloaded_bytes: 1_200_000_000,
+      total_bytes: 1_621_666_023,
+      bytes_per_second: 1_250_000,
+      eta_seconds: 338,
+      current_file: 'model weights',
+    });
+
+    expect(view?.stepLabel).toBe('Step 2 of 3');
+    expect(view?.summary).toContain('model weights');
+    expect(view?.metrics).toContain('74%');
+    expect(view?.metrics).toContain('About 6 min remaining');
+    expect(getModelProgressShortSummary({
+      model: 'large-v3-turbo',
+      size_gb: 1.5,
+      status: 'downloading',
+      phase: 'downloading',
+      progress_percent: 74.4,
+      eta_seconds: 338,
+    })).toBe('Downloading speech model — 74%, about 6 min remaining.');
+  });
+
+  test('uses an indeterminate summary until throughput is known', () => {
+    const view = getModelProgressView({
+      model: 'tiny',
+      size_gb: 0.07,
+      status: 'downloading',
+      phase: 'downloading',
+    });
+
+    expect(view?.progressPercent).toBeNull();
+    expect(view?.metrics).toBe('Estimating time remaining…');
+  });
+
+  test('separates loading from network ETA', () => {
+    const view = getModelProgressView({
+      model: 'large-v3-turbo',
+      size_gb: 1.5,
+      status: 'ready',
+      phase: 'loading',
+      progress_percent: 100,
+    });
+
+    expect(view?.stepLabel).toBe('Step 3 of 3');
+    expect(view?.summary).toContain('Loading the speech model into memory');
+    expect(view?.metrics).not.toContain('remaining');
+  });
+
+  test('does not render a progress card after readiness', () => {
+    expect(getModelProgressView({
+      model: 'tiny',
+      size_gb: 0.07,
+      status: 'ready',
+      phase: 'ready',
+    })).toBeNull();
+  });
+
+  test('formats byte and duration boundaries', () => {
+    expect(formatProgressBytes(1024 ** 3)).toBe('1.00 GB');
+    expect(formatProgressDuration(59)).toBe('less than a minute');
+    expect(formatProgressDuration(3660)).toBe('1 hr 1 min');
+  });
+});

--- a/app/tests/model-progress.test.ts
+++ b/app/tests/model-progress.test.ts
@@ -4,6 +4,7 @@ import {
   formatProgressDuration,
   getModelProgressShortSummary,
   getModelProgressView,
+  shouldShowModelProgress,
 } from '../src/shared/model-progress';
 
 describe('model progress presentation', () => {
@@ -36,15 +37,34 @@ describe('model progress presentation', () => {
   });
 
   test('uses an indeterminate summary until throughput is known', () => {
-    const view = getModelProgressView({
+    const state = {
       model: 'tiny',
       size_gb: 0.07,
-      status: 'downloading',
-      phase: 'downloading',
-    });
+      status: 'downloading' as const,
+      phase: 'downloading' as const,
+    };
+    const view = getModelProgressView(state);
 
     expect(view?.progressPercent).toBeNull();
     expect(view?.metrics).toBe('Estimating time remaining…');
+    expect(getModelProgressShortSummary(state)).toBe(
+      'Downloading speech model — estimating time remaining.'
+    );
+  });
+
+  test('renders the cache-checking stage distinctly', () => {
+    const state = {
+      model: 'large-v3-turbo',
+      size_gb: 1.5,
+      status: 'missing' as const,
+      phase: 'checking' as const,
+    };
+
+    const view = getModelProgressView(state);
+    expect(view?.stepLabel).toBe('Step 1 of 3');
+    expect(view?.metrics).toBeNull();
+    expect(getModelProgressShortSummary(state)).toBe('Checking speech model files.');
+    expect(shouldShowModelProgress(state)).toBeTrue();
   });
 
   test('separates loading from network ETA', () => {

--- a/app/tests/server-health.test.ts
+++ b/app/tests/server-health.test.ts
@@ -32,6 +32,47 @@ describe('server health parsing', () => {
     expect(health.engineStatus).toBeUndefined();
   });
 
+  test('validates and clamps model download progress', () => {
+    const health = parseHealthyResponse({
+      status: 'healthy',
+      model_download: {
+        model: 'large-v3-turbo',
+        size_gb: 1.5,
+        status: 'downloading',
+        phase: 'downloading',
+        progress_percent: 104.5,
+        downloaded_bytes: 750,
+        total_bytes: 1000,
+        bytes_per_second: 25,
+        eta_seconds: 10,
+      },
+    });
+
+    expect(health.modelDownload?.progress_percent).toBe(100);
+    expect(health.modelDownload?.downloaded_bytes).toBe(750);
+    expect(health.modelDownload?.eta_seconds).toBe(10);
+  });
+
+  test('drops malformed model download progress fields', () => {
+    const health = parseHealthyResponse({
+      status: 'healthy',
+      model_download: {
+        model: 'tiny',
+        size_gb: 0.07,
+        status: 'downloading',
+        phase: 'teleporting',
+        progress_percent: Number.NaN,
+        downloaded_bytes: -1,
+        eta_seconds: Number.POSITIVE_INFINITY,
+      },
+    });
+
+    expect(health.modelDownload?.phase).toBeUndefined();
+    expect(health.modelDownload?.progress_percent).toBeUndefined();
+    expect(health.modelDownload?.downloaded_bytes).toBeUndefined();
+    expect(health.modelDownload?.eta_seconds).toBeUndefined();
+  });
+
   test('rejects a non-object response', () => {
     expect(parseHealthyResponse(null)).toEqual({ healthy: false });
   });

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.6.1"
+version = "0.6.2"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/transcription/engines/nemotron.py
+++ b/server/src/transcription/engines/nemotron.py
@@ -122,7 +122,10 @@ class NemotronEngine:
                     size_gb=_MODEL_SIZE_GB,
                     status="ready",
                     cached=True,
-                    detail="cached",
+                    detail="cached; loading model",
+                    repo_id=repo_id,
+                    phase="loading",
+                    progress_percent=100.0,
                 )
             else:
                 update_model_download_state(
@@ -131,6 +134,8 @@ class NemotronEngine:
                     status="downloading",
                     cached=False,
                     detail="download started",
+                    repo_id=repo_id,
+                    phase="downloading",
                 )
                 logger.info(
                     "Nemotron model not found in cache; downloading (~%.1f GB).",
@@ -142,7 +147,9 @@ class NemotronEngine:
                 size_gb=_MODEL_SIZE_GB,
                 status="ready",
                 cached=True,
-                detail="local model",
+                detail="local model; loading",
+                phase="loading",
+                progress_percent=100.0,
             )
 
         # Suppress Python warnings from NeMo/Lhotse before import triggers them.
@@ -185,6 +192,8 @@ class NemotronEngine:
                             status="error",
                             cached=False,
                             detail="download failed: network error",
+                            repo_id=repo_id,
+                            phase="error",
                         )
                     raise offline_exc from exc
                 finally:
@@ -200,6 +209,8 @@ class NemotronEngine:
                         status="error",
                         cached=False,
                         detail="download failed",
+                        repo_id=repo_id,
+                        phase="error",
                     )
                 raise
         self._model.eval()
@@ -232,6 +243,9 @@ class NemotronEngine:
             status="ready",
             cached=True,
             detail=detail,
+            repo_id=repo_id,
+            phase="ready",
+            progress_percent=100.0,
         )
         if preflight_cached is False:
             logger.info("Nemotron model download complete.")

--- a/server/src/transcription/engines/whisper.py
+++ b/server/src/transcription/engines/whisper.py
@@ -14,13 +14,20 @@ try:
 except ImportError:
     pass
 
-from faster_whisper import WhisperModel
+from faster_whisper import WhisperModel, download_model
 from numpy.typing import NDArray
 import numpy as np
 
 from config import Settings
 from transcription.base import EngineInfo
-from transcription.model_download import get_repo_cache_status, update_model_download_state
+from transcription.model_download import (
+    begin_model_download_progress,
+    get_cached_required_bytes,
+    get_repo_cache_status,
+    mark_model_loading,
+    track_huggingface_download_progress,
+    update_model_download_state,
+)
 from transcription.types import TranscribeOptions, TranscribeResult, resolve_option
 
 logger = logging.getLogger(__name__)
@@ -162,21 +169,31 @@ class WhisperEngine:
         repo_id = _resolve_repo_id(model)
         cache_status = get_repo_cache_status(repo_id) if repo_id else None
         preflight_cached: bool | None = None
+        model_source = model
 
         if repo_id:
             assert cache_status is not None
             preflight_cached = cache_status.status == "ready"
             if preflight_cached:
+                model_source = cache_status.snapshot_path or model
                 update_model_download_state(
                     model=model,
                     size_gb=model_size_gb,
                     status="ready",
                     cached=True,
-                    detail=cache_status.detail,
+                    detail="cached; loading model",
                     repo_id=repo_id,
                     path=cache_status.snapshot_path,
+                    phase="loading",
+                    progress_percent=100.0,
                 )
             else:
+                begin_model_download_progress(
+                    model=model,
+                    repo_id=repo_id,
+                    size_gb=model_size_gb,
+                    initial_bytes=get_cached_required_bytes(repo_id),
+                )
                 update_model_download_state(
                     model=model,
                     size_gb=model_size_gb,
@@ -187,6 +204,8 @@ class WhisperEngine:
                     path=cache_status.snapshot_path or cache_status.repo_path,
                     missing_files=cache_status.missing_files,
                     partial_files=cache_status.partial_files,
+                    phase="downloading",
+                    progress_percent=0.0,
                 )
                 logger.info(
                     "Whisper model cache status is %s; loading may download (~%.1f GB).",
@@ -199,8 +218,10 @@ class WhisperEngine:
                 size_gb=model_size_gb,
                 status="ready",
                 cached=True,
-                detail="local model",
+                detail="local model; loading",
                 path=model,
+                phase="loading",
+                progress_percent=100.0,
             )
 
         logger.info(
@@ -209,27 +230,36 @@ class WhisperEngine:
         )
         load_start = time.perf_counter()
         try:
-            self._model = WhisperModel(model, device=device, compute_type=compute_type)
+            if repo_id and preflight_cached is False:
+                with track_huggingface_download_progress():
+                    model_source = download_model(repo_id)
+                mark_model_loading()
+            self._model = WhisperModel(
+                model_source,
+                device=device,
+                compute_type=compute_type,
+            )
         except Exception as exc:
             if _is_network_error(exc):
                 logger.warning(
                     "Network/TLS error loading model, retrying with local cache: %s", exc,
                 )
                 try:
+                    mark_model_loading()
                     self._model = WhisperModel(
                         model, device=device, compute_type=compute_type,
                         local_files_only=True,
                     )
                 except Exception as fallback_exc:
-                    if preflight_cached is False:
-                        update_model_download_state(
-                            model=model,
-                            size_gb=model_size_gb,
-                            status="error",
-                            cached=False,
-                            detail="download failed: network error",
-                            repo_id=repo_id,
-                        )
+                    update_model_download_state(
+                        model=model,
+                        size_gb=model_size_gb,
+                        status="error",
+                        cached=False,
+                        detail="download failed: network error",
+                        repo_id=repo_id,
+                        phase="error",
+                    )
                     raise fallback_exc from exc
             elif _is_cuda_dll_error(exc):
                 logger.error(
@@ -237,19 +267,32 @@ class WhisperEngine:
                     "Install/update the NVIDIA driver or switch to CPU mode.",
                     exc_info=exc,
                 )
+                update_model_download_state(
+                    model=model,
+                    size_gb=model_size_gb,
+                    status="error",
+                    cached=preflight_cached,
+                    detail="model loading failed: CUDA runtime unavailable",
+                    repo_id=repo_id,
+                    phase="error",
+                )
                 raise RuntimeError(
                     "CUDA runtime DLLs are missing. Install/update the NVIDIA driver or switch to CPU mode."
                 ) from exc
             else:
-                if preflight_cached is False:
-                    update_model_download_state(
-                        model=model,
-                        size_gb=model_size_gb,
-                        status="error",
-                        cached=False,
-                        detail="download failed",
-                        repo_id=repo_id,
-                    )
+                update_model_download_state(
+                    model=model,
+                    size_gb=model_size_gb,
+                    status="error",
+                    cached=preflight_cached,
+                    detail=(
+                        "download failed"
+                        if preflight_cached is False
+                        else "model loading failed"
+                    ),
+                    repo_id=repo_id,
+                    phase="error",
+                )
                 raise
         self._load_time_s = time.perf_counter() - load_start
         self._model_name = model
@@ -276,6 +319,8 @@ class WhisperEngine:
             detail=detail,
             repo_id=repo_id,
             path=self._model_path,
+            phase="ready",
+            progress_percent=100.0,
         )
         if preflight_cached is False:
             logger.info("Whisper model download complete.")

--- a/server/src/transcription/model_download.py
+++ b/server/src/transcription/model_download.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from collections import deque
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
+import importlib
 from pathlib import Path
-from typing import Literal
+import threading
+import time
+from typing import Iterator, Literal
 import os
 
 ModelDownloadStatus = Literal["missing", "partial", "downloading", "ready", "error"]
+ModelDownloadPhase = Literal["checking", "downloading", "loading", "ready", "error"]
 
 _TEMP_FILE_MARKERS = (".incomplete", ".lock", ".tmp", ".temp", ".partial")
 _REQUIRED_FILES_BY_REPO: dict[str, tuple[str, ...]] = {
@@ -46,6 +52,14 @@ class ModelDownloadState:
     missing_files: list[str] = field(default_factory=list)
     partial_files: list[str] = field(default_factory=list)
     updated_at: str | None = None
+    phase: ModelDownloadPhase | None = None
+    progress_percent: float | None = None
+    downloaded_bytes: int | None = None
+    total_bytes: int | None = None
+    bytes_per_second: int | None = None
+    eta_seconds: int | None = None
+    current_file: str | None = None
+    started_at: str | None = None
 
 
 @dataclass(frozen=True)
@@ -61,6 +75,17 @@ class ModelCacheStatus:
 
 
 _MODEL_DOWNLOAD_STATE: ModelDownloadState | None = None
+_PROGRESS_LOCK = threading.RLock()
+_PROGRESS_STARTED_AT: str | None = None
+_PROGRESS_DOWNLOADED_BYTES = 0
+_PROGRESS_EXPECTED_BYTES = 0
+_PROGRESS_TRANSFER_TOTALS: dict[int, int] = {}
+_PROGRESS_TRANSFER_LABELS: dict[int, str] = {}
+_PROGRESS_SAMPLES: deque[tuple[float, int]] = deque(maxlen=256)
+_PROGRESS_CURRENT_FILE: str | None = None
+_PROGRESS_ACTIVE_MODEL: str | None = None
+_PROGRESS_ACTIVE_REPO: str | None = None
+_TQDM_PATCH_LOCK = threading.RLock()
 
 
 def _now_iso() -> str:
@@ -216,6 +241,27 @@ def is_repo_cached(repo_id: str) -> bool:
     return get_repo_cache_status(repo_id).status == "ready"
 
 
+def get_cached_required_bytes(repo_id: str) -> int:
+    """Return bytes already present in the most complete cached snapshot."""
+    repo_dir = _repo_cache_dir(repo_id)
+    if repo_dir is None or not repo_dir.exists():
+        return 0
+
+    required = _required_files(repo_id)
+    totals: list[int] = []
+    for snapshot in _candidate_snapshots(repo_dir):
+        total = 0
+        for filename in required:
+            path = snapshot / filename
+            try:
+                if path.is_file():
+                    total += path.stat().st_size
+            except OSError:
+                continue
+        totals.append(total)
+    return max(totals, default=0)
+
+
 def update_model_download_state(
     *,
     model: str,
@@ -227,23 +273,248 @@ def update_model_download_state(
     path: str | None = None,
     missing_files: list[str] | None = None,
     partial_files: list[str] | None = None,
+    phase: ModelDownloadPhase | None = None,
+    progress_percent: float | None = None,
+    downloaded_bytes: int | None = None,
+    total_bytes: int | None = None,
+    bytes_per_second: int | None = None,
+    eta_seconds: int | None = None,
+    current_file: str | None = None,
+    started_at: str | None = None,
 ) -> None:
     global _MODEL_DOWNLOAD_STATE
-    _MODEL_DOWNLOAD_STATE = ModelDownloadState(
-        model=model,
-        size_gb=size_gb,
-        status=status,
-        cached=cached,
-        detail=detail,
-        repo_id=repo_id,
-        path=path,
-        missing_files=missing_files or [],
-        partial_files=partial_files or [],
-        updated_at=_now_iso(),
-    )
+    with _PROGRESS_LOCK:
+        _MODEL_DOWNLOAD_STATE = ModelDownloadState(
+            model=model,
+            size_gb=size_gb,
+            status=status,
+            cached=cached,
+            detail=detail,
+            repo_id=repo_id,
+            path=path,
+            missing_files=missing_files or [],
+            partial_files=partial_files or [],
+            updated_at=_now_iso(),
+            phase=phase,
+            progress_percent=progress_percent,
+            downloaded_bytes=downloaded_bytes,
+            total_bytes=total_bytes,
+            bytes_per_second=bytes_per_second,
+            eta_seconds=eta_seconds,
+            current_file=current_file,
+            started_at=started_at,
+        )
+
+
+def begin_model_download_progress(
+    *,
+    model: str,
+    repo_id: str,
+    size_gb: float,
+    initial_bytes: int = 0,
+) -> None:
+    """Reset byte-level progress before Hugging Face starts a download."""
+    global _PROGRESS_STARTED_AT
+    global _PROGRESS_DOWNLOADED_BYTES
+    global _PROGRESS_EXPECTED_BYTES
+    global _PROGRESS_CURRENT_FILE
+    global _PROGRESS_ACTIVE_MODEL
+    global _PROGRESS_ACTIVE_REPO
+
+    now = time.monotonic()
+    with _PROGRESS_LOCK:
+        _PROGRESS_STARTED_AT = _now_iso()
+        _PROGRESS_DOWNLOADED_BYTES = max(0, int(initial_bytes))
+        _PROGRESS_EXPECTED_BYTES = max(1, int(size_gb * 1024**3))
+        _PROGRESS_TRANSFER_TOTALS.clear()
+        _PROGRESS_TRANSFER_LABELS.clear()
+        _PROGRESS_SAMPLES.clear()
+        _PROGRESS_SAMPLES.append((now, _PROGRESS_DOWNLOADED_BYTES))
+        _PROGRESS_CURRENT_FILE = None
+        _PROGRESS_ACTIVE_MODEL = model
+        _PROGRESS_ACTIVE_REPO = repo_id
+
+
+def _friendly_download_item(description: str | None, total: int | None) -> str:
+    normalized = (description or "").lower()
+    if "model.bin" in normalized or (total is not None and total >= 50 * 1024**2):
+        return "model weights"
+    for filename, label in (
+        ("tokenizer", "tokenizer"),
+        ("vocabulary", "vocabulary"),
+        ("preprocessor", "audio configuration"),
+        ("config", "model configuration"),
+    ):
+        if filename in normalized:
+            return label
+    return "model files"
+
+
+def register_model_download_transfer(
+    transfer_id: int,
+    *,
+    total: int | None,
+    initial: int = 0,
+    description: str | None = None,
+) -> None:
+    """Register one file transfer reported by huggingface_hub."""
+    global _PROGRESS_DOWNLOADED_BYTES
+    global _PROGRESS_EXPECTED_BYTES
+    global _PROGRESS_CURRENT_FILE
+
+    with _PROGRESS_LOCK:
+        if total is not None and total > 0:
+            _PROGRESS_TRANSFER_TOTALS[transfer_id] = int(total)
+            _PROGRESS_EXPECTED_BYTES = max(
+                _PROGRESS_EXPECTED_BYTES,
+                sum(_PROGRESS_TRANSFER_TOTALS.values()),
+            )
+        _PROGRESS_TRANSFER_LABELS[transfer_id] = _friendly_download_item(
+            description,
+            total,
+        )
+        if initial > 0:
+            _PROGRESS_DOWNLOADED_BYTES += int(initial)
+            _PROGRESS_SAMPLES.clear()
+            _PROGRESS_SAMPLES.append((time.monotonic(), _PROGRESS_DOWNLOADED_BYTES))
+        _PROGRESS_CURRENT_FILE = _friendly_download_item(description, total)
+
+
+def report_model_download_bytes(
+    transfer_id: int,
+    delta: int | float,
+    *,
+    description: str | None = None,
+) -> None:
+    """Add a byte delta from a Hugging Face HTTP or Xet transfer callback."""
+    global _PROGRESS_DOWNLOADED_BYTES
+    global _PROGRESS_CURRENT_FILE
+
+    byte_delta = max(0, int(delta))
+    if byte_delta == 0:
+        return
+    now = time.monotonic()
+    with _PROGRESS_LOCK:
+        _PROGRESS_DOWNLOADED_BYTES += byte_delta
+        _PROGRESS_CURRENT_FILE = _PROGRESS_TRANSFER_LABELS.get(
+            transfer_id,
+            _friendly_download_item(description, None),
+        )
+        _PROGRESS_SAMPLES.append((now, _PROGRESS_DOWNLOADED_BYTES))
+
+
+def _progress_metrics() -> dict[str, int | float | str | None]:
+    now = time.monotonic()
+    downloaded = _PROGRESS_DOWNLOADED_BYTES
+    total = max(_PROGRESS_EXPECTED_BYTES, downloaded)
+    rate = 0.0
+
+    if _PROGRESS_SAMPLES:
+        baseline_time, baseline_bytes = _PROGRESS_SAMPLES[0]
+        for sample_time, sample_bytes in _PROGRESS_SAMPLES:
+            if now - sample_time <= 30:
+                baseline_time, baseline_bytes = sample_time, sample_bytes
+                break
+        elapsed = now - baseline_time
+        if elapsed >= 1:
+            rate = max(0.0, (downloaded - baseline_bytes) / elapsed)
+        if now - _PROGRESS_SAMPLES[-1][0] > 15:
+            rate = 0.0
+
+    percent = min(99.0, downloaded / total * 100) if total > 0 else 0.0
+    remaining = max(0, total - downloaded)
+    eta = round(remaining / rate) if rate > 1024 and remaining > 0 else None
+    return {
+        "progress_percent": round(percent, 1),
+        "downloaded_bytes": downloaded,
+        "total_bytes": total,
+        "bytes_per_second": round(rate) if rate > 0 else None,
+        "eta_seconds": eta,
+        "current_file": _PROGRESS_CURRENT_FILE,
+        "started_at": _PROGRESS_STARTED_AT,
+    }
+
+
+def mark_model_loading() -> None:
+    """Switch the visible stage after download and before model initialization."""
+    global _MODEL_DOWNLOAD_STATE
+    with _PROGRESS_LOCK:
+        if _MODEL_DOWNLOAD_STATE is None:
+            return
+        metrics = _progress_metrics()
+        total = int(metrics["total_bytes"] or 0)
+        _MODEL_DOWNLOAD_STATE = replace(
+            _MODEL_DOWNLOAD_STATE,
+            status="downloading",
+            cached=True,
+            detail="download complete; loading model",
+            phase="loading",
+            progress_percent=100.0,
+            downloaded_bytes=total,
+            total_bytes=total,
+            bytes_per_second=None,
+            eta_seconds=None,
+            current_file=None,
+            started_at=metrics["started_at"],
+            updated_at=_now_iso(),
+        )
+
+
+@contextmanager
+def track_huggingface_download_progress() -> Iterator[None]:
+    """Temporarily bridge huggingface_hub byte progress into Murmur state."""
+    with _TQDM_PATCH_LOCK:
+        try:
+            tqdm_module = importlib.import_module("huggingface_hub.utils.tqdm")
+            original_tqdm = tqdm_module.tqdm
+        except (ImportError, AttributeError):
+            yield
+            return
+
+        if getattr(original_tqdm, "_murmur_progress_bridge", False):
+            yield
+            return
+
+        class ReportingTqdm(original_tqdm):
+            _murmur_progress_bridge = True
+
+            def __init__(self, *args, **kwargs):
+                self._murmur_transfer_id = id(self)
+                self._murmur_description = kwargs.get("desc")
+                super().__init__(*args, **kwargs)
+                register_model_download_transfer(
+                    self._murmur_transfer_id,
+                    total=int(self.total) if self.total is not None else None,
+                    initial=int(self.n),
+                    description=self._murmur_description,
+                )
+
+            def update(self, n=1):
+                result = super().update(n)
+                report_model_download_bytes(
+                    self._murmur_transfer_id,
+                    n,
+                    description=self._murmur_description,
+                )
+                return result
+
+        tqdm_module.tqdm = ReportingTqdm
+        try:
+            yield
+        finally:
+            tqdm_module.tqdm = original_tqdm
 
 
 def get_model_download_state() -> dict | None:
-    if _MODEL_DOWNLOAD_STATE is None:
-        return None
-    return asdict(_MODEL_DOWNLOAD_STATE)
+    with _PROGRESS_LOCK:
+        if _MODEL_DOWNLOAD_STATE is None:
+            return None
+        state = asdict(_MODEL_DOWNLOAD_STATE)
+        if (
+            _MODEL_DOWNLOAD_STATE.status == "downloading"
+            and _MODEL_DOWNLOAD_STATE.phase == "downloading"
+            and _MODEL_DOWNLOAD_STATE.model == _PROGRESS_ACTIVE_MODEL
+            and _MODEL_DOWNLOAD_STATE.repo_id == _PROGRESS_ACTIVE_REPO
+        ):
+            state.update(_progress_metrics())
+        return state

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.6.1"
+SERVER_VERSION = "0.6.2"

--- a/server/tests/test_backend_hardening.py
+++ b/server/tests/test_backend_hardening.py
@@ -121,15 +121,18 @@ def test_whisper_uncached_model_reports_downloading(
         missing_files=["model.bin"],
         partial_files=[],
     )
-    observed_during_load: list[str | None] = []
+    observed_during_load: list[tuple[str | None, str | None]] = []
 
     class FakeWhisperModel:
         def __init__(self, *args, **kwargs) -> None:
             state = get_model_download_state()
-            observed_during_load.append(state["status"] if state else None)
+            observed_during_load.append(
+                (state["status"], state["phase"]) if state else (None, None)
+            )
 
     monkeypatch.setattr(whisper, "get_repo_cache_status", lambda _repo: cache_status)
     monkeypatch.setattr(whisper, "WhisperModel", FakeWhisperModel)
+    monkeypatch.setattr(whisper, "download_model", lambda _repo: "cache/snapshot")
     monkeypatch.setattr(whisper, "_get_cuda_active", lambda _device: False)
 
     whisper.WhisperEngine(
@@ -140,8 +143,9 @@ def test_whisper_uncached_model_reports_downloading(
         )
     )
 
-    assert observed_during_load == ["downloading"]
+    assert observed_during_load == [("downloading", "loading")]
     assert get_model_download_state()["status"] == "ready"
+    assert get_model_download_state()["phase"] == "ready"
 
 
 @pytest.mark.parametrize(

--- a/server/tests/test_model_download.py
+++ b/server/tests/test_model_download.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 
 from config import Settings
 import app as app_module
@@ -115,6 +116,39 @@ def test_is_repo_cached_returns_false_without_snapshot(tmp_path, monkeypatch) ->
     assert model_download.is_repo_cached("Systran/faster-whisper-large-v3-turbo") is False
 
 
+def test_cached_required_bytes_preserves_resume_baseline(tmp_path, monkeypatch) -> None:
+    cache_dir = tmp_path / "hub"
+    monkeypatch.setenv("HF_HUB_CACHE", str(cache_dir))
+    snapshot_dir = (
+        cache_dir
+        / "models--mobiuslabsgmbh--faster-whisper-large-v3-turbo"
+        / "snapshots"
+        / "abc123"
+    )
+    _write_required_snapshot(snapshot_dir)
+    (snapshot_dir / "vocabulary.json").unlink()
+
+    cached_bytes = model_download.get_cached_required_bytes(
+        "mobiuslabsgmbh/faster-whisper-large-v3-turbo"
+    )
+    assert cached_bytes == 4
+
+    model_download.begin_model_download_progress(
+        model="tiny",
+        repo_id="example/tiny",
+        size_gb=100 / 1024**3,
+        initial_bytes=cached_bytes,
+    )
+    model_download.update_model_download_state(
+        model="tiny",
+        size_gb=100 / 1024**3,
+        status="downloading",
+        phase="downloading",
+        repo_id="example/tiny",
+    )
+    assert model_download.get_model_download_state()["downloaded_bytes"] == 4
+
+
 def test_health_includes_model_download(monkeypatch) -> None:
     monkeypatch.setattr(app_module, "get_session_manager", lambda: _DummySessionManager())
     monkeypatch.setattr(app_module, "get_engine_manager", lambda: _DummyEngineManager())
@@ -135,3 +169,208 @@ def test_health_includes_model_download(monkeypatch) -> None:
 
     assert payload["model_download"]["status"] == "downloading"
     assert payload["model_download"]["model"] == "large-v3-turbo"
+
+
+def test_byte_progress_reports_percentage_speed_and_eta(monkeypatch) -> None:
+    clock = [0.0]
+    monkeypatch.setattr(model_download.time, "monotonic", lambda: clock[0])
+
+    model_download.begin_model_download_progress(
+        model="tiny", repo_id="example/tiny", size_gb=100 / 1024**3
+    )
+    model_download.update_model_download_state(
+        model="tiny",
+        size_gb=100 / 1024**3,
+        status="downloading",
+        phase="downloading",
+        repo_id="example/tiny",
+    )
+    model_download.register_model_download_transfer(
+        1,
+        total=100,
+        description="model.bin",
+    )
+    clock[0] = 10.0
+    model_download.report_model_download_bytes(1, 50)
+
+    state = model_download.get_model_download_state()
+    assert state is not None
+    assert state["progress_percent"] == 50.0
+    assert state["downloaded_bytes"] == 50
+    assert state["total_bytes"] == 100
+    assert state["bytes_per_second"] == 5
+    assert state["eta_seconds"] is None  # Very low rates do not produce noisy ETAs.
+    assert state["current_file"] == "model weights"
+
+
+def test_byte_progress_uses_recent_rate_for_eta(monkeypatch) -> None:
+    clock = [0.0]
+    monkeypatch.setattr(model_download.time, "monotonic", lambda: clock[0])
+
+    model_download.begin_model_download_progress(
+        model="tiny", repo_id="example/tiny", size_gb=10_000_000 / 1024**3
+    )
+    model_download.update_model_download_state(
+        model="tiny",
+        size_gb=10_000_000 / 1024**3,
+        status="downloading",
+        phase="downloading",
+        repo_id="example/tiny",
+    )
+    model_download.register_model_download_transfer(2, total=10_000_000)
+    clock[0] = 5.0
+    model_download.report_model_download_bytes(2, 5_000_000)
+
+    state = model_download.get_model_download_state()
+    assert state is not None
+    assert state["bytes_per_second"] == 1_000_000
+    assert state["eta_seconds"] == 5
+
+
+def test_byte_progress_hides_eta_after_stall(monkeypatch) -> None:
+    clock = [0.0]
+    monkeypatch.setattr(model_download.time, "monotonic", lambda: clock[0])
+
+    model_download.begin_model_download_progress(
+        model="tiny", repo_id="example/tiny", size_gb=10_000_000 / 1024**3
+    )
+    model_download.update_model_download_state(
+        model="tiny",
+        size_gb=10_000_000 / 1024**3,
+        status="downloading",
+        phase="downloading",
+        repo_id="example/tiny",
+    )
+    model_download.register_model_download_transfer(4, total=10_000_000)
+    clock[0] = 5.0
+    model_download.report_model_download_bytes(4, 5_000_000)
+    clock[0] = 21.0
+
+    state = model_download.get_model_download_state()
+    assert state is not None
+    assert state["bytes_per_second"] is None
+    assert state["eta_seconds"] is None
+
+
+def test_resumed_bytes_do_not_inflate_transfer_rate(monkeypatch) -> None:
+    clock = [0.0]
+    monkeypatch.setattr(model_download.time, "monotonic", lambda: clock[0])
+    model_download.begin_model_download_progress(
+        model="tiny",
+        repo_id="example/tiny",
+        size_gb=10_000_000 / 1024**3,
+        initial_bytes=4_000_000,
+    )
+    model_download.update_model_download_state(
+        model="tiny",
+        size_gb=10_000_000 / 1024**3,
+        status="downloading",
+        phase="downloading",
+        repo_id="example/tiny",
+    )
+    model_download.register_model_download_transfer(5, total=6_000_000, initial=1_000_000)
+    clock[0] = 5.0
+    model_download.report_model_download_bytes(5, 1_000_000)
+
+    state = model_download.get_model_download_state()
+    assert state is not None
+    assert state["downloaded_bytes"] == 6_000_000
+    assert state["bytes_per_second"] == 200_000
+    assert state["eta_seconds"] == 20
+
+
+def test_other_engines_do_not_inherit_whisper_progress(monkeypatch) -> None:
+    monkeypatch.setattr(model_download.time, "monotonic", lambda: 1.0)
+    model_download.begin_model_download_progress(
+        model="tiny", repo_id="example/tiny", size_gb=100 / 1024**3
+    )
+    model_download.register_model_download_transfer(6, total=100)
+    model_download.report_model_download_bytes(6, 50)
+    model_download.update_model_download_state(
+        model="nemotron",
+        size_gb=2.3,
+        status="downloading",
+        phase="downloading",
+        repo_id="nvidia/nemotron",
+    )
+
+    state = model_download.get_model_download_state()
+    assert state is not None
+    assert state["progress_percent"] is None
+    assert state["downloaded_bytes"] is None
+    assert state["eta_seconds"] is None
+
+
+def test_mark_model_loading_clears_network_eta(monkeypatch) -> None:
+    monkeypatch.setattr(model_download.time, "monotonic", lambda: 1.0)
+    model_download.begin_model_download_progress(
+        model="tiny", repo_id="example/tiny", size_gb=100 / 1024**3
+    )
+    model_download.update_model_download_state(
+        model="tiny",
+        size_gb=100 / 1024**3,
+        status="downloading",
+        phase="downloading",
+        repo_id="example/tiny",
+    )
+    model_download.register_model_download_transfer(3, total=100)
+    model_download.report_model_download_bytes(3, 100)
+
+    model_download.mark_model_loading()
+    state = model_download.get_model_download_state()
+    assert state is not None
+    assert state["status"] == "downloading"
+    assert state["phase"] == "loading"
+    assert state["progress_percent"] == 100.0
+    assert state["eta_seconds"] is None
+
+
+def test_huggingface_progress_bridge_observes_byte_callbacks(monkeypatch) -> None:
+    clock = [0.0]
+    monkeypatch.setattr(model_download.time, "monotonic", lambda: clock[0])
+    model_download.begin_model_download_progress(
+        model="tiny", repo_id="example/tiny", size_gb=100 / 1024**3
+    )
+    model_download.update_model_download_state(
+        model="tiny",
+        size_gb=100 / 1024**3,
+        status="downloading",
+        phase="downloading",
+        repo_id="example/tiny",
+    )
+
+    tqdm_module = importlib.import_module("huggingface_hub.utils.tqdm")
+    with model_download.track_huggingface_download_progress():
+        with tqdm_module._get_progress_bar_context(
+            desc="model.bin",
+            log_level=100,
+            total=100,
+            initial=0,
+        ) as progress:
+            clock[0] = 2.0
+            progress.update(25)
+
+    state = model_download.get_model_download_state()
+    assert state is not None
+    assert state["downloaded_bytes"] == 25
+    assert state["progress_percent"] == 25.0
+
+
+def test_huggingface_progress_bridge_restores_nested_and_failed_contexts() -> None:
+    tqdm_module = importlib.import_module("huggingface_hub.utils.tqdm")
+    original_tqdm = tqdm_module.tqdm
+
+    with model_download.track_huggingface_download_progress():
+        reporting_tqdm = tqdm_module.tqdm
+        assert reporting_tqdm is not original_tqdm
+        with model_download.track_huggingface_download_progress():
+            assert tqdm_module.tqdm is reporting_tqdm
+        assert tqdm_module.tqdm is reporting_tqdm
+    assert tqdm_module.tqdm is original_tqdm
+
+    try:
+        with model_download.track_huggingface_download_progress():
+            raise RuntimeError("test failure")
+    except RuntimeError:
+        pass
+    assert tqdm_module.tqdm is original_tqdm

--- a/server/tests/test_model_download.py
+++ b/server/tests/test_model_download.py
@@ -341,11 +341,11 @@ def test_huggingface_progress_bridge_observes_byte_callbacks(monkeypatch) -> Non
 
     tqdm_module = importlib.import_module("huggingface_hub.utils.tqdm")
     with model_download.track_huggingface_download_progress():
-        with tqdm_module._get_progress_bar_context(
+        with tqdm_module.tqdm(
             desc="model.bin",
-            log_level=100,
             total=100,
             initial=0,
+            disable=True,
         ) as progress:
             clock[0] = 2.0
             progress.update(25)


### PR DESCRIPTION
## Summary
- report real Hugging Face model download bytes, percentage, throughput, and estimated time
- separate cache checking, download, model-loading, ready, and error stages
- show a compact non-stretched progress banner globally, detailed progress on Server, and progress in the minimized hotkey overlay
- preserve resume behavior, external-server compatibility, Nemotron indeterminate state, and release smoke readiness semantics
- bump the synchronized application/server version to 0.6.2

## Validation
- 136 backend tests passed
- 50 desktop tests passed
- main and renderer TypeScript checks passed
- production main and renderer builds passed
- v0.6.2 version/tag consistency passed
- independent regression review completed with no remaining blocker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed speech model download progress, including percentage, transfer speed, estimated time remaining, and loading stages.
  * Added progress banners and cards throughout the app to clearly communicate model status.
  * Recording guidance now reflects the model’s current download or loading progress.
* **Bug Fixes**
  * Improved validation and handling of malformed model download status data.
  * Enhanced download resumption and progress tracking reliability.
* **Chores**
  * Updated the application, server, and documentation version to 0.6.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->