### PR TITLE
Prevent main-process EPIPE crashes

### DIFF
--- a/app/src/main/lib/logger.ts
+++ b/app/src/main/lib/logger.ts
@@ -29,6 +29,13 @@ export interface LogEntry {
 
 export type Transport = (entry: LogEntry) => void;
 
+export interface LogOutputStream {
+  readonly destroyed?: boolean;
+  readonly writableEnded?: boolean;
+  on(event: 'error', listener: (error: Error) => void): unknown;
+  write(chunk: string): boolean;
+}
+
 // Configuration from environment
 const config = {
   showTrace: process.env.MURMUR_TRACE === '1',
@@ -104,6 +111,34 @@ function formatData(data: Record<string, unknown>): [string, string[]] {
 }
 
 /**
+ * Create a writer that permanently disables itself if its output stream closes
+ * or errors. GUI apps can inherit stdout/stderr pipes from a launcher that exits
+ * before the app, and an unhandled EPIPE must never crash the main process.
+ */
+export function createSafeStreamWriter(
+  stream?: LogOutputStream
+): (line: string) => void {
+  if (!stream) return () => {};
+
+  let available = true;
+  stream.on('error', () => {
+    available = false;
+  });
+
+  return (line: string): void => {
+    if (!available || stream.destroyed || stream.writableEnded) return;
+    try {
+      stream.write(`${line}\n`);
+    } catch {
+      available = false;
+    }
+  };
+}
+
+const writeStdout = createSafeStreamWriter(process.stdout);
+const writeStderr = createSafeStreamWriter(process.stderr);
+
+/**
  * Console transport - formats and writes to stdout/stderr.
  */
 function consoleTransport(entry: LogEntry): void {
@@ -120,8 +155,9 @@ function consoleTransport(entry: LogEntry): void {
     extraLines = stacks;
   }
 
-  // Use stderr for warn/error, stdout for others
-  const output = entry.level === 'warn' || entry.level === 'error' ? console.error : console.log;
+  // Use stderr for warn/error, stdout for others. The safe writers absorb
+  // broken/closed pipe failures from GUI launchers and disable further output.
+  const output = entry.level === 'warn' || entry.level === 'error' ? writeStderr : writeStdout;
   output(line);
   for (const extra of extraLines) {
     output(extra);

--- a/app/tests/logger.test.ts
+++ b/app/tests/logger.test.ts
@@ -63,4 +63,14 @@ describe('safe logger stream writer', () => {
 
     expect(stream.writes).toEqual([]);
   });
+
+  test('does not write to a destroyed stream', () => {
+    const stream = new FakeOutputStream();
+    stream.destroyed = true;
+    const write = createSafeStreamWriter(stream);
+
+    write('ignored');
+
+    expect(stream.writes).toEqual([]);
+  });
 });

--- a/app/tests/logger.test.ts
+++ b/app/tests/logger.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import {
+  createSafeStreamWriter,
+  type LogOutputStream,
+} from '../src/main/lib/logger';
+
+class FakeOutputStream extends EventEmitter implements LogOutputStream {
+  destroyed = false;
+  writableEnded = false;
+  writes: string[] = [];
+
+  write(chunk: string): boolean {
+    this.writes.push(chunk);
+    return true;
+  }
+}
+
+describe('safe logger stream writer', () => {
+  test('writes complete log lines while the stream is available', () => {
+    const stream = new FakeOutputStream();
+    const write = createSafeStreamWriter(stream);
+
+    write('first line');
+    write('second line');
+
+    expect(stream.writes).toEqual(['first line\n', 'second line\n']);
+  });
+
+  test('absorbs an asynchronous EPIPE and disables further writes', () => {
+    const stream = new FakeOutputStream();
+    const write = createSafeStreamWriter(stream);
+
+    write('before failure');
+    const error = Object.assign(new Error('broken pipe'), { code: 'EPIPE' });
+    expect(() => stream.emit('error', error)).not.toThrow();
+    write('after failure');
+
+    expect(stream.writes).toEqual(['before failure\n']);
+  });
+
+  test('absorbs synchronous write failures and disables further writes', () => {
+    let attempts = 0;
+    const stream = new FakeOutputStream();
+    stream.write = () => {
+      attempts += 1;
+      throw Object.assign(new Error('broken pipe'), { code: 'EPIPE' });
+    };
+    const write = createSafeStreamWriter(stream);
+
+    expect(() => write('before failure')).not.toThrow();
+    write('after failure');
+
+    expect(attempts).toBe(1);
+  });
+
+  test('does not write to an already closed stream', () => {
+    const stream = new FakeOutputStream();
+    stream.writableEnded = true;
+    const write = createSafeStreamWriter(stream);
+
+    write('ignored');
+
+    expect(stream.writes).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- replace direct main-process console writes with stdout/stderr writers that disable themselves after a closed-pipe error
- prevent synchronous or asynchronous `EPIPE` failures from crashing Electron
- add focused regression coverage for normal, closed, asynchronous-error, and synchronous-error stream states

## Why
A packaged Murmur instance launched from a short-lived parent could inherit its stdout/stderr pipe. Switching dictation modes logs an event after that parent exits, and the resulting `EPIPE` surfaced as an uncaught JavaScript error in the Electron main process.

## Validation
- `bun test` — 55 passed
- `bun run test:history` — passed
- `bunx tsc --noEmit -p tsconfig.main.json` — passed
- `bunx tsc --noEmit -p tsconfig.json` — passed
- `bun run build` — passed
- Windows NSIS web package built and installed locally
- installed app remained alive after the launcher exited; server healthy, Whisper ready, CUDA active
- History and Insights retained 352 entries; SQLite `quick_check=ok`

## Release note
The local validation package remains version 0.6.2 to test an exact in-place rebuild. If approved, this should ship as a 0.6.3 hotfix rather than replacing the existing 0.6.2 release assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging reliability when output streams close, end, or encounter broken-pipe errors.
  * Prevented logging failures from crashing the application.
  * Preserved routing of warnings and errors to standard error, with other logs sent to standard output.
* **Tests**
  * Added coverage for healthy streams, stream errors, synchronous write failures, and ended/destroyed streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->