### PR TITLE
Add privacy-safe diagnostics copy

### DIFF
--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -1,10 +1,12 @@
 import { app, dialog, ipcMain } from 'electron';
 import { readFile, writeFile } from 'node:fs/promises';
+import { arch, release } from 'node:os';
 import { IPC_CHANNELS } from '../../shared/constants.js';
 import type { HistoryFilters, Settings, Hotkey } from '../../shared/types.js';
 import { formatHotwordsCsl, parseHotwordsCsl } from '../../shared/hotwords.js';
 import { isInsightsRange } from '../../shared/insights.js';
 import { copyToClipboard } from '../services/clipboard.js';
+import { formatDiagnosticsReport } from '../services/diagnostics-report.js';
 import type { HistoryService } from '../services/history.js';
 import type { ServerManager } from '../services/server-manager.js';
 import { getSetting, getSettings, updateSetting } from '../services/settings.js';
@@ -45,6 +47,16 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
   // Handle clipboard copy requests
   ipcMain.on(IPC_CHANNELS.COMMAND_COPY_TO_CLIPBOARD, (_event, text: string) => {
     copyToClipboard(text);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.COMMAND_COPY_DIAGNOSTICS, () => {
+    const report = formatDiagnosticsReport({
+      appVersion: app.getVersion(),
+      windowsRelease: release(),
+      architecture: arch(),
+      serverState: serverManagerRef?.getState(),
+    });
+    copyToClipboard(report);
   });
 
   // Handle settings requests

--- a/app/src/main/preload/main.ts
+++ b/app/src/main/preload/main.ts
@@ -98,6 +98,10 @@ const murmurMainAPI = {
     ipcRenderer.send(IPC_CHANNELS.COMMAND_COPY_TO_CLIPBOARD, text);
   },
 
+  copyDiagnostics: (): Promise<void> => {
+    return ipcRenderer.invoke(IPC_CHANNELS.COMMAND_COPY_DIAGNOSTICS);
+  },
+
   // Recording controls and state (for Test view)
   getRecordingDebugState: (): Promise<RecordingDebugState> => {
     return ipcRenderer.invoke(IPC_CHANNELS.RECORDING_GET_STATE);

--- a/app/src/main/services/diagnostics-report.ts
+++ b/app/src/main/services/diagnostics-report.ts
@@ -10,13 +10,29 @@ export interface DiagnosticsReportInput {
 const SERVER_STATUSES = new Set(['idle', 'starting', 'running', 'stopping', 'stopped', 'error']);
 const ENGINE_STATUSES = new Set(['loading', 'ready', 'error']);
 const MODEL_PHASES = new Set(['checking', 'downloading', 'loading', 'ready', 'error']);
-const SAFE_IDENTIFIER = /^[A-Za-z0-9._-]{1,80}$/;
-const SAFE_MODEL_IDENTIFIER = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/;
+const ENGINE_IDS = new Set(['nemotron', 'whisper']);
+const MODEL_IDS = new Set([
+  'nvidia/nemotron-speech-streaming-en-0.6b',
+  'large-v3-turbo',
+  'large-v3',
+  'medium',
+  'small',
+  'tiny',
+  'mobiuslabsgmbh/faster-whisper-large-v3-turbo',
+  'dropbox-dash/faster-whisper-large-v3-turbo',
+  'Systran/faster-whisper-large-v3-turbo',
+  'Systran/faster-whisper-large-v3',
+  'Systran/faster-whisper-medium',
+  'Systran/faster-whisper-small',
+  'Systran/faster-whisper-tiny',
+]);
+const DEVICES = new Set(['auto', 'cpu', 'cuda']);
+const COMPUTE_TYPES = new Set(['auto', 'int8', 'int8_float16', 'int16', 'float16', 'float32']);
+const RUNTIME_DLLS = new Set(['vcruntime140.dll', 'vcruntime140_1.dll', 'msvcp140.dll']);
 const SAFE_VERSION = /^[A-Za-z0-9._+-]{1,40}$/;
 const SAFE_WINDOWS_RELEASE = /^[0-9A-Za-z._-]{1,40}$/;
 const SAFE_GPU_NAME = /^[A-Za-z0-9 .()_+\-]{1,120}$/;
 const SAFE_DRIVER_VERSION = /^[0-9.]{1,30}$/;
-const SAFE_DLL_NAME = /^[A-Za-z0-9._-]{1,80}\.dll$/i;
 
 const WARNING_MESSAGES: Record<string, string> = {
   vc_redist_missing: 'The required Microsoft Visual C++ runtime was not detected.',
@@ -65,7 +81,7 @@ function safeModelLabel(engineInfo: UnknownRecord | null, modelDownload: Unknown
   for (const candidate of candidates) {
     if (typeof candidate !== 'string' || candidate.length === 0) continue;
     sawString = true;
-    if (candidate.length <= 128 && SAFE_MODEL_IDENTIFIER.test(candidate)) return candidate;
+    if (MODEL_IDS.has(candidate)) return candidate;
   }
   return sawString ? 'custom/local model' : null;
 }
@@ -77,7 +93,8 @@ function appendWarnings(lines: string[], diagnostics: UnknownRecord | null): voi
   for (const value of diagnostics.warnings.slice(0, 20)) {
     const warning = asRecord(value);
     if (!warning) continue;
-    const code = matchingString(warning.code, /^[a-z0-9_-]{1,64}$/) ?? 'unknown_warning';
+    const requestedCode = typeof warning.code === 'string' ? warning.code : '';
+    const code = Object.hasOwn(WARNING_MESSAGES, requestedCode) ? requestedCode : 'unknown_warning';
     const message = WARNING_MESSAGES[code] ?? 'Additional details omitted for privacy.';
     warnings.push(`- ${code}: ${message}`);
   }
@@ -94,6 +111,7 @@ export function formatDiagnosticsReport(input: DiagnosticsReportInput): string {
   const nvidiaDriver = asRecord(diagnostics?.nvidia_driver);
   const vcRedist = asRecord(diagnostics?.vc_redist);
   const modelDownload = asRecord(state?.modelDownload);
+  const managedServer = state?.managed === true;
 
   const appVersion = matchingString(input.appVersion, SAFE_VERSION) ?? 'unknown';
   const windowsRelease = matchingString(input.windowsRelease, SAFE_WINDOWS_RELEASE) ?? 'unknown';
@@ -108,33 +126,39 @@ export function formatDiagnosticsReport(input: DiagnosticsReportInput): string {
     `Server status: ${serverStatus}`,
   ];
 
-  const serverVersion = matchingString(state?.version, SAFE_VERSION);
+  const serverVersion = managedServer ? matchingString(state?.version, SAFE_VERSION) : null;
   if (serverVersion) lines.push(`Server version: ${serverVersion}`);
 
-  const engine = matchingString(engineStatus?.current, SAFE_IDENTIFIER);
+  const engine = enumString(engineStatus?.current, ENGINE_IDS);
   if (engine) lines.push(`Engine: ${engine}`);
   const engineState = enumString(engineStatus?.status, ENGINE_STATUSES);
   if (engineState) lines.push(`Engine status: ${engineState}`);
   const model = safeModelLabel(engineInfo, modelDownload);
   if (model) lines.push(`Model: ${model}`);
 
-  const device = matchingString(engineInfo?.device, SAFE_IDENTIFIER);
+  const device = enumString(engineInfo?.device, DEVICES);
   if (device) lines.push(`Device: ${device}`);
-  const computeType = matchingString(engineInfo?.compute_type, SAFE_IDENTIFIER);
+  const computeType = enumString(engineInfo?.compute_type, COMPUTE_TYPES);
   if (computeType) lines.push(`Compute type: ${computeType}`);
   const cudaActive = yesNo(engineInfo?.cuda_active);
   if (cudaActive) lines.push(`CUDA active: ${cudaActive}`);
 
   const cudaAvailable = yesNo(cuda?.available);
   if (cudaAvailable) lines.push(`CUDA available: ${cudaAvailable}`);
-  const gpuName = matchingString(cuda?.name, SAFE_GPU_NAME) ?? matchingString(engineInfo?.gpu_name, SAFE_GPU_NAME);
+  const gpuName = managedServer
+    ? matchingString(cuda?.name, SAFE_GPU_NAME) ?? matchingString(engineInfo?.gpu_name, SAFE_GPU_NAME)
+    : null;
   if (gpuName) lines.push(`GPU: ${gpuName}`);
-  const computeCapability = matchingString(cuda?.compute_capability, SAFE_DRIVER_VERSION);
+  const computeCapability = managedServer
+    ? matchingString(cuda?.compute_capability, SAFE_DRIVER_VERSION)
+    : null;
   if (computeCapability) lines.push(`Compute capability: ${computeCapability}`);
 
-  const driverVersion = matchingString(nvidiaDriver?.version, SAFE_DRIVER_VERSION);
+  const driverVersion = managedServer ? matchingString(nvidiaDriver?.version, SAFE_DRIVER_VERSION) : null;
   if (driverVersion) lines.push(`NVIDIA driver: ${driverVersion}`);
-  const minimumDriver = matchingString(nvidiaDriver?.minimum_version, SAFE_DRIVER_VERSION);
+  const minimumDriver = managedServer
+    ? matchingString(nvidiaDriver?.minimum_version, SAFE_DRIVER_VERSION)
+    : null;
   if (minimumDriver) lines.push(`Minimum NVIDIA driver: ${minimumDriver}`);
   const driverSupported = yesNo(nvidiaDriver?.meets_minimum);
   if (driverSupported) lines.push(`Driver meets minimum: ${driverSupported}`);
@@ -142,9 +166,11 @@ export function formatDiagnosticsReport(input: DiagnosticsReportInput): string {
   const vcInstalled = yesNo(vcRedist?.installed);
   if (vcInstalled) lines.push(`VC++ runtime installed: ${vcInstalled}`);
   if (Array.isArray(vcRedist?.missing)) {
-    const missingDlls = vcRedist.missing
-      .filter((value): value is string => matchingString(value, SAFE_DLL_NAME) !== null)
-      .slice(0, 20);
+    const missingDlls: string[] = [];
+    for (const value of vcRedist.missing.slice(0, 100)) {
+      if (typeof value === 'string' && RUNTIME_DLLS.has(value)) missingDlls.push(value);
+      if (missingDlls.length === 20) break;
+    }
     if (missingDlls.length > 0) lines.push(`Missing runtime files: ${missingDlls.join(', ')}`);
   }
 

--- a/app/src/main/services/diagnostics-report.ts
+++ b/app/src/main/services/diagnostics-report.ts
@@ -1,0 +1,167 @@
+type UnknownRecord = Record<string, unknown>;
+
+export interface DiagnosticsReportInput {
+  appVersion: unknown;
+  windowsRelease: unknown;
+  architecture: unknown;
+  serverState: unknown;
+}
+
+const SERVER_STATUSES = new Set(['idle', 'starting', 'running', 'stopping', 'stopped', 'error']);
+const ENGINE_STATUSES = new Set(['loading', 'ready', 'error']);
+const MODEL_PHASES = new Set(['checking', 'downloading', 'loading', 'ready', 'error']);
+const SAFE_IDENTIFIER = /^[A-Za-z0-9._-]{1,80}$/;
+const SAFE_MODEL_IDENTIFIER = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/;
+const SAFE_VERSION = /^[A-Za-z0-9._+-]{1,40}$/;
+const SAFE_WINDOWS_RELEASE = /^[0-9A-Za-z._-]{1,40}$/;
+const SAFE_GPU_NAME = /^[A-Za-z0-9 .()_+\-]{1,120}$/;
+const SAFE_DRIVER_VERSION = /^[0-9.]{1,30}$/;
+const SAFE_DLL_NAME = /^[A-Za-z0-9._-]{1,80}\.dll$/i;
+
+const WARNING_MESSAGES: Record<string, string> = {
+  vc_redist_missing: 'The required Microsoft Visual C++ runtime was not detected.',
+  cuda_unavailable: 'CUDA is unavailable; Murmur may use CPU mode.',
+  cuda_dll_missing: 'One or more required CUDA runtime files were not detected.',
+  nvidia_driver_old: 'The NVIDIA driver is older than the supported minimum.',
+};
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as UnknownRecord
+    : null;
+}
+
+function matchingString(value: unknown, pattern: RegExp): string | null {
+  return typeof value === 'string' && pattern.test(value) ? value : null;
+}
+
+function enumString(value: unknown, allowed: Set<string>): string | null {
+  return typeof value === 'string' && allowed.has(value) ? value : null;
+}
+
+function finiteNonNegative(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function yesNo(value: unknown): string | null {
+  return typeof value === 'boolean' ? (value ? 'yes' : 'no') : null;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${Math.round(value)} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let amount = value;
+  let unitIndex = -1;
+  do {
+    amount /= 1024;
+    unitIndex += 1;
+  } while (amount >= 1024 && unitIndex < units.length - 1);
+  return `${amount.toFixed(2)} ${units[unitIndex]}`;
+}
+
+function safeModelLabel(engineInfo: UnknownRecord | null, modelDownload: UnknownRecord | null): string | null {
+  const candidates = [engineInfo?.model, engineInfo?.repo_id, modelDownload?.model, modelDownload?.repo_id];
+  let sawString = false;
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string' || candidate.length === 0) continue;
+    sawString = true;
+    if (candidate.length <= 128 && SAFE_MODEL_IDENTIFIER.test(candidate)) return candidate;
+  }
+  return sawString ? 'custom/local model' : null;
+}
+
+function appendWarnings(lines: string[], diagnostics: UnknownRecord | null): void {
+  if (!Array.isArray(diagnostics?.warnings) || diagnostics.warnings.length === 0) return;
+
+  const warnings: string[] = [];
+  for (const value of diagnostics.warnings.slice(0, 20)) {
+    const warning = asRecord(value);
+    if (!warning) continue;
+    const code = matchingString(warning.code, /^[a-z0-9_-]{1,64}$/) ?? 'unknown_warning';
+    const message = WARNING_MESSAGES[code] ?? 'Additional details omitted for privacy.';
+    warnings.push(`- ${code}: ${message}`);
+  }
+
+  if (warnings.length > 0) lines.push('Warnings:', ...warnings);
+}
+
+export function formatDiagnosticsReport(input: DiagnosticsReportInput): string {
+  const state = asRecord(input.serverState);
+  const engineStatus = asRecord(state?.engineStatus);
+  const engineInfo = asRecord(engineStatus?.info);
+  const diagnostics = asRecord(state?.diagnostics);
+  const cuda = asRecord(diagnostics?.cuda);
+  const nvidiaDriver = asRecord(diagnostics?.nvidia_driver);
+  const vcRedist = asRecord(diagnostics?.vc_redist);
+  const modelDownload = asRecord(state?.modelDownload);
+
+  const appVersion = matchingString(input.appVersion, SAFE_VERSION) ?? 'unknown';
+  const windowsRelease = matchingString(input.windowsRelease, SAFE_WINDOWS_RELEASE) ?? 'unknown';
+  const architecture = enumString(input.architecture, new Set(['x64', 'arm64', 'ia32'])) ?? 'unknown';
+  const managed = typeof state?.managed === 'boolean' ? (state.managed ? 'managed' : 'external') : 'unknown';
+  const serverStatus = enumString(state?.status, SERVER_STATUSES) ?? 'unknown';
+  const lines = [
+    'Murmur diagnostics',
+    `App version: ${appVersion}`,
+    `Windows: ${windowsRelease} (${architecture})`,
+    `Server mode: ${managed}`,
+    `Server status: ${serverStatus}`,
+  ];
+
+  const serverVersion = matchingString(state?.version, SAFE_VERSION);
+  if (serverVersion) lines.push(`Server version: ${serverVersion}`);
+
+  const engine = matchingString(engineStatus?.current, SAFE_IDENTIFIER);
+  if (engine) lines.push(`Engine: ${engine}`);
+  const engineState = enumString(engineStatus?.status, ENGINE_STATUSES);
+  if (engineState) lines.push(`Engine status: ${engineState}`);
+  const model = safeModelLabel(engineInfo, modelDownload);
+  if (model) lines.push(`Model: ${model}`);
+
+  const device = matchingString(engineInfo?.device, SAFE_IDENTIFIER);
+  if (device) lines.push(`Device: ${device}`);
+  const computeType = matchingString(engineInfo?.compute_type, SAFE_IDENTIFIER);
+  if (computeType) lines.push(`Compute type: ${computeType}`);
+  const cudaActive = yesNo(engineInfo?.cuda_active);
+  if (cudaActive) lines.push(`CUDA active: ${cudaActive}`);
+
+  const cudaAvailable = yesNo(cuda?.available);
+  if (cudaAvailable) lines.push(`CUDA available: ${cudaAvailable}`);
+  const gpuName = matchingString(cuda?.name, SAFE_GPU_NAME) ?? matchingString(engineInfo?.gpu_name, SAFE_GPU_NAME);
+  if (gpuName) lines.push(`GPU: ${gpuName}`);
+  const computeCapability = matchingString(cuda?.compute_capability, SAFE_DRIVER_VERSION);
+  if (computeCapability) lines.push(`Compute capability: ${computeCapability}`);
+
+  const driverVersion = matchingString(nvidiaDriver?.version, SAFE_DRIVER_VERSION);
+  if (driverVersion) lines.push(`NVIDIA driver: ${driverVersion}`);
+  const minimumDriver = matchingString(nvidiaDriver?.minimum_version, SAFE_DRIVER_VERSION);
+  if (minimumDriver) lines.push(`Minimum NVIDIA driver: ${minimumDriver}`);
+  const driverSupported = yesNo(nvidiaDriver?.meets_minimum);
+  if (driverSupported) lines.push(`Driver meets minimum: ${driverSupported}`);
+
+  const vcInstalled = yesNo(vcRedist?.installed);
+  if (vcInstalled) lines.push(`VC++ runtime installed: ${vcInstalled}`);
+  if (Array.isArray(vcRedist?.missing)) {
+    const missingDlls = vcRedist.missing
+      .filter((value): value is string => matchingString(value, SAFE_DLL_NAME) !== null)
+      .slice(0, 20);
+    if (missingDlls.length > 0) lines.push(`Missing runtime files: ${missingDlls.join(', ')}`);
+  }
+
+  const modelPhase = enumString(modelDownload?.phase, MODEL_PHASES);
+  if (modelPhase) lines.push(`Model phase: ${modelPhase}`);
+  const progress = finiteNonNegative(modelDownload?.progress_percent);
+  if (progress !== null) lines.push(`Model progress: ${Math.min(100, progress).toFixed(0)}%`);
+  const downloaded = finiteNonNegative(modelDownload?.downloaded_bytes);
+  const total = finiteNonNegative(modelDownload?.total_bytes);
+  if (downloaded !== null && total !== null) {
+    lines.push(`Downloaded: ${formatBytes(downloaded)} / ${formatBytes(total)}`);
+  }
+  const speed = finiteNonNegative(modelDownload?.bytes_per_second);
+  if (speed !== null) lines.push(`Transfer speed: ${formatBytes(speed)}/s`);
+  const eta = finiteNonNegative(modelDownload?.eta_seconds);
+  if (eta !== null) lines.push(`ETA: ${Math.round(eta)} s`);
+
+  appendWarnings(lines, diagnostics);
+  return `${lines.join('\n')}\n`;
+}

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -19,6 +19,8 @@
   let isLoading = $state(false);
   let logsContainer: HTMLDivElement | null = $state(null);
   let logsCopied = $state(false);
+  let diagnosticsCopyState = $state<'idle' | 'copied' | 'error'>('idle');
+  let diagnosticsCopyTimer: ReturnType<typeof setTimeout> | null = null;
   let pendingLogs: ServerLogEntry[] = [];
   let logFrame: number | null = null;
   let scrollAfterLogBatch = false;
@@ -148,6 +150,21 @@
     setTimeout(() => (logsCopied = false), 2000);
   }
 
+  async function copyDiagnostics() {
+    if (diagnosticsCopyTimer !== null) clearTimeout(diagnosticsCopyTimer);
+    diagnosticsCopyState = 'idle';
+    try {
+      await window.murmurMain.copyDiagnostics();
+      diagnosticsCopyState = 'copied';
+    } catch {
+      diagnosticsCopyState = 'error';
+    }
+    diagnosticsCopyTimer = setTimeout(() => {
+      diagnosticsCopyState = 'idle';
+      diagnosticsCopyTimer = null;
+    }, 2000);
+  }
+
   function queueLog(entry: ServerLogEntry) {
     scrollAfterLogBatch ||= showLogs && isScrolledToBottom();
     pendingLogs.push(entry);
@@ -188,6 +205,7 @@
 
   onDestroy(() => {
     if (logFrame !== null) cancelAnimationFrame(logFrame);
+    if (diagnosticsCopyTimer !== null) clearTimeout(diagnosticsCopyTimer);
     window.murmurMain.removeServerListeners();
   });
 </script>
@@ -220,6 +238,24 @@
         </div>
       </div>
     {/if}
+
+    <SettingsSection title="Diagnostics">
+      <div class="flex w-full items-center justify-between gap-4 rounded-xl bg-zinc-900/50 p-4">
+        <p class="text-xs text-zinc-500">
+          Copies an allowlisted system summary without logs, paths, history, or transcription text.
+        </p>
+        <button
+          onclick={copyDiagnostics}
+          class="shrink-0 rounded-lg bg-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-600 cursor-pointer"
+        >
+          {diagnosticsCopyState === 'copied'
+            ? 'Copied diagnostics'
+            : diagnosticsCopyState === 'error'
+              ? 'Copy failed'
+              : 'Copy diagnostics'}
+        </button>
+      </div>
+    </SettingsSection>
 
     <div class="space-y-8 {useExternalServer ? 'opacity-45 pointer-events-none select-none' : ''}">
 
@@ -376,6 +412,7 @@
             {/if}
           </div>
         {/if}
+
       </div>
     </SettingsSection>
 
@@ -425,7 +462,8 @@
         </button>
 
         {#if showLogs}
-          <div class="mt-2 flex items-center justify-end px-1">
+          <div class="mt-2 flex items-center justify-between gap-3 px-1">
+            <p class="text-xs text-amber-300/70">Raw logs may contain local paths. Review before sharing.</p>
             <button
               onclick={(e: MouseEvent) => { e.stopPropagation(); copyLogs(); }}
               disabled={logs.length === 0}
@@ -441,7 +479,7 @@
                 Copied
               {:else}
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
-                Copy
+                Copy raw logs
               {/if}
             </button>
           </div>

--- a/app/src/renderer/global.d.ts
+++ b/app/src/renderer/global.d.ts
@@ -40,6 +40,7 @@ declare global {
       rebuildInsights: () => Promise<void>;
       onNewHistoryEntry: (callback: (entry: HistoryEntryWithGroup) => void) => () => void;
       copyToClipboard: (text: string) => void;
+      copyDiagnostics: () => Promise<void>;
       getRecordingDebugState: () => Promise<RecordingDebugState>;
       startRecording: () => Promise<RecordingDebugState>;
       stopRecording: () => Promise<RecordingDebugState>;

--- a/app/src/shared/constants.ts
+++ b/app/src/shared/constants.ts
@@ -17,6 +17,7 @@ export const IPC_CHANNELS = {
 
   // Renderer → Main (commands)
   COMMAND_COPY_TO_CLIPBOARD: 'command:copy-to-clipboard',
+  COMMAND_COPY_DIAGNOSTICS: 'command:copy-diagnostics',
 
   // Main window controls
   MAIN_WINDOW_CLOSE: 'main-window:close',

--- a/app/tests/diagnostics-report.test.ts
+++ b/app/tests/diagnostics-report.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test';
+import { formatDiagnosticsReport } from '../src/main/services/diagnostics-report';
+
+function report(serverState: unknown): string {
+  return formatDiagnosticsReport({
+    appVersion: '0.6.2',
+    windowsRelease: '10.0.26100',
+    architecture: 'x64',
+    serverState,
+  });
+}
+
+describe('privacy-safe diagnostics report', () => {
+  test('formats an allowlisted healthy CUDA summary deterministically', () => {
+    expect(report({
+      status: 'running',
+      managed: true,
+      version: '0.6.2',
+      engineStatus: {
+        current: 'parakeet',
+        status: 'ready',
+        info: {
+          model: 'nvidia/parakeet-tdt-0.6b-v2',
+          device: 'cuda',
+          compute_type: 'float16',
+          cuda_active: true,
+        },
+      },
+      diagnostics: {
+        cuda: { available: true, name: 'NVIDIA GeForce RTX 4060', compute_capability: '8.9' },
+        nvidia_driver: { version: '560.94', minimum_version: '525.0', meets_minimum: true },
+        vc_redist: { installed: true },
+        warnings: [],
+      },
+    })).toBe(`Murmur diagnostics
+App version: 0.6.2
+Windows: 10.0.26100 (x64)
+Server mode: managed
+Server status: running
+Server version: 0.6.2
+Engine: parakeet
+Engine status: ready
+Model: nvidia/parakeet-tdt-0.6b-v2
+Device: cuda
+Compute type: float16
+CUDA active: yes
+CUDA available: yes
+GPU: NVIDIA GeForce RTX 4060
+Compute capability: 8.9
+NVIDIA driver: 560.94
+Minimum NVIDIA driver: 525.0
+Driver meets minimum: yes
+VC++ runtime installed: yes
+`);
+  });
+
+  test('includes bounded progress metrics without current file details', () => {
+    const output = report({
+      status: 'starting',
+      managed: true,
+      modelDownload: {
+        model: 'large-v3-turbo',
+        phase: 'downloading',
+        progress_percent: 104.7,
+        downloaded_bytes: 1024,
+        total_bytes: 2048,
+        bytes_per_second: 512,
+        eta_seconds: 12.4,
+        current_file: 'C:\\Users\\Alice\\secret-model.bin',
+      },
+    });
+
+    expect(output).toContain('Model phase: downloading');
+    expect(output).toContain('Model progress: 100%');
+    expect(output).toContain('Downloaded: 1.00 KB / 2.00 KB');
+    expect(output).toContain('Transfer speed: 512 B/s');
+    expect(output).toContain('ETA: 12 s');
+    expect(output).not.toContain('Alice');
+    expect(output).not.toContain('secret-model.bin');
+  });
+
+  test('canonicalizes warning text and omits all raw private fields', () => {
+    const sensitiveValues = [
+      'C:\\Users\\Alice\\models\\private',
+      'Bearer top-secret-token',
+      'private transcript words',
+      'clipboard secret',
+      'https://private.example/action',
+    ];
+    const output = report({
+      status: 'error',
+      managed: false,
+      pid: 1234,
+      port: 51717,
+      wsUrl: 'ws://private-host:51717/ws',
+      error: sensitiveValues[0],
+      engineStatus: {
+        current: 'whisper',
+        status: 'error',
+        message: sensitiveValues[1],
+        info: { model: sensitiveValues[0], model_path: sensitiveValues[0] },
+      },
+      modelDownload: { model: sensitiveValues[0], detail: sensitiveValues[2], path: sensitiveValues[0] },
+      diagnostics: {
+        cuda: { available: false, reason: sensitiveValues[3] },
+        cuda_dlls: { available: false, detail: sensitiveValues[0] },
+        warnings: [
+          { code: 'cuda_unavailable', message: sensitiveValues[2], action: sensitiveValues[1] },
+          { code: 'unexpected_probe', message: sensitiveValues[3], url: sensitiveValues[4] },
+        ],
+      },
+      logs: sensitiveValues,
+      history: sensitiveValues[2],
+    });
+
+    expect(output).toContain('Server mode: external');
+    expect(output).toContain('Model: custom/local model');
+    expect(output).toContain('- cuda_unavailable: CUDA is unavailable; Murmur may use CPU mode.');
+    expect(output).toContain('- unexpected_probe: Additional details omitted for privacy.');
+    for (const sensitive of sensitiveValues) expect(output).not.toContain(sensitive);
+    expect(output).not.toContain('51717');
+    expect(output).not.toContain('1234');
+  });
+
+  test('drops malformed nested values and unsafe missing-file paths', () => {
+    const output = formatDiagnosticsReport({
+      appVersion: '0.6.2\nInjected',
+      windowsRelease: 'C:\\Users\\Alice',
+      architecture: 'mips',
+      serverState: {
+        status: 'almost-running',
+        managed: 'yes',
+        engineStatus: { current: 'bad/value', status: 'ready', info: { gpu_name: 'C:\\secret' } },
+        diagnostics: {
+          vc_redist: { installed: 'yes', missing: ['vcruntime140.dll', 'C:\\secret.dll'] },
+          warnings: [{ code: 'BAD CODE', message: 'private details' }, null],
+        },
+        modelDownload: { progress_percent: Number.NaN, eta_seconds: -5 },
+      },
+    });
+
+    expect(output).toContain('App version: unknown');
+    expect(output).toContain('Windows: unknown (unknown)');
+    expect(output).toContain('Server mode: unknown');
+    expect(output).toContain('Server status: unknown');
+    expect(output).toContain('Engine status: ready');
+    expect(output).toContain('Missing runtime files: vcruntime140.dll');
+    expect(output).toContain('- unknown_warning: Additional details omitted for privacy.');
+    expect(output).not.toContain('Alice');
+    expect(output).not.toContain('secret.dll');
+    expect(output).not.toContain('private details');
+    expect(output).not.toContain('Model progress:');
+    expect(output).not.toContain('ETA:');
+  });
+
+  test('handles an unavailable server snapshot', () => {
+    expect(report(null)).toContain(`Server mode: unknown
+Server status: unknown
+`);
+  });
+});

--- a/app/tests/diagnostics-report.test.ts
+++ b/app/tests/diagnostics-report.test.ts
@@ -17,10 +17,10 @@ describe('privacy-safe diagnostics report', () => {
       managed: true,
       version: '0.6.2',
       engineStatus: {
-        current: 'parakeet',
+        current: 'nemotron',
         status: 'ready',
         info: {
-          model: 'nvidia/parakeet-tdt-0.6b-v2',
+          model: 'nvidia/nemotron-speech-streaming-en-0.6b',
           device: 'cuda',
           compute_type: 'float16',
           cuda_active: true,
@@ -38,9 +38,9 @@ Windows: 10.0.26100 (x64)
 Server mode: managed
 Server status: running
 Server version: 0.6.2
-Engine: parakeet
+Engine: nemotron
 Engine status: ready
-Model: nvidia/parakeet-tdt-0.6b-v2
+Model: nvidia/nemotron-speech-streaming-en-0.6b
 Device: cuda
 Compute type: float16
 CUDA active: yes
@@ -116,7 +116,7 @@ VC++ runtime installed: yes
     expect(output).toContain('Server mode: external');
     expect(output).toContain('Model: custom/local model');
     expect(output).toContain('- cuda_unavailable: CUDA is unavailable; Murmur may use CPU mode.');
-    expect(output).toContain('- unexpected_probe: Additional details omitted for privacy.');
+    expect(output).toContain('- unknown_warning: Additional details omitted for privacy.');
     for (const sensitive of sensitiveValues) expect(output).not.toContain(sensitive);
     expect(output).not.toContain('51717');
     expect(output).not.toContain('1234');
@@ -151,6 +151,51 @@ VC++ runtime installed: yes
     expect(output).not.toContain('private details');
     expect(output).not.toContain('Model progress:');
     expect(output).not.toContain('ETA:');
+  });
+
+  test('does not copy regex-valid secrets from an external server', () => {
+    const secret = 'top-secret-token';
+    const output = report({
+      status: 'running',
+      managed: false,
+      version: secret,
+      engineStatus: {
+        current: secret,
+        status: 'ready',
+        info: {
+          model: secret,
+          repo_id: secret,
+          device: secret,
+          compute_type: secret,
+          gpu_name: secret,
+        },
+      },
+      diagnostics: {
+        cuda: { available: true, name: secret, compute_capability: '8.9' },
+        nvidia_driver: { version: '560.94', minimum_version: '525.0' },
+        vc_redist: { missing: [`${secret}.dll`] },
+        warnings: [{ code: secret, message: secret }],
+      },
+      modelDownload: { model: secret, repo_id: secret },
+    });
+
+    expect(output).toContain('Model: custom/local model');
+    expect(output).toContain('- unknown_warning: Additional details omitted for privacy.');
+    expect(output).not.toContain(secret);
+    expect(output).not.toContain('GPU:');
+    expect(output).not.toContain('NVIDIA driver:');
+    expect(output).not.toContain('Missing runtime files:');
+  });
+
+  test('bounds the inspected missing-runtime prefix', () => {
+    const missing = Array.from({ length: 150 }, () => 'not-a-runtime.dll');
+    missing[120] = 'vcruntime140.dll';
+
+    expect(report({
+      status: 'running',
+      managed: true,
+      diagnostics: { vc_redist: { missing } },
+    })).not.toContain('Missing runtime files:');
   });
 
   test('handles an unavailable server snapshot', () => {


### PR DESCRIPTION
## Summary
- add a main-process-owned, allowlisted diagnostics report and copy action
- expose a narrow preload API and a Server-page control that works in managed and external-server modes
- distinguish raw log copying and warn that raw logs may contain local paths

## Privacy boundary
The report excludes raw logs, transcription/history/Insights content, clipboard contents, usernames and computer names, environment variables and tokens, local paths, raw server/engine errors, download filenames, host/port/PID, and arbitrary warning text.

## Validation
- 56 Bun tests passed
- main and renderer TypeScript checks passed
- production build passed
- focused privacy tests cover malformed and adversarial server fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Diagnostics section that copies a privacy-safe system and server summary.
  * Added copy success/failure feedback for diagnostics, plus improved the Logs copy action to “Copy raw logs” with a note that raw logs may include local file paths.
* **Privacy**
  * Diagnostics are strictly allowlisted and sanitize/omit sensitive details, including unsafe secrets and private runtime identifiers; unsupported/missing fields render as “unknown.”
* **Bug Fixes**
  * Improved handling of malformed or unsafe diagnostics inputs so reports remain stable and privacy-safe even with unexpected server data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->