### PR TITLE
Contain History text and refine microphone warning

### DIFF
--- a/app/src/renderer/app/views/HistoryView.svelte
+++ b/app/src/renderer/app/views/HistoryView.svelte
@@ -523,7 +523,7 @@
 
           <!-- Entry -->
           <div
-            class="group rounded-2xl border border-zinc-800/60 transition-all duration-200
+            class="group min-w-0 overflow-hidden rounded-2xl border border-zinc-800/60 transition-all duration-200
               {isExpanded ? 'bg-zinc-900 border-zinc-800' : 'hover:bg-zinc-900/50 hover:border-zinc-800'}"
           >
             <!-- Collapsed/Preview State -->
@@ -541,7 +541,7 @@
             >
               <div class="flex items-start gap-3">
                 <div class="flex-1 min-w-0">
-                  <p class="text-sm text-zinc-200 {isExpanded ? '' : 'line-clamp-2'}">
+                  <p class="max-w-full text-sm text-zinc-200 [overflow-wrap:anywhere] {isExpanded ? '' : 'line-clamp-2'}">
                     {item.text}
                   </p>
                   <p class="text-xs text-zinc-500 mt-1.5">

--- a/app/src/renderer/overlay/App.svelte
+++ b/app/src/renderer/overlay/App.svelte
@@ -152,10 +152,20 @@
 >
   <div class="absolute inset-x-0 bottom-[88px] flex flex-col items-center gap-5 px-4">
     {#if warningMessage}
-      <div class="max-w-xl rounded-2xl border border-amber-500/40 bg-amber-500/10 px-3 py-2">
-        <p class="text-center text-xs font-medium text-amber-200">
-          {warningMessage}
-        </p>
+      <div
+        class="max-w-xl rounded-2xl border border-zinc-500/25 bg-black/95 px-4 py-2 shadow-[0_4px_16px_rgba(239,68,68,0.18)]"
+        role="status"
+        aria-live="polite"
+      >
+        <div class="flex items-center justify-center gap-2">
+          <span class="relative flex h-2 w-2 shrink-0" aria-hidden="true">
+            <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400/35 motion-reduce:animate-none"></span>
+            <span class="relative inline-flex h-2 w-2 rounded-full bg-red-400"></span>
+          </span>
+          <p class="text-center text-xs font-medium text-zinc-200 [overflow-wrap:anywhere]">
+            {warningMessage}
+          </p>
+        </div>
       </div>
     {/if}
 

--- a/app/tests/renderer-visual-guards.test.ts
+++ b/app/tests/renderer-visual-guards.test.ts
@@ -12,15 +12,22 @@ const overlayView = readFileSync(
 
 describe('renderer visual regression guards', () => {
   test('contains long unbroken history text inside its card', () => {
-    expect(historyView).toContain('group min-w-0 overflow-hidden rounded-2xl');
-    expect(historyView).toContain('[overflow-wrap:anywhere]');
+    const historyCard = historyView.match(/<div\s+class="group[^>]+>/)?.[0];
+    const transcript = historyView.match(/<p\s+class="[^"]+"[^>]*>\s*\{item\.text\}\s*<\/p>/)?.[0];
+
+    expect(historyCard).toContain('min-w-0 overflow-hidden');
+    expect(transcript).toContain('max-w-full');
+    expect(transcript).toContain('[overflow-wrap:anywhere]');
   });
 
   test('uses an accessible dark microphone warning instead of the amber card', () => {
-    expect(overlayView).toContain('border-zinc-500/25 bg-black/95');
-    expect(overlayView).toContain('aria-live="polite"');
-    expect(overlayView).toContain('bg-red-400/35');
-    expect(overlayView).toContain('motion-reduce:animate-none');
-    expect(overlayView).not.toContain('border-amber-500/40 bg-amber-500/10');
+    const warning = overlayView.match(/\{#if warningMessage\}([\s\S]*?)\{\/if\}/)?.[1];
+    const warningCard = warning?.match(/<div\s+class="[^"]+"\s+role="status"\s+aria-live="polite"\s*>/)?.[0];
+    const warningIndicator = warning?.match(/<span\s+class="[^"]*animate-ping[^"]*"[^>]*>/)?.[0];
+
+    expect(warningCard).toContain('border-zinc-500/25 bg-black/95');
+    expect(warningCard).not.toContain('amber');
+    expect(warningIndicator).toContain('bg-red-400/35');
+    expect(warningIndicator).toContain('motion-reduce:animate-none');
   });
 });

--- a/app/tests/renderer-visual-guards.test.ts
+++ b/app/tests/renderer-visual-guards.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const historyView = readFileSync(
+  new URL('../src/renderer/app/views/HistoryView.svelte', import.meta.url),
+  'utf8'
+);
+const overlayView = readFileSync(
+  new URL('../src/renderer/overlay/App.svelte', import.meta.url),
+  'utf8'
+);
+
+describe('renderer visual regression guards', () => {
+  test('contains long unbroken history text inside its card', () => {
+    expect(historyView).toContain('group min-w-0 overflow-hidden rounded-2xl');
+    expect(historyView).toContain('[overflow-wrap:anywhere]');
+  });
+
+  test('uses an accessible dark microphone warning instead of the amber card', () => {
+    expect(overlayView).toContain('border-zinc-500/25 bg-black/95');
+    expect(overlayView).toContain('aria-live="polite"');
+    expect(overlayView).toContain('bg-red-400/35');
+    expect(overlayView).toContain('motion-reduce:animate-none');
+    expect(overlayView).not.toContain('border-amber-500/40 bg-amber-500/10');
+  });
+});


### PR DESCRIPTION
## Summary
- keep long and unbroken transcription text inside History cards
- replace the amber microphone warning card with a dark, accessible status treatment matching the overlay pill
- add focused renderer regression guards for both behaviors

## Scope
Renderer-only. This PR does not change microphone capture, WebSocket/session behavior, transcription engines, server code, or logging.

## Validation
- 65 app tests passed
- History/Insights aggregate check passed
- main-process TypeScript check passed
- renderer TypeScript check passed
- production app build passed
- focused renderer test and renderer build rerun after the reduced-motion refinement
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced History view layout to better handle long entries, improving overflow behavior and text wrapping when collapsed or expanded.
  - Refreshed the overlay warning banner with clearer visual emphasis and improved accessibility (live status updates).
  - Updated warning indicator animation to respect reduced-motion preferences.

- **Tests**
  - Added visual regression safeguards to detect unintended changes in the History view styling and the accessible warning banner structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->