### PR TITLE
Wait for transcription protocol readiness

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -4,7 +4,10 @@ import { createMainWindow, showMainWindow } from './windows/main.js';
 import { setupHotkeyService } from './services/hotkey.js';
 import { setupTray } from './services/tray.js';
 import { setupIpcHandlers } from './ipc/handlers.js';
-import { TranscriptionService } from './services/transcription.js';
+import {
+  TranscriptionConnectionCancelledError,
+  TranscriptionService,
+} from './services/transcription.js';
 import { HistoryService } from './services/history.js';
 import { ServerManager } from './services/server-manager.js';
 import { processFinalTranscription } from './services/pipeline.js';
@@ -333,6 +336,9 @@ async function startRecording(source: 'lab' | 'normal', sessionMode: DictationSe
     overlayWindow.webContents.send(IPC_CHANNELS.COMMAND_START_RECORDING, deviceId);
   } catch (error) {
     if (transcriptionService !== service) {
+      return;
+    }
+    if (error instanceof TranscriptionConnectionCancelledError) {
       return;
     }
     log.error('Failed to connect to transcription server', { error: error as Error });

--- a/app/src/main/services/transcription.ts
+++ b/app/src/main/services/transcription.ts
@@ -20,6 +20,13 @@ import { createLogger } from '../lib/logger.js';
 
 const log = createLogger('Transcription');
 
+export class TranscriptionConnectionCancelledError extends Error {
+  constructor() {
+    super('Transcription connection cancelled');
+    this.name = 'TranscriptionConnectionCancelledError';
+  }
+}
+
 export class TranscriptionService {
   private ws: WebSocket | null = null;
   private serverUrl: string;
@@ -40,6 +47,8 @@ export class TranscriptionService {
   private lastTextFrame: TextFrame | null = null;
   private didReceiveFinal = false;
   private didReceiveReady = false;
+  private stopRequested = false;
+  private cancelPendingConnect: (() => void) | null = null;
 
   constructor(
     serverUrl: string,
@@ -62,8 +71,23 @@ export class TranscriptionService {
       this.lastTextFrame = null;
       this.didReceiveFinal = false;
       this.didReceiveReady = false;
+      this.stopRequested = false;
       this.sendConnectionState('connecting');
       let connectSettled = false;
+
+      const settleConnect = (error?: Error) => {
+        if (connectSettled) return;
+        connectSettled = true;
+        this.cancelPendingConnect = null;
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+      this.cancelPendingConnect = () => {
+        settleConnect(new TranscriptionConnectionCancelledError());
+      };
 
       this.ws = new WebSocket(this.serverUrl);
 
@@ -74,28 +98,22 @@ export class TranscriptionService {
 
       this.ws.on('message', (data) => {
         this.handleMessage(data.toString());
-        if (this.didReceiveReady && !connectSettled) {
-          connectSettled = true;
-          resolve();
+        if (this.didReceiveReady) {
+          settleConnect();
         }
       });
 
       this.ws.on('error', (error) => {
+        if (this.stopRequested) return;
         log.error('WebSocket error', { error });
         this.sendConnectionState('error', error.message);
-        if (!connectSettled) {
-          connectSettled = true;
-          reject(error);
-        }
+        settleConnect(error);
       });
 
       this.ws.on('close', () => {
         this.maybeEmitSyntheticFinal('socket_closed');
         this.sendConnectionState('disconnected');
-        if (!connectSettled) {
-          connectSettled = true;
-          reject(new Error('WebSocket closed before connection was ready'));
-        }
+        settleConnect(new Error('WebSocket closed before connection was ready'));
         this.onCloseCallback?.();
       });
     });
@@ -124,6 +142,9 @@ export class TranscriptionService {
   }
 
   stop(): void {
+    this.stopRequested = true;
+    this.cancelPendingConnect?.();
+
     // Don't send stop if server already initiated close
     if (this.serverClosing) {
       return;
@@ -193,6 +214,7 @@ export class TranscriptionService {
     if (frame.frame === 'control') {
       switch (frame.type) {
         case 'ready':
+          if (this.stopRequested) break;
           this.didReceiveReady = true;
           this.isReady = true;
           this.sendRecordingState('listening');

--- a/app/src/main/services/transcription.ts
+++ b/app/src/main/services/transcription.ts
@@ -30,7 +30,6 @@ export class TranscriptionService {
   private sequenceNumber = 0;
   private isReady = false;
   private serverClosing = false; // Server initiated close, don't send stop
-  private stopRequested = false;
   private onFinalCallback: ((frame: TextFrameFinal) => void) | null = null;
   private onCloseCallback: (() => void) | null = null;
   private onRecordingStateCallback: ((payload: RecordingStatePayload) => void) | null = null;
@@ -60,7 +59,6 @@ export class TranscriptionService {
     return new Promise((resolve, reject) => {
       this.isReady = false;
       this.serverClosing = false;
-      this.stopRequested = false;
       this.lastTextFrame = null;
       this.didReceiveFinal = false;
       this.didReceiveReady = false;
@@ -72,15 +70,14 @@ export class TranscriptionService {
       this.ws.on('open', () => {
         this.sendStartFrame();
         this.sendConnectionState('connected');
-        connectSettled = true;
-        resolve();
-        if (this.stopRequested) {
-          this.stop();
-        }
       });
 
       this.ws.on('message', (data) => {
         this.handleMessage(data.toString());
+        if (this.didReceiveReady && !connectSettled) {
+          connectSettled = true;
+          resolve();
+        }
       });
 
       this.ws.on('error', (error) => {
@@ -127,8 +124,6 @@ export class TranscriptionService {
   }
 
   stop(): void {
-    this.stopRequested = true;
-
     // Don't send stop if server already initiated close
     if (this.serverClosing) {
       return;

--- a/app/tests/transcription-readiness.test.ts
+++ b/app/tests/transcription-readiness.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import { once } from 'node:events';
+import type { BrowserWindow } from 'electron';
+import { WebSocketServer, type WebSocket } from 'ws';
+import { TranscriptionService } from '../src/main/services/transcription';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('TranscriptionService protocol readiness', () => {
+  test('does not connect or send audio until the server emits ready', async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await once(server, 'listening');
+    const address = server.address();
+    if (typeof address === 'string' || address === null) {
+      throw new Error('Expected an ephemeral TCP address');
+    }
+
+    const accepted = deferred<WebSocket>();
+    const startReceived = deferred<void>();
+    const audioReceived = deferred<void>();
+    let binaryFrames = 0;
+
+    server.on('connection', (socket) => {
+      accepted.resolve(socket);
+      socket.on('message', (_data, isBinary) => {
+        if (isBinary) {
+          binaryFrames += 1;
+          audioReceived.resolve();
+        } else {
+          startReceived.resolve();
+        }
+      });
+    });
+
+    const overlay = {
+      isDestroyed: () => false,
+      webContents: { send: () => undefined },
+    } as unknown as BrowserWindow;
+    const service = new TranscriptionService(
+      `ws://127.0.0.1:${address.port}`,
+      10,
+      overlay
+    );
+    let connected = false;
+
+    try {
+      const connectPromise = service.connect().then(() => {
+        connected = true;
+      });
+      const socket = await accepted.promise;
+      await startReceived.promise;
+
+      expect(connected).toBeFalse();
+      service.sendAudioBuffer(new ArrayBuffer(8));
+      expect(binaryFrames).toBe(0);
+
+      socket.send(JSON.stringify({ frame: 'control', type: 'ready' }));
+      await connectPromise;
+      expect(connected).toBeTrue();
+
+      service.sendAudioBuffer(new ArrayBuffer(8));
+      await audioReceived.promise;
+      expect(binaryFrames).toBe(1);
+
+    } finally {
+      for (const client of server.clients) {
+        client.terminate();
+      }
+      server.close();
+    }
+  });
+});

--- a/app/tests/transcription-readiness.test.ts
+++ b/app/tests/transcription-readiness.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'bun:test';
 import { once } from 'node:events';
 import type { BrowserWindow } from 'electron';
 import { WebSocketServer, type WebSocket } from 'ws';
-import { TranscriptionService } from '../src/main/services/transcription';
+import {
+  TranscriptionConnectionCancelledError,
+  TranscriptionService,
+} from '../src/main/services/transcription';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -68,6 +71,56 @@ describe('TranscriptionService protocol readiness', () => {
       await audioReceived.promise;
       expect(binaryFrames).toBe(1);
 
+    } finally {
+      for (const client of server.clients) {
+        client.terminate();
+      }
+      server.close();
+    }
+  });
+
+  test('distinguishes a user stop before readiness from a connection failure', async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await once(server, 'listening');
+    const address = server.address();
+    if (typeof address === 'string' || address === null) {
+      throw new Error('Expected an ephemeral TCP address');
+    }
+
+    const startReceived = deferred<void>();
+    const stopReceived = deferred<void>();
+    server.on('connection', (socket) => {
+      socket.on('message', (data, isBinary) => {
+        if (isBinary) return;
+        const frame = JSON.parse(data.toString()) as { type?: string };
+        if (frame.type === 'start') {
+          startReceived.resolve();
+        } else if (frame.type === 'stop') {
+          stopReceived.resolve();
+          socket.close();
+        }
+      });
+    });
+
+    const overlay = {
+      isDestroyed: () => false,
+      webContents: { send: () => undefined },
+    } as unknown as BrowserWindow;
+    const service = new TranscriptionService(
+      `ws://127.0.0.1:${address.port}`,
+      10,
+      overlay
+    );
+
+    try {
+      const connectPromise = service.connect();
+      await startReceived.promise;
+      service.stop();
+
+      await expect(connectPromise).rejects.toBeInstanceOf(
+        TranscriptionConnectionCancelledError
+      );
+      await stopReceived.promise;
     } finally {
       for (const client of server.clients) {
         client.terminate();


### PR DESCRIPTION
## Summary
- keep TranscriptionService.connect pending until the server sends the protocol ready frame
- prevent the renderer microphone from starting during the socket-open/server-not-ready window
- add a real loopback WebSocket regression test proving pre-ready audio is withheld and post-ready audio is delivered

## Why
The protocol requires clients to send audio only after ready. Current trunk resolves connect on WebSocket open, so the main process starts capture while TranscriptionService still silently drops frames. This is a deterministic startup audio-loss window. It may contribute to missing starts, but this PR does not claim to explain every rare gibberish report.

## Scope
App main-process transcription lifecycle only. No microphone acquisition, server, VAD, Whisper, model, UI, or logging changes.

## Validation
- focused test demonstrated the failure before the change and passes after it
- 64 app tests passed
- main and renderer TypeScript checks passed
- production app build passed
- git diff --check passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a deterministic startup audio-loss window by keeping `TranscriptionService.connect()` pending until the server emits the `ready` control frame, and prevents the renderer microphone from starting during the socket-open/server-not-ready gap. The `cancelPendingConnect` mechanism cleanly rejects the connection promise with a typed `TranscriptionConnectionCancelledError` when `stop()` is called before the server is ready, and `index.ts` silently swallows that error to avoid a spurious error state.

- **`transcription.ts`**: `connect()` now resolves on `ready` instead of `open`; `cancelPendingConnect` replaces the old deferred-stop pattern for clean cancellation during the readiness window.
- **`index.ts`**: Imports and catches `TranscriptionConnectionCancelledError`, returning silently so a user-initiated pre-ready stop is not treated as a connection failure.
- **`transcription-readiness.test.ts`**: New loopback WebSocket regression tests cover both the happy-path (no audio before ready, audio flows after) and the stop-during-window path (promise rejects with `TranscriptionConnectionCancelledError`, stop frame is delivered to server).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped to the connection lifecycle, all three code paths (happy, cancelled, error) are covered by the new tests, and the caller in index.ts correctly handles the new error type.

The `cancelPendingConnect` mechanism is idempotent and races cleanly with the close/error handlers; `settleConnect` is guarded by `connectSettled` so double-settlement cannot happen. The typed `TranscriptionConnectionCancelledError` ensures the catch block in `startRecording` treats user-initiated pre-ready stops as silent no-ops rather than faults. Both regression tests exercise the code paths introduced by the PR.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/src/main/services/transcription.ts | Core change: connect() now pends until 'ready' is received; cancelPendingConnect cleanly rejects the promise on stop(), and the error handler skips logging/state emission when stop was already requested. |
| app/src/main/index.ts | Imports TranscriptionConnectionCancelledError and silently returns from the catch block when connect() is cancelled, preventing a spurious error state and redundant stopRecording() call. |
| app/tests/transcription-readiness.test.ts | New regression test with two scenarios: (1) no audio before ready, audio flows after; (2) stop during readiness window distinguishes cancellation from connection failure via TranscriptionConnectionCancelledError. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Caller as index.ts (startRecording)
  participant TS as TranscriptionService
  participant WS as WebSocket
  participant Server as Transcription Server

  Caller->>TS: connect()
  activate TS
  TS->>WS: new WebSocket(serverUrl)
  WS->>Server: TCP connect
  Server-->>WS: open
  WS->>TS: 'open' event
  TS->>Server: sendStartFrame()
  Note over TS: cancelPendingConnect set,<br/>connect() still pending

  alt Happy Path
    Server-->>WS: "{frame:'control', type:'ready'}"
    WS->>TS: 'message' event
    TS->>TS: "handleMessage() → didReceiveReady=true, isReady=true"
    TS-->>Caller: resolve()
    deactivate TS
    Caller->>Server: sendAudioBuffer() (audio flows)
  else Stop during readiness window
    Caller->>TS: stop()
    TS->>TS: cancelPendingConnect() → reject(TranscriptionConnectionCancelledError)
    TS->>Server: sendStopFrame()
    TS-->>Caller: reject(TranscriptionConnectionCancelledError)
    Note over Caller: Caught, silently returns
    Server-->>WS: close
    WS->>TS: 'close' event → onCloseCallback() cleanup
  else Connection error before ready
    Server-->>WS: error / close
    WS->>TS: 'error' or 'close' event
    TS-->>Caller: reject(Error)
    Note over Caller: Caught, logs error, calls stopRecording()
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Caller as index.ts (startRecording)
  participant TS as TranscriptionService
  participant WS as WebSocket
  participant Server as Transcription Server

  Caller->>TS: connect()
  activate TS
  TS->>WS: new WebSocket(serverUrl)
  WS->>Server: TCP connect
  Server-->>WS: open
  WS->>TS: 'open' event
  TS->>Server: sendStartFrame()
  Note over TS: cancelPendingConnect set,<br/>connect() still pending

  alt Happy Path
    Server-->>WS: "{frame:'control', type:'ready'}"
    WS->>TS: 'message' event
    TS->>TS: "handleMessage() → didReceiveReady=true, isReady=true"
    TS-->>Caller: resolve()
    deactivate TS
    Caller->>Server: sendAudioBuffer() (audio flows)
  else Stop during readiness window
    Caller->>TS: stop()
    TS->>TS: cancelPendingConnect() → reject(TranscriptionConnectionCancelledError)
    TS->>Server: sendStopFrame()
    TS-->>Caller: reject(TranscriptionConnectionCancelledError)
    Note over Caller: Caught, silently returns
    Server-->>WS: close
    WS->>TS: 'close' event → onCloseCallback() cleanup
  else Connection error before ready
    Server-->>WS: error / close
    WS->>TS: 'error' or 'close' event
    TS-->>Caller: reject(Error)
    Note over Caller: Caught, logs error, calls stopRecording()
  end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/src/main/services/transcription.ts`, line 126-150 ([link](https://github.com/burntcookiedough/murmur/blob/7d866f341685268a1b68bd7255e03368c0bea72b/app/src/main/services/transcription.ts#L126-L150)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`stop()` during the open-to-ready window rejects `connect()` rather than tearing down cleanly**

   Before this PR, `connect()` resolved the promise in the `open` handler, so by the time any external caller could observe the connection and call `stop()`, the promise was already settled. The PR extends the pending window to include the time between socket-open and server-ready. During that window, `ws.readyState` is `OPEN` and `connectSettled` is still `false`.

   If `stop()` is called now (e.g., the user presses the stop hotkey before the server sends `ready`), the method sends the stop frame to the server, the server closes the connection, the `close` handler fires with `connectSettled === false`, and `connect()` rejects with `"WebSocket closed before connection was ready"`. The old `stopRequested` flag was the mechanism to defer that stop until after resolve; removing it leaves this window unguarded.

   Concrete failure: user starts a transcription session, the server is slow to send `ready`, the user presses stop — the caller's `catch` branch fires and may show an error to the user instead of a clean teardown.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22burntcookiedough%2Fmurmur%22%20on%20the%20existing%20branch%20%22codex%2Fwait-for-transcription-ready%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fwait-for-transcription-ready%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fsrc%2Fmain%2Fservices%2Ftranscription.ts%0ALine%3A%20126-150%0A%0AComment%3A%0A**%60stop%28%29%60%20during%20the%20open-to-ready%20window%20rejects%20%60connect%28%29%60%20rather%20than%20tearing%20down%20cleanly**%0A%0ABefore%20this%20PR%2C%20%60connect%28%29%60%20resolved%20the%20promise%20in%20the%20%60open%60%20handler%2C%20so%20by%20the%20time%20any%20external%20caller%20could%20observe%20the%20connection%20and%20call%20%60stop%28%29%60%2C%20the%20promise%20was%20already%20settled.%20The%20PR%20extends%20the%20pending%20window%20to%20include%20the%20time%20between%20socket-open%20and%20server-ready.%20During%20that%20window%2C%20%60ws.readyState%60%20is%20%60OPEN%60%20and%20%60connectSettled%60%20is%20still%20%60false%60.%0A%0AIf%20%60stop%28%29%60%20is%20called%20now%20%28e.g.%2C%20the%20user%20presses%20the%20stop%20hotkey%20before%20the%20server%20sends%20%60ready%60%29%2C%20the%20method%20sends%20the%20stop%20frame%20to%20the%20server%2C%20the%20server%20closes%20the%20connection%2C%20the%20%60close%60%20handler%20fires%20with%20%60connectSettled%20%3D%3D%3D%20false%60%2C%20and%20%60connect%28%29%60%20rejects%20with%20%60%22WebSocket%20closed%20before%20connection%20was%20ready%22%60.%20The%20old%20%60stopRequested%60%20flag%20was%20the%20mechanism%20to%20defer%20that%20stop%20until%20after%20resolve%3B%20removing%20it%20leaves%20this%20window%20unguarded.%0A%0AConcrete%20failure%3A%20user%20starts%20a%20transcription%20session%2C%20the%20server%20is%20slow%20to%20send%20%60ready%60%2C%20the%20user%20presses%20stop%20%E2%80%94%20the%20caller's%20%60catch%60%20branch%20fires%20and%20may%20show%20an%20error%20to%20the%20user%20instead%20of%20a%20clean%20teardown.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=burntcookiedough%2Fmurmur&pr=9&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Handle stops before transcription readin..."](https://github.com/burntcookiedough/murmur/commit/f5e7d3da97c1ae83cd2cdcbc7bbbf3913a94951b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44556164)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription connection handling when recording is stopped during connection setup.
  * Prevented misleading connection errors and UI error states after cancellation.
  * Prevented audio from being sent before the transcription service signals readiness.
  * Ensured readiness signals received after stopping do not restart connection state.

* **Tests**
  * Added coverage for readiness sequencing, cancellation behavior, stop messaging, and socket cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->