### PR TITLE
Cancel stale microphone startup

### DIFF
--- a/app/src/renderer/overlay/audio-capture.ts
+++ b/app/src/renderer/overlay/audio-capture.ts
@@ -28,6 +28,8 @@ export class AudioCapture {
   private workletNode: AudioWorkletNode | null = null;
   private sequenceNumber = 0;
   private isCapturing = false;
+  private isStarting = false;
+  private startGeneration = 0;
 
   private onAudioData: ((buffer: ArrayBuffer) => void) | null = null;
   private onLevels: ((levels: number[]) => void) | null = null;
@@ -46,7 +48,10 @@ export class AudioCapture {
     onLevels: (levels: number[]) => void,
     options?: AudioCaptureOptions
   ): Promise<void> {
-    if (this.isCapturing) return;
+    if (this.isCapturing || this.isStarting) return;
+
+    const generation = ++this.startGeneration;
+    this.isStarting = true;
 
     this.options = { ...DEFAULTS, ...options };
     this.onAudioData = onAudioData;
@@ -70,13 +75,19 @@ export class AudioCapture {
         audioConstraints.deviceId = { exact: this.options.deviceId };
       }
 
-      this.stream = await navigator.mediaDevices.getUserMedia({
+      const stream = await navigator.mediaDevices.getUserMedia({
         audio: audioConstraints,
       });
+      if (generation !== this.startGeneration) {
+        stream.getTracks().forEach(track => track.stop());
+        return;
+      }
+      this.stream = stream;
 
-      this.audioContext = new AudioContext({
+      const audioContext = new AudioContext({
         sampleRate: TARGET_SAMPLE_RATE,
       });
+      this.audioContext = audioContext;
 
       // Use a Blob URL for the worklet to avoid Vite inlining raw TypeScript
       // as a data: URL (which AudioWorklet can't execute). Blob URLs work
@@ -95,16 +106,26 @@ registerProcessor('audio-processor', AudioProcessor);
 `;
       const blob = new Blob([workletCode], { type: 'application/javascript' });
       const workletUrl = URL.createObjectURL(blob);
-      await this.audioContext.audioWorklet.addModule(workletUrl);
-      URL.revokeObjectURL(workletUrl);
+      try {
+        await audioContext.audioWorklet.addModule(workletUrl);
+      } finally {
+        URL.revokeObjectURL(workletUrl);
+      }
+      if (generation !== this.startGeneration) {
+        if (this.audioContext === audioContext) this.audioContext = null;
+        if (this.stream === stream) this.stream = null;
+        void audioContext.close().catch(() => undefined);
+        stream.getTracks().forEach(track => track.stop());
+        return;
+      }
 
-      this.sourceNode = this.audioContext.createMediaStreamSource(this.stream);
+      this.sourceNode = audioContext.createMediaStreamSource(stream);
 
-      this.analyserNode = this.audioContext.createAnalyser();
+      this.analyserNode = audioContext.createAnalyser();
       this.analyserNode.fftSize = 256;
       this.analyserNode.smoothingTimeConstant = 0.5;
 
-      this.workletNode = new AudioWorkletNode(this.audioContext, 'audio-processor');
+      this.workletNode = new AudioWorkletNode(audioContext, 'audio-processor');
       this.workletNode.port.onmessage = (event) => {
         if (!this.isCapturing) return;
         const { audioData } = event.data;
@@ -119,13 +140,20 @@ registerProcessor('audio-processor', AudioProcessor);
       this.isCapturing = true;
       this.startVisualizationLoop();
     } catch (error) {
+      if (generation !== this.startGeneration) return;
       console.error('Failed to start audio capture:', error);
       this.stop();
       throw error;
+    } finally {
+      if (generation === this.startGeneration) {
+        this.isStarting = false;
+      }
     }
   }
 
   stop(): void {
+    this.startGeneration += 1;
+    this.isStarting = false;
     this.isCapturing = false;
 
     if (this.animationFrame) {

--- a/app/src/renderer/overlay/audio-capture.ts
+++ b/app/src/renderer/overlay/audio-capture.ts
@@ -79,7 +79,7 @@ export class AudioCapture {
         audio: audioConstraints,
       });
       if (generation !== this.startGeneration) {
-        stream.getTracks().forEach(track => track.stop());
+        this.disposeMedia(stream, null);
         return;
       }
       this.stream = stream;
@@ -114,8 +114,7 @@ registerProcessor('audio-processor', AudioProcessor);
       if (generation !== this.startGeneration) {
         if (this.audioContext === audioContext) this.audioContext = null;
         if (this.stream === stream) this.stream = null;
-        void audioContext.close().catch(() => undefined);
-        stream.getTracks().forEach(track => track.stop());
+        this.disposeMedia(stream, audioContext);
         return;
       }
 
@@ -176,18 +175,19 @@ registerProcessor('audio-processor', AudioProcessor);
       this.sourceNode = null;
     }
 
-    if (this.audioContext) {
-      this.audioContext.close();
-      this.audioContext = null;
-    }
-
-    if (this.stream) {
-      this.stream.getTracks().forEach(track => track.stop());
-      this.stream = null;
-    }
+    this.disposeMedia(this.stream, this.audioContext);
+    this.audioContext = null;
+    this.stream = null;
 
     this.onAudioData = null;
     this.onLevels = null;
+  }
+
+  private disposeMedia(stream: MediaStream | null, audioContext: AudioContext | null): void {
+    if (audioContext) {
+      void audioContext.close().catch(() => undefined);
+    }
+    stream?.getTracks().forEach(track => track.stop());
   }
 
   private startVisualizationLoop(): void {

--- a/app/tests/audio-capture-cancellation.test.ts
+++ b/app/tests/audio-capture-cancellation.test.ts
@@ -27,8 +27,9 @@ describe('AudioCapture startup cancellation', () => {
     const pendingStream = fakeStream();
     const activeStream = fakeStream();
     const firstAcquisition = deferred<MediaStream>();
+    let getUserMediaCallCount = 0;
     const getUserMedia = mock(() =>
-      getUserMedia.mock.calls.length === 1
+      ++getUserMediaCallCount === 1
         ? firstAcquisition.promise
         : Promise.resolve(activeStream.stream)
     );

--- a/app/tests/audio-capture-cancellation.test.ts
+++ b/app/tests/audio-capture-cancellation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { AudioCapture } from '../src/renderer/overlay/audio-capture';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function fakeStream() {
+  const stop = mock(() => undefined);
+  return {
+    stream: { getTracks: () => [{ stop }] } as unknown as MediaStream,
+    stop,
+  };
+}
+
+describe('AudioCapture startup cancellation', () => {
+  test('discards a stopped pending acquisition and allows the next start', async () => {
+    const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+    const originalAudioContext = Object.getOwnPropertyDescriptor(globalThis, 'AudioContext');
+    const originalAudioWorkletNode = Object.getOwnPropertyDescriptor(globalThis, 'AudioWorkletNode');
+    const originalRequestAnimationFrame = Object.getOwnPropertyDescriptor(globalThis, 'requestAnimationFrame');
+    const originalCancelAnimationFrame = Object.getOwnPropertyDescriptor(globalThis, 'cancelAnimationFrame');
+    const pendingStream = fakeStream();
+    const activeStream = fakeStream();
+    const firstAcquisition = deferred<MediaStream>();
+    const getUserMedia = mock(() =>
+      getUserMedia.mock.calls.length === 1
+        ? firstAcquisition.promise
+        : Promise.resolve(activeStream.stream)
+    );
+
+    class FakeAudioContext {
+      static created = 0;
+      audioWorklet = { addModule: async () => undefined };
+
+      constructor() {
+        FakeAudioContext.created += 1;
+      }
+
+      createMediaStreamSource() {
+        return { connect: () => undefined, disconnect: () => undefined };
+      }
+
+      createAnalyser() {
+        return {
+          fftSize: 0,
+          smoothingTimeConstant: 0,
+          frequencyBinCount: 128,
+          getByteTimeDomainData: () => undefined,
+          disconnect: () => undefined,
+        };
+      }
+
+      async close() {}
+    }
+
+    class FakeAudioWorkletNode {
+      static latest: FakeAudioWorkletNode | null = null;
+      port = { onmessage: null as ((event: MessageEvent) => void) | null };
+
+      constructor() {
+        FakeAudioWorkletNode.latest = this;
+      }
+
+      disconnect() {}
+    }
+
+    Object.defineProperties(globalThis, {
+      navigator: {
+        configurable: true,
+        value: { mediaDevices: { getUserMedia } },
+      },
+      AudioContext: { configurable: true, value: FakeAudioContext },
+      AudioWorkletNode: { configurable: true, value: FakeAudioWorkletNode },
+      requestAnimationFrame: { configurable: true, value: () => 1 },
+      cancelAnimationFrame: { configurable: true, value: () => undefined },
+    });
+
+    const capture = new AudioCapture();
+    const audioFrames: ArrayBuffer[] = [];
+
+    try {
+      const stoppedStart = capture.start(
+        (frame) => audioFrames.push(frame),
+        () => undefined
+      );
+      capture.stop();
+      firstAcquisition.resolve(pendingStream.stream);
+      await stoppedStart;
+
+      expect(pendingStream.stop).toHaveBeenCalledTimes(1);
+      expect(FakeAudioContext.created).toBe(0);
+
+      await capture.start(
+        (frame) => audioFrames.push(frame),
+        () => undefined
+      );
+      const worklet = FakeAudioWorkletNode.latest;
+      expect(worklet).not.toBeNull();
+      worklet?.port.onmessage?.({
+        data: { audioData: new Float32Array([0.5]) },
+      } as MessageEvent);
+
+      expect(audioFrames).toHaveLength(1);
+      capture.stop();
+      expect(activeStream.stop).toHaveBeenCalledTimes(1);
+    } finally {
+      capture.stop();
+      for (const [name, descriptor] of [
+        ['navigator', originalNavigator],
+        ['AudioContext', originalAudioContext],
+        ['AudioWorkletNode', originalAudioWorkletNode],
+        ['requestAnimationFrame', originalRequestAnimationFrame],
+        ['cancelAnimationFrame', originalCancelAnimationFrame],
+      ] as const) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else delete (globalThis as Record<string, unknown>)[name];
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- invalidate pending microphone startup when recording stops
- dispose a late media stream instead of allowing the stopped request to reactivate capture
- allow the next Fast or Long Dictation start to proceed cleanly
- always revoke the temporary AudioWorklet URL
- add one focused delayed-getUserMedia regression test with a successful following start

## Why
Current trunk only marks capture active after asynchronous getUserMedia and AudioWorklet setup. A stop during that window cannot clean resources that have not arrived yet, so the stale request can finish after stop and collide with the next session. The regression test reproduces that control-flow defect without a physical microphone.

## Scope
Renderer microphone startup lifecycle only. No WebSocket, server, VAD, Whisper, model, UI, device-selection, or logging changes.

## Validation
- focused regression test failed before the change and passes after it
- 64 app tests passed
- main and renderer TypeScript checks passed
- production app build passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping audio-capture startups by invalidating in-flight initialization and blocking concurrent starts.
  * Improved cleanup when initialization is interrupted (including revoking worklet URLs, stopping tracks, and closing/discarding audio contexts).
  * Enhanced reliability of stop behavior by cancelling pending startup steps and ensuring resources are released.
* **Tests**
  * Added coverage for start cancellation before media acquisition completes, successful restart, receipt of audio-worklet messages, and proper stopping of the active stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition in the microphone startup lifecycle where a `stop()` during the async `getUserMedia`/`addModule` window could not clean resources that hadn't arrived yet, allowing the stale request to complete and collide with the next session. It introduces a `startGeneration` counter and an `isStarting` flag to invalidate and clean up in-flight startup operations.

- `stop()` now increments `startGeneration` and clears `isStarting`; generation checks after each `await` in `start()` detect staleness and dispose resources (stream, AudioContext) via local-variable references, preventing double-ownership with any concurrent session.
- The worklet Blob URL is now revoked inside a `finally` block, guaranteeing cleanup even when `addModule` throws.
- A regression test uses a deferred-promise mock to hold the first `getUserMedia` open, calls `stop()` mid-flight, resolves the deferred, and verifies the stale stream is disposed, no `AudioContext` is created, and the following start completes cleanly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is tightly scoped to the microphone startup lifecycle with no cross-cutting side effects.

The generation-counter approach is sound: every async yield point is bracketed by a generation check, double-disposal of stream/AudioContext is harmless because AudioContext.close() is idempotent and track stop() is a no-op on already-stopped tracks, isStarting lifecycle is correctly maintained across all paths, and the regression test faithfully reproduces the original defect.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/renderer/overlay/audio-capture.ts | Adds generation-based startup cancellation: `isStarting` flag blocks concurrent starts; `startGeneration` counter invalidates in-flight async operations when `stop()` is called. Resources (stream, AudioContext) are disposed via local variables when a stale path is detected, and the worklet URL is now always revoked in a `finally` block. |
| app/tests/audio-capture-cancellation.test.ts | New focused regression test that reproduces the stale-getUserMedia control-flow defect without a physical microphone. Uses a deferred promise to hold the first acquisition open, calls stop() mid-flight, then verifies the stale stream is disposed, no AudioContext is created, and a subsequent clean start succeeds end-to-end. |

<sub>Reviews (3): Last reviewed commit: ["Unify audio capture cleanup"](https://github.com/burntcookiedough/murmur/commit/c9c3c0a4afe8f39b63c8aa0ca5aac7d2bb90b80d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44556162)</sub>

<!-- /greptile_comment -->