### PR TITLE
Prepare v0.6.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/v0.6.2-orange?style=flat-square" alt="v0.6.2">
+  <img src="https://img.shields.io/badge/v0.6.3-orange?style=flat-square" alt="v0.6.3">
 </p>
 
 <!-- TODO: add a demo gif here once one exists -->

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$ExpectedVersion = "0.6.0",
+    [string]$ExpectedVersion = "0.6.3",
     [string]$InstallerDir = "E:\MurmurRelease\release-prep\full-nsis-web\nsis-web",
     [string]$InstallDir = "E:\MurmurRelease\release-prep\smoke-install\Murmur",
     [string]$BaseBranch = "trunk",

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -14,7 +14,9 @@ ROOT = Path(__file__).resolve().parents[1]
 APP_PACKAGE = ROOT / "app" / "package.json"
 SERVER_PYPROJECT = ROOT / "server" / "pyproject.toml"
 SERVER_VERSION_FILE = ROOT / "server" / "src" / "version.py"
+SERVER_UV_LOCK = ROOT / "server" / "uv.lock"
 README_FILE = ROOT / "README.md"
+RELEASE_VERIFY_FILE = ROOT / "scripts" / "release-verify.ps1"
 
 SEMVER_RE = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
@@ -26,6 +28,13 @@ SERVER_VERSION_RE = re.compile(r'^SERVER_VERSION\s*=\s*"([^"]+)"\s*$', re.MULTIL
 PYPROJECT_VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
 README_BADGE_RE = re.compile(
     r'(https://img\.shields\.io/badge/v)(.+?)(-orange\?style=flat-square)'
+)
+UV_LOCK_MURMUR_VERSION_RE = re.compile(
+    r'(\[\[package\]\]\s+name\s*=\s*"murmur"\s+version\s*=\s*")([^"]+)(")',
+    re.MULTILINE,
+)
+RELEASE_VERIFY_VERSION_RE = re.compile(
+    r'(\[string\]\$ExpectedVersion\s*=\s*")([^"]+)(")'
 )
 
 
@@ -70,12 +79,30 @@ def read_readme_version() -> str:
     return match.group(2)
 
 
+def read_server_uv_lock_version() -> str:
+    content = SERVER_UV_LOCK.read_text(encoding="utf-8")
+    match = UV_LOCK_MURMUR_VERSION_RE.search(content)
+    if not match:
+        raise ValueError(f"Could not find Murmur package version in {SERVER_UV_LOCK}")
+    return match.group(2)
+
+
+def read_release_verify_version() -> str:
+    content = RELEASE_VERIFY_FILE.read_text(encoding="utf-8")
+    match = RELEASE_VERIFY_VERSION_RE.search(content)
+    if not match:
+        raise ValueError(f"Could not find ExpectedVersion in {RELEASE_VERIFY_FILE}")
+    return match.group(2)
+
+
 def collect_versions() -> dict[str, str]:
     return {
         "app/package.json": read_app_version(),
         "server/pyproject.toml": read_server_pyproject_version(),
         "server/src/version.py": read_server_source_version(),
+        "server/uv.lock": read_server_uv_lock_version(),
         "README.md": read_readme_version(),
+        "scripts/release-verify.ps1": read_release_verify_version(),
     }
 
 
@@ -125,6 +152,26 @@ def write_readme_version(version: str) -> None:
     README_FILE.write_text(updated, encoding="utf-8")
 
 
+def write_server_uv_lock_version(version: str) -> None:
+    content = SERVER_UV_LOCK.read_text(encoding="utf-8")
+    updated, count = UV_LOCK_MURMUR_VERSION_RE.subn(
+        lambda match: f'{match.group(1)}{version}{match.group(3)}', content, count=1
+    )
+    if count != 1:
+        raise ValueError(f"Could not update Murmur package version in {SERVER_UV_LOCK}")
+    SERVER_UV_LOCK.write_text(updated, encoding="utf-8")
+
+
+def write_release_verify_version(version: str) -> None:
+    content = RELEASE_VERIFY_FILE.read_text(encoding="utf-8")
+    updated, count = RELEASE_VERIFY_VERSION_RE.subn(
+        lambda match: f'{match.group(1)}{version}{match.group(3)}', content, count=1
+    )
+    if count != 1:
+        raise ValueError(f"Could not update ExpectedVersion in {RELEASE_VERIFY_FILE}")
+    RELEASE_VERIFY_FILE.write_text(updated, encoding="utf-8")
+
+
 def check_versions(expected_tag: str | None = None) -> int:
     versions = collect_versions()
     unique_versions = set(versions.values())
@@ -163,14 +210,23 @@ def bump_version(version: str, dry_run: bool = False) -> int:
 
     if dry_run:
         print(f"Would set version to {version} in:")
-        for path in [APP_PACKAGE, SERVER_PYPROJECT, SERVER_VERSION_FILE, README_FILE]:
+        for path in [
+            APP_PACKAGE,
+            SERVER_PYPROJECT,
+            SERVER_VERSION_FILE,
+            SERVER_UV_LOCK,
+            README_FILE,
+            RELEASE_VERIFY_FILE,
+        ]:
             print(f"  - {path.relative_to(ROOT)}")
         return 0
 
     write_app_version(version)
     write_server_pyproject_version(version)
     write_server_source_version(version)
+    write_server_uv_lock_version(version)
     write_readme_version(version)
+    write_release_verify_version(version)
 
     print(f"Updated version to {version}")
     return 0

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -30,8 +30,7 @@ README_BADGE_RE = re.compile(
     r'(https://img\.shields\.io/badge/v)(.+?)(-orange\?style=flat-square)'
 )
 UV_LOCK_MURMUR_VERSION_RE = re.compile(
-    r'(\[\[package\]\]\s+name\s*=\s*"murmur"\s+version\s*=\s*")([^"]+)(")',
-    re.MULTILINE,
+    r'(\[\[package\]\]\s+name\s*=\s*"murmur"\s+version\s*=\s*")([^"]+)(")'
 )
 RELEASE_VERIFY_VERSION_RE = re.compile(
     r'(\[string\]\$ExpectedVersion\s*=\s*")([^"]+)(")'

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.6.2"
+version = "0.6.3"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.6.2"
+SERVER_VERSION = "0.6.3"

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -163,7 +163,7 @@ def test_runtime_preparation_script_uses_uv_managed_python() -> None:
     assert 'Join-Path $runtimePath "python.exe"' in contents
 
 
-def test_version_check_includes_readme_badge() -> None:
+def test_version_check_includes_all_release_metadata() -> None:
     version = _load_package_json()["version"]
     completed = subprocess.run(
         [
@@ -180,3 +180,28 @@ def test_version_check_includes_readme_badge() -> None:
     )
     assert completed.returncode == 0, completed.stderr
     assert f"Version check passed: {version}" in completed.stdout
+
+    dry_run = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "version.py"),
+            "bump",
+            version,
+            "--dry-run",
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert dry_run.returncode == 0, dry_run.stderr
+    dry_run_output = dry_run.stdout.replace("\\", "/")
+    for path in (
+        "app/package.json",
+        "server/pyproject.toml",
+        "server/src/version.py",
+        "server/uv.lock",
+        "README.md",
+        "scripts/release-verify.ps1",
+    ):
+        assert path in dry_run_output

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "murmur"
-version = "0.6.0"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- bump Murmur's synchronized release metadata from 0.6.2 to 0.6.3
- include the root `server/uv.lock` package version and `release-verify.ps1` default in `scripts/version.py`
- extend the focused release-config test so every managed version file remains covered

## Accepted release contents
This version publishes the already merged launch-hardening work, including privacy-safe Copy Diagnostics, main-process EPIPE protection, History overflow containment, the dark microphone warning, transcription protocol readiness, and stale microphone-start cancellation.

## Validation
- user accepted private `0.6.3-rc.1` after repeated Fast and Long dictation; Copy Diagnostics worked and the previous microphone error did not recur
- private Windows candidate: 136 server tests and 68 app tests passed
- renderer and main-process TypeScript checks passed
- portable and packaged runtime import checks passed
- isolated packaged server reached healthy/ready at version `0.6.3-rc.1`
- focused final metadata tests: `11 passed`
- `python scripts/version.py check --tag v0.6.3`
- `git diff --check`

## Artifact evidence
The private RC payload was 2,041,268,597 bytes, leaving 58,731,403 bytes (56.01 MiB) below the repository's 2.10 GB safety budget. Final Release Windows must re-check the produced artifact before publication.

## Non-goals
- no model-selection changes
- no package-size architecture rewrite
- no signing changes
- no updater, rebranding, or repository migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README version badge to **0.6.3**.
* **Chores**
  * Bumped application and server versions to **0.6.3** across release metadata and version artifacts.
  * Expanded release verification to include additional maintained version references, keeping them in sync.
* **Tests**
  * Updated version-check coverage to validate all release metadata files and ensure dry-run output includes every expected versioned path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the v0.6.3 release by bumping version strings across all managed files and closing a gap in the version-management tooling — `server/uv.lock` and `scripts/release-verify.ps1` were previously untracked by `scripts/version.py` and are now fully integrated.

- Version bumped from 0.6.2 → 0.6.3 in `app/package.json`, `server/pyproject.toml`, `server/src/version.py`, `README.md`, and `server/uv.lock` (which was stale at 0.6.0); `scripts/release-verify.ps1` default updated from 0.6.0 → 0.6.3.
- `scripts/version.py` gains read/write support for the two newly tracked files, using correctly anchored regex patterns and `subn(..., count=1)` guards.
- `test_release_config.py` extends the existing version test with a `--dry-run` bump assertion that verifies all six managed paths are covered, with cross-platform backslash normalisation.

<h3>Confidence Score: 5/5</h3>

All version strings are consistent at 0.6.3 across every managed file; the new tooling paths are well-guarded and covered by an expanded test.

The change is a mechanical version bump plus additive tooling — no runtime logic is altered, all regex replacements are guarded with match-count assertions, and the extended test exercises every newly tracked file path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/version.py | Adds `server/uv.lock` and `scripts/release-verify.ps1` to the version-management system — both read and write paths look correct; regex patterns properly escape `[` and `]` and use `subn(..., count=1)` to guard against double-replacement. |
| server/tests/test_release_config.py | Extends the existing version-check test to also run a `--dry-run` bump and assert all six managed paths appear in the output; normalises Windows backslashes before the assertions, so the test is cross-platform safe. |
| server/uv.lock | Murmur package entry bumped from 0.6.0 to 0.6.3 — it was two releases behind because uv.lock was not previously tracked by version.py; now brought up to date alongside the other files. |
| scripts/release-verify.ps1 | Default `$ExpectedVersion` updated from 0.6.0 to 0.6.3; now managed by version.py so it will stay in sync automatically on future bumps. |
| app/package.json | Version field bumped from 0.6.2 to 0.6.3; no other changes. |
| server/pyproject.toml | Version field bumped from 0.6.2 to 0.6.3; no other changes. |
| server/src/version.py | `SERVER_VERSION` constant bumped from 0.6.2 to 0.6.3; no other changes. |
| README.md | Version badge updated from v0.6.2 to v0.6.3 in both the `src` URL and the `alt` attribute. |

<sub>Reviews (2): Last reviewed commit: ["Simplify version metadata pattern"](https://github.com/burntcookiedough/murmur/commit/da7c4262c33e54f035a96dc749136fbb0e51d3ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44730677)</sub>

<!-- /greptile_comment -->