### PR TITLE
Point releases at standalone repository

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dikkadev/murmur.git"
+    "url": "https://github.com/burntcookiedough/eve-windows-dictation.git"
   },
   "main": "dist/main/index.js",
   "type": "module",
@@ -99,7 +99,7 @@
       {
         "provider": "github",
         "owner": "burntcookiedough",
-        "repo": "murmur"
+        "repo": "eve-windows-dictation"
       }
     ]
   }

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -73,7 +73,7 @@ def test_electron_builder_publish_targets_release_repository() -> None:
         {
             "provider": "github",
             "owner": "burntcookiedough",
-            "repo": "murmur",
+            "repo": "eve-windows-dictation",
         }
     ]
 


### PR DESCRIPTION
## Summary
- point package repository metadata at the standalone `eve-windows-dictation` repository
- point electron-builder GitHub publishing at the renamed repository
- update the release-configuration regression expectation

## Safety boundary
- no change to `com.murmur.app`
- no product, executable, installer, package, or user-data rename
- no release or tag publication

## Validation
- `uv run --no-sync pytest tests/test_release_config.py` (11 passed)
- `python scripts/version.py check`
- `git diff --check`