### PR TITLE
Present Eve repository and engineering record

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Eve targets Windows and combines an Electron/Svelte client with a Python transcription service. Keep changes narrow enough to review and verify as one behavior change.
+
+Before contributing:
+
+1. Read [AGENT.md](AGENT.md) and [BUILDING.md](BUILDING.md).
+2. Use Windows PowerShell for Bun, uv, Python, pytest, dependency, and build commands. Do not create Linux dependencies in a Windows worktree.
+3. Preserve `%APPDATA%\murmur`, model caches, History, settings, and existing installer identity unless a migration proposal has been approved separately.
+4. Do not include transcripts, audio, clipboard contents, tokens, private paths, or raw environment dumps in logs, fixtures, screenshots, or bug reports.
+
+## Pull requests
+
+- Start from current `trunk` and explain the user-visible problem or engineering failure.
+- Separate observed behavior from hypotheses.
+- Include focused regression coverage and the exact validation commands you ran.
+- Avoid dependency or lockfile churn unrelated to the change.
+- Treat benchmark results as reproducible measurements: record hardware, operating system, engine and model versions, decoding settings, audio set, sample count, and date.
+- Label future-engine, component-pack, and visual concepts as research until they pass packaged Windows acceptance.
+
+The project does not currently promise review or support response times. A draft pull request is the clearest way to propose a source change while public issue tracking remains closed.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# Notice
+
+Eve contains software derived from the MIT-licensed Murmur project created by Raik Rohde. The original copyright notice and MIT terms are retained in [LICENSE](LICENSE), and the Git history preserves commit authorship.
+
+Subsequent contributors retain authorship of their changes. Repository documentation distinguishes later implementation and release-hardening work from the inherited codebase; it does not claim that those contributors created the original project.
+
+The v0.6.3 Windows artifacts retain the Murmur application and installer identity during the compatibility-preserving transition to Eve.
+
+Third-party libraries, models, and tools remain subject to their respective licenses and notices. This file does not replace those terms or claim that a complete binary-distribution notice audit has been finished. That audit is a release gate for a future Eve-branded distribution.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,25 @@
+# Privacy boundaries
+
+The default packaged configuration performs speech recognition on the user's machine. Microphone audio travels from the Electron renderer through the main process to the packaged Python service over a WebSocket on that machine. Final transcripts and derived History/Insights data are stored locally.
+
+## Network access
+
+Network access is still required in these cases:
+
+- the NSIS web installer downloads the application payload from GitHub Releases;
+- an engine downloads its model files from Hugging Face on first use;
+- a developer or user deliberately configures external-server mode.
+
+External-server mode changes the trust boundary because captured audio is sent to the configured server URL. Users are responsible for the operator and privacy terms of that endpoint.
+
+## Local data
+
+The current v0.6.3 binary uses Electron's Murmur user-data directory, including `%APPDATA%\murmur` on a standard Windows installation. It stores settings and a SQLite transcription History there. Model files use the relevant Hugging Face cache location.
+
+Repository and product naming work does not authorize moving or deleting these locations. A future Eve application-identity migration must preserve History, settings, and model caches, support rollback, and avoid duplicate downloads where practical.
+
+## Diagnostics and contributions
+
+The in-app diagnostics copy feature is designed around an allowlisted summary and excludes logs, paths, History, and transcription text. Users should still review any report before sharing it.
+
+Do not add telemetry or analytics without a separate privacy review, explicit documentation, and user-visible controls. Test fixtures, screenshots, crash reports, and pull requests must not contain private dictated text, audio, clipboard data, tokens, device labels, or unredacted paths.

--- a/README.md
+++ b/README.md
@@ -1,145 +1,83 @@
-<p align="center">
-  <img src="app/resources/icon.png" alt="Murmur" width="100" height="100">
-</p>
+# Eve for Windows
 
-<h1 align="center">Murmur</h1>
+Local dictation for Windows, built as an Electron desktop client with a packaged Python transcription service.
 
-<p align="center">
-  Local voice-to-text for Windows. Hold a key, talk, let go — your words land wherever you're typing.
-</p>
+<img src="https://img.shields.io/badge/v0.6.3-orange?style=flat-square" alt="v0.6.3">
 
-<p align="center">
-  <img src="https://img.shields.io/badge/v0.6.3-orange?style=flat-square" alt="v0.6.3">
-</p>
+> [!IMPORTANT]
+> Eve is the repository and future product identity. The current v0.6.3 download still uses the **Murmur** application and installer, the `com.murmur.app` app ID, and the `%APPDATA%\murmur` data path. Those identifiers are intentionally unchanged so existing History, settings, and model caches remain accessible while a compatible migration is designed.
 
-<!-- TODO: add a demo gif here once one exists -->
+## What works today
 
----
+- Global hotkeys for Fast and Long Dictation
+- A click-through recording overlay with microphone levels and partial text
+- Local transcription through faster-whisper or Nemotron
+- Automatic clipboard copy and paste, with optional clipboard restoration
+- Searchable local History and aggregate Insights
+- Packaged server lifecycle controls and privacy-bounded diagnostics
+- CPU fallback and CUDA diagnostics for supported NVIDIA systems
 
-Everything runs on your machine. No cloud, no account, no sending audio anywhere. Murmur sits in your system tray and gives you a global hotkey that turns speech into text in any app — your editor, your browser, a chat window, whatever has focus.
-
-## How It Works
+The desktop client sends 16 kHz mono PCM audio through its main process to the packaged Python service over a WebSocket on the same machine. The service returns partial and final text, and History is stored in a local SQLite database.
 
 ```mermaid
-graph LR
-    A["🎤 Hold hotkey"] --> B["🎙️ Mic capture"]
-    B --> C["📡 WebSocket"]
-    C --> D["🧠 Transcription engine"]
-    D --> E["💬 Partials stream to overlay"]
-    E --> F["📋 Release → clipboard + paste"]
+flowchart LR
+    Mic["Microphone"] --> Capture["Electron audio capture"]
+    Capture --> Socket["Local WebSocket protocol"]
+    Socket --> ASR["Packaged Python ASR service"]
+    ASR --> Result["Overlay, clipboard, and local History"]
 ```
 
-Audio flows from your mic through an [AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet), gets sent as 16-bit PCM over a local WebSocket, and hits the transcription engine running on your GPU (or CPU). Partials stream back in real-time so you see words forming as you speak. When you release the key, the final transcription lands in your clipboard and gets pasted automatically.
+Models are not embedded in the installer payload. The selected engine downloads its model from Hugging Face on first use. The optional external-server mode changes the data boundary: audio is sent to the server URL configured by the user rather than the packaged local service.
 
-The overlay is a transparent, always-on-top, click-through window — it shows up when you're recording and gets out of the way when you're not.
+## Current release
 
-- Windows 10/11
-- Bun
-- Python 3.11+
-- uv
-- just
-- CUDA-capable GPU recommended (driver 525+; CPU is supported but slower)
+[Download v0.6.3](https://github.com/burntcookiedough/eve-windows-dictation/releases/tag/v0.6.3). The release is currently unsigned and may trigger Windows reputation warnings.
 
-- **Hold-to-talk or toggle mode** — bind any key as your global hotkey
-- **Transparent overlay** — live waveform and partial transcription while you speak
-- **Two engines, hot-swappable** — switch between them without restarting
-- **Auto-paste** — transcribed text goes straight to your clipboard and into the active field
-- **Post-processing** — auto-append periods, spaces, or both
-- **Searchable history** — every transcription saved locally in SQLite
-- **In-app server controls** — start, stop, restart, stream logs, all from the settings panel
-- **External server mode** — point Murmur at a remote server if you want
+| Asset | Bytes | SHA-256 |
+|---|---:|---|
+| `Murmur.Web.Setup.0.6.3.exe` | 887,561 | `366088a4266f54ea7c39e2e7fd1fc7177cac46bf8a4b3f43d58a6d025e15cd33` |
+| `murmur-0.6.3-x64.nsis.7z` | 2,034,188,308 | `0b557fde05853da1f7c0aef77cecbad1faf8c5fc9314457ea45119d3a69f4fbd` |
+| `latest.yml` | 564 | `b211cdb0322a0f6da01eee77921f6c6961735de59d4ffd8cacc31d9a3f7395a9` |
 
-## Engines
+The small web installer downloads the large application payload during installation. Internet access is also required when an engine fetches its model for the first time.
 
-Murmur ships with two transcription engines. Both run locally and can be swapped at runtime from the settings panel.
+## Engineering record
 
-| | Nemotron | Whisper |
-|---|---|---|
-| **Model** | `nvidia/nemotron-speech-streaming-en-0.6b` | `large-v3-turbo` (via faster-whisper) |
-| **Best for** | English dictation, low latency | Multilingual, accuracy |
-| **Streaming** | Native streaming architecture | Chunked re-transcription |
-| **Extras** | — | Hotword boosting |
-| **VRAM** | ~1.5 GB | ~3 GB |
+This repository preserves the original commit authorship and the later work that made the Windows release path dependable. The work added through v0.6.3 includes:
 
-Nemotron is the default. It's a 0.6B parameter model built for streaming — partials come back fast and the final result is usually identical to the last partial. Whisper is the fallback for non-English languages or when you need hotword support to nail domain-specific terms.
+- portable Python discovery and packaged-runtime validation;
+- constrained release publication and corrected NSIS-web download targeting;
+- visible model-download progress and estimated time remaining;
+- broken-pipe containment, protocol-readiness gating, and stale microphone-start cancellation;
+- privacy-bounded diagnostics and History layout corrections;
+- repeatable release checks with exact artifact sizes and digests.
 
-## Quick Start
+The [v0.6.3 engineering case study](docs/engineering/v0.6.3-release-case-study.md) maps these claims to pull requests, commits, tests, and release artifacts. Planned component downloads and new ASR profiles are documented in the [roadmap](ROADMAP.md) as research, not shipped functionality.
 
-You need Windows 10/11 with [Bun](https://bun.sh), [Python 3.11+](https://python.org), [uv](https://docs.astral.sh/uv/), and [just](https://github.com/casey/just). A CUDA GPU is recommended but not required.
+## Development
+
+Development and packaging target Windows. If the repository is opened from WSL, run Bun, uv, Python, pytest, and packaging commands through Windows PowerShell so platform-specific environments are not replaced with Linux binaries.
 
 ```powershell
 # Server
 cd server
-uv sync --extra all    # or: --extra nemotron / --extra whisper
-just start
+uv sync --extra whisper --group dev
+uv run pytest
 
-# App (separate terminal)
+# Desktop app, in a separate PowerShell session
 cd app
 bun install
 bun run dev
 ```
 
-The app auto-detects a running server in dev mode. In production, it manages the server lifecycle itself.
+Use `uv sync --extra all` when preparing a release runtime with both shipped engines. See [BUILDING.md](BUILDING.md) for release and packaging details, [docs/protocol.md](docs/protocol.md) for the WebSocket protocol, and [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-> [!NOTE]
-> If you develop from WSL, run all `uv`/`bun`/`just` commands through PowerShell — not Linux. Running them from WSL replaces Windows binaries with Linux ones and breaks everything. See [BUILDING.md](BUILDING.md).
+## Privacy and support
 
-## Build
+The default packaged path keeps captured audio and transcription on the local machine. Network access is used to download the installer payload and first-use model files. External-server mode is an explicit exception to local processing. See [PRIVACY.md](PRIVACY.md) for the data boundaries and [SUPPORT.md](SUPPORT.md) for support expectations.
 
-```powershell
-cd server && uv sync --extra all
-..\scripts\prepare-python-runtime.ps1 -ServerDir .
-cd ../app && bun run package:win
-```
+Security reports should follow [SECURITY.md](SECURITY.md) and should never include private audio, transcript text, clipboard contents, access tokens, or unredacted local paths.
 
-`bun run package:win` produces a small nsis-web installer stub plus payloads (for example `.7z`, `.yml`, `.blockmap`) in `app/release/`. End users need internet to install (payload download) and to fetch models on first run.
+## License and provenance
 
-Root-level helper:
-
-```bash
-just build
-```
-
-See `BUILDING.md` for full release and troubleshooting details.
-
-For the exact Windows 11 + RTX 3060 local CUDA dictation setup, including model cache paths, settings JSON, verification commands, and expected latency/VRAM numbers, see **[docs/windows-local-cuda-dictation.md](docs/windows-local-cuda-dictation.md)**.
-
-## Configuration
-
-App settings (hotkey, audio device, engine, post-processing, auto-paste) are configured through the UI.
-
-Server settings use `MURMUR_`-prefixed environment variables and can also be changed at runtime from the app. Packaged builds persist them under the Electron user-data directory so upgrades do not overwrite them.
-
-<details>
-<summary><strong>Server environment variables</strong></summary>
-
-| Variable | Default | Description |
-|---|---|---|
-| `MURMUR_HOST` | `0.0.0.0` | Bind host |
-| `MURMUR_PORT` | `51717` | Bind port |
-| `MURMUR_ENGINE` | `nemotron` | Default engine (`nemotron` / `whisper`) |
-| `MURMUR_NEMOTRON_MODEL` | `nvidia/nemotron-speech-streaming-en-0.6b` | Nemotron model |
-| `MURMUR_NEMOTRON_DEVICE` | `auto` | Device (`auto`/`cuda`/`cpu`) |
-| `MURMUR_WHISPER_MODEL` | `large-v3-turbo` | Whisper model |
-| `MURMUR_WHISPER_DEVICE` | `auto` | Device (`auto`/`cuda`/`cpu`) |
-| `MURMUR_WHISPER_COMPUTE_TYPE` | `auto` | Whisper precision mode |
-| `MURMUR_MAX_SESSIONS` | `10` | Concurrent session cap |
-| `MURMUR_LOG_LEVEL` | `INFO` | `DEBUG`/`INFO`/`WARNING`/`ERROR` |
-
-</details>
-
-## Project Structure
-
-```
-app/      Electron desktop app (Svelte 5, TypeScript, Tailwind v4)
-server/   Transcription server (FastAPI, faster-whisper, NeMo)
-docs/     Protocol spec and technical docs
-```
-
-## Protocol
-
-The app and server communicate over a custom WebSocket protocol on port 51717 — binary frames for audio, JSON frames for control and text. Full spec: **[docs/protocol.md](docs/protocol.md)**
-
-## License
-
-[MIT](LICENSE)
+The source is available under the [MIT License](LICENSE). Eve contains software derived from the MIT-licensed Murmur project. Original copyright notices and commit authorship are preserved; later implementation and release-hardening work is identified separately. See [NOTICE.md](NOTICE.md).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Models are not embedded in the installer payload. The selected engine downloads 
 | `murmur-0.6.3-x64.nsis.7z` | 2,034,188,308 | `0b557fde05853da1f7c0aef77cecbad1faf8c5fc9314457ea45119d3a69f4fbd` |
 | `latest.yml` | 564 | `b211cdb0322a0f6da01eee77921f6c6961735de59d4ffd8cacc31d9a3f7395a9` |
 
-The small web installer downloads the large application payload during installation. Internet access is also required when an engine fetches its model for the first time.
+The small `nsis-web` installer downloads the large application payload during installation. Internet access is also required when an engine fetches its model for the first time.
 
 ## Engineering record
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,38 @@
+# Roadmap
+
+This roadmap separates shipped behavior from design and research. It is not a release-date promise.
+
+## Current baseline
+
+v0.6.3 is the production baseline. It retains the Murmur application identity and ships a packaged Python runtime with faster-whisper/CTranslate2 and NeMo/PyTorch/CUDA dependency stacks. Models download separately on first use.
+
+The repository is now standalone under `burntcookiedough/eve-windows-dictation`, and its release configuration targets that repository. Existing app IDs, installer identity, update behavior, and user-data paths remain unchanged.
+
+## Next: application-identity migration design
+
+Before an Eve-branded binary is produced:
+
+- complete manual trademark checks in relevant software classes and markets;
+- inventory every app ID, executable, installer, protocol, package, update, and data-path identifier;
+- define migration and rollback for History, settings, model caches, startup registration, and installed versions;
+- test clean install, upgrade, downgrade/rollback, repair, and uninstall without deleting user data;
+- complete the binary-distribution third-party notice audit.
+
+## Later: visual system
+
+Design Eve's icon, typography, color, windows, overlay, onboarding, and public screenshots after identity and migration constraints are fixed. Do not reskin the existing product and treat that as an identity migration.
+
+## Later: component-based distribution
+
+The measured installer payload is dominated by portable Python and two independent ASR runtime stacks. The planned direction is a thin core client with separately versioned engine packs, while model weights remain separate first-use downloads.
+
+Required properties include resumable downloads, signed or checksum-verified manifests, exact size and disk preflight, atomic staging and activation, compatibility metadata, rollback, repair, offline behavior, and uninstall rules that preserve user data and model caches.
+
+## Later: profile-based ASR experiments
+
+- Fast Dictation: evaluate Nemotron 3.5 ASR Streaming 0.6B through an isolated Transformers/PyTorch pack on native Windows.
+- Long Dictation: evaluate Qwen3-ASR 0.6B through Transformers with deterministic offline decoding.
+- Hinglish: evaluate the Srota Qwen3-ASR fine-tune as an experimental opt-in.
+- Production fallback: retain faster-whisper until challengers pass accuracy, latency, memory, packaging, recovery, and component lifecycle gates on target Windows hardware.
+
+Do not ship vLLM inside the native Windows client. Benchmark raw ASR output separately from optional cleanup, and preserve model downloads as a different lifecycle from runtime/engine packs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security policy
+
+The supported public binary is the latest release listed on GitHub. Older builds may not receive fixes.
+
+Do not publish exploit details, secrets, private audio, transcript text, clipboard contents, tokens, or unredacted local paths. Use GitHub's private **Report a vulnerability** option if it is available for this repository. If it is unavailable, contact the repository owner through the contact method listed on their GitHub profile and share only enough information to arrange a private channel.
+
+A useful report includes the affected version, Windows version, whether the packaged or development build was used, a minimal reproduction, and the security impact. Redact user data from screenshots and diagnostics.
+
+The current Windows release is unsigned. Verify downloads against the SHA-256 digests published by GitHub Releases and repeated in the repository README. Signing remains a separate release-infrastructure decision.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,14 @@
+# Support
+
+Eve is currently maintained as an engineering project, not a staffed support service. There is no guaranteed response time.
+
+Before reporting a problem:
+
+1. Confirm the exact release version and whether the app is using the packaged local service or an external server.
+2. Read [BUILDING.md](BUILDING.md) for development and packaging failures.
+3. Use the app's bounded diagnostics summary where available. Review it before sharing.
+4. Remove transcript text, clipboard contents, device labels, tokens, usernames, and full local paths.
+
+Public issue tracking is currently closed. Source fixes can be proposed with a focused draft pull request. Security-sensitive reports must use the private process in [SECURITY.md](SECURITY.md), not a public pull request.
+
+The v0.6.3 download still installs Murmur and stores application data under the existing Murmur path. Do not rename or move that data manually; the later Eve identity migration will define compatibility and rollback behavior.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This directory keeps only docs that still match the current codebase.
 
 ## Active docs
 
+- `engineering/v0.6.3-release-case-study.md`: evidence-backed account of the Windows packaging and lifecycle work shipped through v0.6.3.
 - `protocol.md`: WebSocket audio/control/text frame specification used by app and server.
 - `benchmark-report.md`: Nemotron vs Whisper benchmark data that informed engine defaults.
 - `vram-aware-engine-selection.md`: VRAM sizing background for engine fallback/recording estimates.

--- a/docs/engineering/v0.6.3-release-case-study.md
+++ b/docs/engineering/v0.6.3-release-case-study.md
@@ -1,0 +1,72 @@
+# Engineering Eve's v0.6.3 Windows baseline
+
+## Scope and ownership
+
+The starting point was an existing MIT-licensed desktop dictation project. The work described here did not create that original application. It took responsibility for the later Windows distribution and lifecycle-hardening path, preserved the original authorship, and shipped the resulting v0.6.3 release.
+
+The public record is the repository's Git history, pull requests, checks, tags, and release assets. The table below maps each claim to that record.
+
+| PR | Shipped work |
+|---:|---|
+| [#1](https://github.com/burntcookiedough/eve-windows-dictation/pull/1) | Prepared the portable Windows v0.6.0 release path. |
+| [#2](https://github.com/burntcookiedough/eve-windows-dictation/pull/2) | Fixed packaged Python runtime validation. |
+| [#3](https://github.com/burntcookiedough/eve-windows-dictation/pull/3) | Restricted release publication to intended installer artifacts. |
+| [#4](https://github.com/burntcookiedough/eve-windows-dictation/pull/4) | Corrected the v0.6.1 web installer's download source. |
+| [#5](https://github.com/burntcookiedough/eve-windows-dictation/pull/5) | Added model-download progress and estimated time remaining. |
+| [#6](https://github.com/burntcookiedough/eve-windows-dictation/pull/6) | Prevented main-process crashes when logger streams fail with `EPIPE`. |
+| [#7](https://github.com/burntcookiedough/eve-windows-dictation/pull/7) | Added a diagnostics-copy path with bounded, allowlisted output. |
+| [#8](https://github.com/burntcookiedough/eve-windows-dictation/pull/8) | Contained long History text and refined microphone warnings. |
+| [#9](https://github.com/burntcookiedough/eve-windows-dictation/pull/9) | Gated recording on transcription-protocol readiness. |
+| [#10](https://github.com/burntcookiedough/eve-windows-dictation/pull/10) | Cancelled stale microphone startup after rapid stop/restart actions. |
+| [#11](https://github.com/burntcookiedough/eve-windows-dictation/pull/11) | Synchronized, validated, and published v0.6.3. |
+
+Repository migration work followed in [#12](https://github.com/burntcookiedough/eve-windows-dictation/pull/12), which points future release publication at the standalone repository without changing the application identity.
+
+## The engineering problem
+
+A desktop transcription app can work in development while failing at the boundaries that define a Windows release: finding portable Python, downloading a model, knowing when the server is ready, cancelling obsolete microphone work, surviving child-process shutdown, publishing the intended assets, and producing diagnostics without exposing dictated text.
+
+The release-hardening work treated those boundaries as one lifecycle:
+
+```mermaid
+flowchart LR
+    Install["NSIS-web install"] --> Runtime["Portable Python runtime"]
+    Runtime --> Model["First-use model download"]
+    Model --> Ready["Protocol ready"]
+    Ready --> Capture["Microphone capture"]
+    Capture --> Final["Final transcript"]
+    Final --> Local["Clipboard and local History"]
+```
+
+The implementation changes remained split into reviewable pull requests. Readiness became an explicit protocol state; pending microphone acquisition became cancellable; expected broken-pipe failures were contained at the logger boundary; and the release workflow verified the packaged runtime before publication.
+
+## Release evidence
+
+The v0.6.3 release was published from merge commit [`fbb114f`](https://github.com/burntcookiedough/eve-windows-dictation/commit/fbb114f43dc61387b3c5b513e8b476405be56ea3). GitHub records these assets:
+
+| Asset | Exact bytes | SHA-256 |
+|---|---:|---|
+| `Murmur.Web.Setup.0.6.3.exe` | 887,561 | `366088a4266f54ea7c39e2e7fd1fc7177cac46bf8a4b3f43d58a6d025e15cd33` |
+| `murmur-0.6.3-x64.nsis.7z` | 2,034,188,308 | `0b557fde05853da1f7c0aef77cecbad1faf8c5fc9314457ea45119d3a69f4fbd` |
+| `latest.yml` | 564 | `b211cdb0322a0f6da01eee77921f6c6961735de59d4ffd8cacc31d9a3f7395a9` |
+
+The release pipeline checks version consistency, runs the app and server test suites, smoke-starts the portable server, verifies imports before and after packaging, enforces an artifact-size safety budget, and uploads only the expected installer artifacts.
+
+## What the evidence does not claim
+
+- Eve is not yet the identity of the installed v0.6.3 application.
+- The Windows binaries are not code-signed.
+- The 2 GB payload has not yet been replaced by component downloads.
+- Nemotron 3.5, Qwen3-ASR, and Srota are research candidates, not shipped profiles.
+- Benchmark results in this repository are workload-specific measurements, not universal model rankings.
+
+The measured package attribution and profile-based ASR comparison inform the [post-release roadmap](../../ROADMAP.md). They remain design work until native-Windows packaging, recovery, privacy, and repeat-start acceptance tests pass.
+
+## Portfolio evidence still to capture
+
+The repository history and release assets are already public evidence. A later portfolio update should add:
+
+- a 60–90 second Windows recording showing installation, first-use model progress, Fast and Long Dictation, History, and the bounded diagnostics summary;
+- screenshots after the Eve visual system is implemented, with transitional Murmur-branded screenshots labelled accurately in the meantime;
+- one microphone/protocol lifecycle diagram and one release-pipeline diagram;
+- benchmark tables only when the hardware, software versions, decoding settings, audio set, sample count, and measurement date accompany the result.


### PR DESCRIPTION
## Summary

- present Eve as the standalone repository and future product identity while clearly labelling v0.6.3 as a Murmur-branded compatibility release
- preserve the MIT license and add a concise provenance notice without making upstream lineage the product narrative
- publish an evidence-backed v0.6.3 case study plus privacy, security, support, contribution, and roadmap boundaries

## Safety boundaries

- no changes to `com.murmur.app`, product or executable names, installer identity, package names, `%APPDATA%\murmur`, model caches, or update behavior
- no code, dependency, workflow, release, tag, or asset changes
- future component packs and ASR profiles remain explicitly labelled as research

## Validation

- `python scripts/version.py check`
- relative Markdown link audit across all added/changed docs
- `git diff --cached --check`
- verified public availability of PR #1-#12 and release v0.6.3 evidence
- confirmed `LICENSE` is unchanged and staged scope is documentation-only