### PR TITLE
Design fresh Eve application identity

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -16,7 +16,7 @@ External-server mode changes the trust boundary because captured audio is sent t
 
 The current v0.6.3 binary uses Electron's Murmur user-data directory, including `%APPDATA%\murmur` on a standard Windows installation. It stores settings and a SQLite transcription History there. Model files use the relevant Hugging Face cache location.
 
-Repository and product naming work does not authorize moving or deleting these locations. A future Eve application-identity migration must preserve History, settings, and model caches, support rollback, and avoid duplicate downloads where practical.
+Repository and product naming work does not authorize moving or deleting these locations. The future Eve application will use a separate fresh profile and will not import Murmur History, settings, hotwords, browser storage, credentials, or external-server configuration. The legacy Murmur directory will remain untouched. Shared third-party model caches are a separate runtime-asset boundary and may be reused without reading Murmur userData.
 
 ## Diagnostics and contributions
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Local dictation for Windows, built as an Electron desktop client with a packaged
 <img src="https://img.shields.io/badge/v0.6.3-orange?style=flat-square" alt="v0.6.3">
 
 > [!IMPORTANT]
-> Eve is the repository and future product identity. The current v0.6.3 download still uses the **Murmur** application and installer, the `com.murmur.app` app ID, and the `%APPDATA%\murmur` data path. Those identifiers are intentionally unchanged so existing History, settings, and model caches remain accessible while a compatible migration is designed.
+> Eve is the repository and future product identity. The current v0.6.3 download still uses the **Murmur** application and installer, the `com.murmur.app` app ID, and the `%APPDATA%\murmur` data path. The later Eve application will start with a separate, fresh data profile; it will not import or delete Murmur History, settings, or other personal state.
 
 ## What works today
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,12 +10,15 @@ The repository is now standalone under `burntcookiedough/eve-windows-dictation`,
 
 ## Next: application-identity migration design
 
+The proposed technical contract is documented in [ADR-001](docs/architecture/adr-001-eve-application-identity-migration.md). Trademark work is currently deferred; it remains separate from the compatibility design.
+
 Before an Eve-branded binary is produced:
 
 - complete manual trademark checks in relevant software classes and markets;
 - inventory every app ID, executable, installer, protocol, package, update, and data-path identifier;
-- define migration and rollback for History, settings, model caches, startup registration, and installed versions;
-- test clean install, upgrade, downgrade/rollback, repair, and uninstall without deleting user data;
+- establish a fresh Eve profile that never imports Murmur History, settings, hotwords, browser storage, credentials, or external-server configuration;
+- preserve the inactive Murmur data directory without reading, moving, or deleting it;
+- test clean install, upgrade, downgrade/rollback, repair, startup registration, and uninstall without deleting either data profile or shared model caches;
 - complete the binary-distribution third-party notice audit.
 
 ## Later: visual system

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Before an Eve-branded binary is produced:
 - complete manual trademark checks in relevant software classes and markets;
 - inventory every app ID, executable, installer, protocol, package, update, and data-path identifier;
 - establish a fresh Eve profile that never imports Murmur History, settings, hotwords, browser storage, credentials, or external-server configuration;
-- preserve the inactive Murmur data directory without reading, moving, or deleting it;
+- preserve the inactive Murmur data directory without reading, moving, or deleting personal files; permit only a bounded `server.pid` ownership check when required to prevent process conflicts;
 - test clean install, upgrade, downgrade/rollback, repair, startup registration, and uninstall without deleting either data profile or shared model caches;
 - complete the binary-distribution third-party notice audit.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,4 +11,4 @@ Before reporting a problem:
 
 Public issue tracking is currently closed. Source fixes can be proposed with a focused draft pull request. Security-sensitive reports must use the private process in [SECURITY.md](SECURITY.md), not a public pull request.
 
-The v0.6.3 download still installs Murmur and stores application data under the existing Murmur path. Do not rename or move that data manually; the later Eve identity migration will define compatibility and rollback behavior.
+The v0.6.3 download still installs Murmur and stores application data under the existing Murmur path. Do not rename or move that data manually. The later Eve application will start with a separate fresh profile and leave Murmur data untouched rather than importing it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This directory keeps only docs that still match the current codebase.
 
 ## Active docs
 
+- `architecture/adr-001-eve-application-identity-migration.md`: proposed fresh-profile, installer-compatibility, recovery, and acceptance design for the later Eve application rename.
 - `engineering/v0.6.3-release-case-study.md`: evidence-backed account of the Windows packaging and lifecycle work shipped through v0.6.3.
 - `protocol.md`: WebSocket audio/control/text frame specification used by app and server.
 - `benchmark-report.md`: Nemotron vs Whisper benchmark data that informed engine defaults.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory keeps only docs that still match the current codebase.
 ## Active docs
 
 - `architecture/adr-001-eve-application-identity-migration.md`: proposed fresh-profile, installer-compatibility, recovery, and acceptance design for the later Eve application rename.
+- `architecture/eve-identity-cutover-checklist.md`: exact file map, implementation gates, validation sequence, and remaining-work ledger for that cutover.
 - `engineering/v0.6.3-release-case-study.md`: evidence-backed account of the Windows packaging and lifecycle work shipped through v0.6.3.
 - `protocol.md`: WebSocket audio/control/text frame specification used by app and server.
 - `benchmark-report.md`: Nemotron vs Whisper benchmark data that informed engine defaults.

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -43,7 +43,7 @@ This inventory is based on `trunk` at `fc40ad5a6b37f31b861bd904a0e106813fc81eb8`
 | Historical artifacts | `Murmur.Web.Setup.*.exe`, `murmur-*-x64.nsis.7z` | Immutable. Future Eve artifact names do not rename old releases. |
 | Publish repository | `burntcookiedough/eve-windows-dictation` | Already migrated and not part of the app cutover. |
 
-Electron Builder documents that NSIS derives a deterministic GUID from `appId` when `nsis.guid` is absent and warns that changing `appId` can break silent upgrades. It also documents product-name changes as supported when installer identity remains stable. See the official [NSIS configuration](https://www.electron.build/docs/nsis/) and [application configuration](https://www.electron.build/docs/configuration/).
+Electron Builder documents that NSIS derives a deterministic GUID from `appId` when a target-specific GUID is absent and warns that changing `appId` can break silent upgrades. It also documents product-name changes as supported when installer identity remains stable. This repository targets `nsis-web`, so its options belong under `build.nsisWeb`, not `build.nsis`. See the official [NSIS configuration](https://www.electron.build/docs/nsis/), [NSIS web options](https://www.electron.build/docs/api/electron-builder.interface.nsisweboptions/), and [application configuration](https://www.electron.build/docs/configuration/).
 
 ### Legacy Murmur data
 
@@ -53,7 +53,7 @@ Electron Builder documents that NSIS derives a deterministic GUID from `appId` w
 | Window state | `%APPDATA%\murmur\internal.json` | Do not read or copy. |
 | History and Insights | `%APPDATA%\murmur\history.db` plus WAL/SHM when present | Do not open, copy, merge, or index. |
 | Server settings | `%APPDATA%\murmur\server-settings.json` | Do not import. This prevents transfer of external-server details or other saved configuration. |
-| Server PID | `%APPDATA%\murmur\server.pid` | Do not migrate. It may be inspected only to prevent an old owned server from conflicting with Eve startup. |
+| Server PID | `%APPDATA%\murmur\server.pid` | Do not migrate. It may be inspected only to prevent an old owned server from conflicting with Eve startup. A recorded process must pass command-line ownership verification before Eve adopts, stops, or otherwise trusts it, even when the recorded port responds as healthy. |
 | Paste helpers | `%APPDATA%\murmur\paste-helper.vbs`, `paste-sendinput.ps1` | Do not copy; Eve regenerates its own helpers. |
 | Chromium storage and caches | `Local Storage`, `Network`, `Cache`, `GPUCache`, and related entries | Do not read or copy. This prevents accidental transfer of cookies, browser state, or cached data. |
 | Diagnostic traces | for example `hotkey-trace.log` | Do not read or copy. |
@@ -111,8 +111,8 @@ Use compatibility stages so the installer and Windows identity can be tested ind
 
 ### Stage A: compatibility foundation, no visible rename
 
-- Confirm the NSIS uninstall key on a clean published v0.6.3 installation and set `nsis.guid` explicitly.
-- Set `deleteAppDataOnUninstall: false` explicitly even though it is currently Electron Builder's default.
+- Confirm the NSIS uninstall key on a clean published v0.6.3 installation and set `build.nsisWeb.guid` explicitly.
+- Confirm the current one-click behavior, then pin `build.nsisWeb.oneClick: true` and `build.nsisWeb.deleteAppDataOnUninstall: false` so the web uninstaller's data policy is explicit.
 - Add typed constants for legacy installer identity and future Eve identity.
 - Introduce a bootstrap entrypoint that obtains the single-instance lock and selects userData before importing settings, History, clipboard, or server modules.
 - Keep selecting `%APPDATA%\murmur` in this stage so behavior remains unchanged.
@@ -126,7 +126,7 @@ This is the smallest safe implementation PR. It changes no visible product or da
 - Do not test for or inspect Murmur settings, History, Chromium state, or diagnostics.
 - Initialize Eve settings, window state, History, server settings, PID file, and generated helpers from clean defaults.
 - If the Eve directory exists, use it normally. If it is malformed or inaccessible, stop with repair guidance; do not fall back to Murmur data.
-- Permit only a narrow legacy PID ownership check when needed to prevent two managed transcription servers from conflicting.
+- Permit only a narrow legacy PID ownership check when needed to prevent two managed transcription servers from conflicting. Before adopting a process from the recorded PID and port, require the existing command-line ownership proof. Refuse to adopt or terminate a stale or reused PID owned by another process.
 - Leave `%APPDATA%\murmur` byte-for-byte untouched.
 
 ### Stage C: visible Eve identity with stable installer continuity
@@ -179,6 +179,7 @@ After the compatibility window, internal `MURMUR_*`, Python package, preload bri
 - Reinstall the same Eve version.
 - Interrupted install and repair.
 - Uninstall Eve while preserving Eve data, Murmur data, and model caches.
+- Run an explicit nsis-web uninstall regression proving both Eve userData and `%APPDATA%\murmur` survive.
 - Verify executable, shortcuts, Start menu, taskbar grouping, AppUserModelID, Control Panel entry, uninstaller, and artifact names.
 
 ### Data isolation
@@ -189,7 +190,7 @@ After the compatibility window, internal `MURMUR_*`, Python package, preload bri
 - Eve creates a distinct settings file and empty History database.
 - Existing valid Eve data is reused without consulting Murmur.
 - Malformed or read-only Eve data produces repair guidance without Murmur fallback.
-- Process/file tracing confirms no read or write under `%APPDATA%\murmur`, except the separately tested narrow PID ownership check if retained.
+- Process/file tracing confirms Eve does not open Murmur personal files; the only permitted legacy-root access is the separately tested `server.pid` ownership check.
 - Migration and startup logs contain no transcript, settings, credential, token, device-label, or personal-path values.
 
 ### Startup and lifecycle
@@ -197,7 +198,7 @@ After the compatibility window, internal `MURMUR_*`, Python package, preload bri
 - Launch-on-login starts disabled even when Murmur previously enabled it.
 - Multiple exact known historical startup registrations are handled safely.
 - An unrecognized similarly named entry remains untouched.
-- Stale, malformed, live-owned, and live-unrecognized legacy PID cases.
+- Stale, malformed, live-owned, healthy-but-unowned, and PID-reused-by-an-unrelated-process cases.
 - Rapid restart and crash during first Eve initialization.
 - First launch works without developer tools on a fresh Windows VM.
 
@@ -215,6 +216,7 @@ After the compatibility window, internal `MURMUR_*`, Python package, preload bri
 - Changing `appId` before freezing and validating the NSIS GUID can break upgrade and uninstall continuity.
 - Importing `settings.ts` before setting Eve userData can create or write the wrong directory. The current top-level Electron Store construction makes bootstrap ordering a release blocker.
 - Any fallback to `%APPDATA%\murmur` violates the fresh-profile decision and may expose old personal data.
+- Adopting a healthy endpoint from `server.pid` without proving process ownership can connect Eve to an unrelated local service or reused PID.
 - Broad startup-registry cleanup can remove unrelated user entries.
 - Any uninstall configuration that deletes app data can destroy History or settings.
 
@@ -245,7 +247,7 @@ The smallest safe PR is **identity compatibility scaffolding only**:
 
 1. add typed constants for current and proposed identities;
 2. add a bootstrap/userData resolver that still selects the current Murmur path;
-3. freeze the clean-install-verified NSIS GUID and explicitly set `deleteAppDataOnUninstall: false`;
+3. freeze the clean-install-verified `build.nsisWeb.guid` and explicitly set `build.nsisWeb.oneClick: true` plus `deleteAppDataOnUninstall: false`;
 4. add configuration, bootstrap-order, and path-selection tests;
 5. prove that v0.6.3 userData, installer names, executable, startup behavior, and release artifacts remain unchanged.
 

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -4,6 +4,8 @@
 
 Proposed. This document authorizes no runtime, installer, registry, or data-path changes.
 
+The companion [cutover checklist](eve-identity-cutover-checklist.md) maps this decision to exact files, release gates, checks, and remaining work.
+
 Product decision: Eve will not import Murmur's History, settings, hotwords, external-server configuration, browser storage, credentials, or other personal state. The old Murmur data directory will be left untouched as an inactive archive.
 
 Trademark review is deferred. It remains separate from this technical design.
@@ -86,9 +88,9 @@ A read-only machine audit found three historical entries named `Murmur`, `electr
 The implementation must:
 
 1. enumerate through Electron's supported login-item API where possible;
-2. remove only registrations whose names are in an exact compatibility allowlist and whose normalized paths are exact known Murmur install or test paths;
+2. remove only registrations whose names are in an exact compatibility allowlist and whose normalized paths match the published Murmur installation being upgraded;
 3. never delete registry values through substring matching;
-4. leave an unrecognized entry untouched and report a privacy-safe warning;
+4. leave unrecognized, development, and unpacked-candidate entries untouched and report a privacy-safe warning;
 5. create one Eve registration only after the user enables launch-on-login in Eve;
 6. verify the resulting path and enabled state.
 

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -1,0 +1,275 @@
+# ADR-001: Cut over to Eve with a fresh data profile
+
+## Status
+
+Proposed. This document authorizes no runtime, installer, registry, or data-path changes.
+
+Product decision: Eve will not import Murmur's History, settings, hotwords, external-server configuration, browser storage, credentials, or other personal state. The old Murmur data directory will be left untouched as an inactive archive.
+
+Trademark review is deferred. It remains separate from this technical design.
+
+## Context
+
+The repository is `burntcookiedough/eve-windows-dictation`, while v0.6.3 still installs Murmur. The later installed-product cutover must give Eve its own identity and clean data profile without breaking the existing NSIS upgrade chain or deleting any legacy files.
+
+The design must protect:
+
+- installer upgrade and uninstall recognition for existing Murmur installations;
+- the user's decision not to transfer old personal data into Eve;
+- launch-on-login correctness after the executable name changes;
+- recovery after an interrupted installation or first launch;
+- clear separation from later visual, signing, thin-client, and ASR-engine work.
+
+The project targets Windows and is maintained by a small team. A direct, explicit cutover is safer than a general migration framework that the product no longer needs.
+
+## Current identity inventory
+
+This inventory is based on `trunk` at `fc40ad5a6b37f31b861bd904a0e106813fc81eb8` and a read-only inspection of an installed Windows build. Paths use environment-variable notation and contain no user-specific directory.
+
+### Installer and Windows identity
+
+| Surface | Current value or behavior | Consequence |
+|---|---|---|
+| Electron package name | `murmur` | Build-tool identifier; change separately from installer continuity work. |
+| Product name | `Murmur` | Controls executable and installer-facing names. |
+| Application ID | `com.murmur.app` | Used as the Windows Application User Model ID and as input to the default NSIS GUID. |
+| Runtime AppUserModelID | `com.murmur.app` | Set explicitly in `app/src/main/index.ts`. |
+| Observed NSIS uninstall key | `0204d005-75b3-5b31-b1f6-ef2831e2b204` | Treat as the installed upgrade identity. Confirm on a clean v0.6.3 installation, then freeze it explicitly before changing `appId`. |
+| Executable | `Murmur.exe` | Renaming affects startup paths, shortcuts, firewall prompts, and user expectations. |
+| Uninstaller | `Uninstall Murmur.exe` | Must remain discoverable across an in-place upgrade. |
+| Existing install directory | `%LOCALAPPDATA%\Programs\murmur` | An upgrade should continue to recognize this installation. New clean Eve installs may use an Eve directory after testing. |
+| Historical artifacts | `Murmur.Web.Setup.*.exe`, `murmur-*-x64.nsis.7z` | Immutable. Future Eve artifact names do not rename old releases. |
+| Publish repository | `burntcookiedough/eve-windows-dictation` | Already migrated and not part of the app cutover. |
+
+Electron Builder documents that NSIS derives a deterministic GUID from `appId` when `nsis.guid` is absent and warns that changing `appId` can break silent upgrades. It also documents product-name changes as supported when installer identity remains stable. See the official [NSIS configuration](https://www.electron.build/docs/nsis/) and [application configuration](https://www.electron.build/docs/configuration/).
+
+### Legacy Murmur data
+
+| Data | Current location | Eve behavior |
+|---|---|---|
+| User settings and hotwords | `%APPDATA%\murmur\settings.json` | Do not read or copy. Eve starts with defaults. |
+| Window state | `%APPDATA%\murmur\internal.json` | Do not read or copy. |
+| History and Insights | `%APPDATA%\murmur\history.db` plus WAL/SHM when present | Do not open, copy, merge, or index. |
+| Server settings | `%APPDATA%\murmur\server-settings.json` | Do not import. This prevents transfer of external-server details or other saved configuration. |
+| Server PID | `%APPDATA%\murmur\server.pid` | Do not migrate. It may be inspected only to prevent an old owned server from conflicting with Eve startup. |
+| Paste helpers | `%APPDATA%\murmur\paste-helper.vbs`, `paste-sendinput.ps1` | Do not copy; Eve regenerates its own helpers. |
+| Chromium storage and caches | `Local Storage`, `Network`, `Cache`, `GPUCache`, and related entries | Do not read or copy. This prevents accidental transfer of cookies, browser state, or cached data. |
+| Diagnostic traces | for example `hotkey-trace.log` | Do not read or copy. |
+
+The complete `%APPDATA%\murmur` directory remains untouched. Eve will use a distinct root such as `%APPDATA%\Eve`, with the final casing and constant approved during implementation.
+
+Electron documents `userData` as an app-name-derived directory that also contains Chromium-managed state. Eve must set its explicit path before any module constructs Electron Store or calls a service that uses `app.getPath('userData')`. See Electron's [app path documentation](https://www.electronjs.org/docs/latest/api/app#appgetpathname).
+
+### Model caches are separate
+
+Hugging Face model weights live in the standard Hugging Face cache or a user-configured cache, not in Murmur's History/settings directory. They are downloaded third-party runtime assets, not imported Murmur personal data.
+
+Eve may reuse an already verified standard model cache to avoid a multi-gigabyte duplicate download. It must not move, rename, or delete that cache. A later component-pack design may give engine assets an Eve-owned lifecycle; that is outside this identity cutover.
+
+### Runtime and internal identifiers
+
+| Surface | Examples | Decision |
+|---|---|---|
+| Server environment prefix | `MURMUR_*` | Keep as a compatibility API during the Windows identity cutover. Add `EVE_*` aliases only in a separate proposal. |
+| Python package and CLI | `murmur`, `murmur-testui` | Keep during the installed-product rename. |
+| Renderer bridge globals | `window.murmurMain` and the overlay bridge | Keep. Renaming internal preload contracts adds risk without changing public ownership. |
+| Internal types and helpers | `MurmurMainAPI`, logger text, helper names | Rename only when a focused cleanup provides value. |
+| Dormant homepage | old Murmur copy and base path | Keep unpublished until the visual/public-site phase. |
+| Icons and color system | current Murmur assets | Handle after identity and installer compatibility are proven. |
+
+## Launch-on-login risk
+
+`app.setLoginItemSettings({ openAtLogin })` defaults to the current executable and uses the AppUserModelID as a Windows value name unless another name is supplied. Electron's [login item documentation](https://www.electronjs.org/docs/latest/api/app#appsetloginitemsettingssettings-macos-windows) confirms that path, arguments, and name are part of the registration.
+
+A read-only machine audit found three historical entries named `Murmur`, `electron.app.Murmur`, and `com.murmur.app`, pointing at an installed executable and different unpacked candidates. Eve must not import the old `launchOnBoot` setting, so it starts with launch-on-login disabled. The cutover must still neutralize stale known Murmur registrations safely.
+
+The implementation must:
+
+1. enumerate through Electron's supported login-item API where possible;
+2. remove only registrations whose names are in an exact compatibility allowlist and whose normalized paths are exact known Murmur install or test paths;
+3. never delete registry values through substring matching;
+4. leave an unrecognized entry untouched and report a privacy-safe warning;
+5. create one Eve registration only after the user enables launch-on-login in Eve;
+6. verify the resulting path and enabled state.
+
+## Options considered
+
+| Option | Benefit | Cost and risk | Decision |
+|---|---|---|---|
+| Import all Murmur data into Eve | Continuity | Transfers personal state the user does not want; copies browser state and risks inconsistent SQLite data | Reject |
+| Offer automatic selective import | Some continuity | Adds consent UI, migration code, repair states, and ambiguity about secrets | Reject for the initial Eve cutover |
+| Delete Murmur data during upgrade | Clean disk state | Irreversible loss and violates preservation rules | Reject |
+| Leave Murmur data untouched and start Eve fresh | Strong privacy boundary, simple recovery, no database migration | Old History is not visible in Eve | Choose |
+
+## Decision
+
+Eve receives a fresh userData root and default settings. It never automatically reads or imports the legacy Murmur data root.
+
+Use compatibility stages so the installer and Windows identity can be tested independently.
+
+### Stage A: compatibility foundation, no visible rename
+
+- Confirm the NSIS uninstall key on a clean published v0.6.3 installation and set `nsis.guid` explicitly.
+- Set `deleteAppDataOnUninstall: false` explicitly even though it is currently Electron Builder's default.
+- Add typed constants for legacy installer identity and future Eve identity.
+- Introduce a bootstrap entrypoint that obtains the single-instance lock and selects userData before importing settings, History, clipboard, or server modules.
+- Keep selecting `%APPDATA%\murmur` in this stage so behavior remains unchanged.
+- Add tests for bootstrap ordering, identity constants, installer GUID, and the no-delete uninstall policy.
+
+This is the smallest safe implementation PR. It changes no visible product or data behavior.
+
+### Stage B: clean Eve data boundary
+
+- Change the bootstrap resolver to select a new Eve userData directory unconditionally for Eve builds.
+- Do not test for or inspect Murmur settings, History, Chromium state, or diagnostics.
+- Initialize Eve settings, window state, History, server settings, PID file, and generated helpers from clean defaults.
+- If the Eve directory exists, use it normally. If it is malformed or inaccessible, stop with repair guidance; do not fall back to Murmur data.
+- Permit only a narrow legacy PID ownership check when needed to prevent two managed transcription servers from conflicting.
+- Leave `%APPDATA%\murmur` byte-for-byte untouched.
+
+### Stage C: visible Eve identity with stable installer continuity
+
+- Change the product, executable, installer display, shortcut, tray strings, and user-facing copy to Eve.
+- Preserve the explicit legacy NSIS GUID so existing Murmur installations remain in the upgrade chain.
+- Repair exact known launch-on-login registrations. Do not copy the old launch preference; Eve defaults to disabled.
+- Decide whether `appId` remains `com.murmur.app` for one bridge release based on clean-machine upgrade, notification, and taskbar tests.
+- Do not redesign the interface in this stage. Visual work remains a separate phase.
+
+### Stage D: AppUserModelID cutover
+
+- Change to a distinctive identifier such as `io.github.burntcookiedough.eve` only after Stage C upgrade tests pass.
+- Preserve the explicit NSIS GUID.
+- Update `app.setAppUserModelId()` and launch-on-login handling together.
+- Validate notifications, taskbar grouping, shortcuts, Control Panel metadata, install-over-existing behavior, and uninstall/reinstall behavior.
+
+The exact future AppUserModelID remains separately approved. The example value is not authorized by this ADR.
+
+### Stage E: optional internal cleanup
+
+After the compatibility window, internal `MURMUR_*`, Python package, preload bridge, and test names may be assessed separately. Cosmetic internal renaming is not required for Eve's public identity.
+
+## Legacy-data contract
+
+- Eve never reads transcript rows from Murmur History.
+- Eve never imports Murmur settings, hotwords, external-server URLs, browser storage, cookies, credentials, logs, or clipboard-related files.
+- Eve never writes into `%APPDATA%\murmur`.
+- Install, repair, upgrade, and uninstall never delete `%APPDATA%\murmur`.
+- Eve does not display an automatic import prompt during the initial cutover.
+- A future manual import tool requires a new explicit product decision and separate threat/privacy review.
+- Reinstalling a compatible Murmur build may still expose the old untouched data. Eve-created data remains isolated in Eve's directory.
+
+## Recovery and repair contract
+
+- A Stage A failure changes no user identity or data path.
+- A Stage B failure never falls back to or mutates Murmur personal data.
+- A Stage C installer failure must leave the previous install recoverable through the frozen NSIS identity.
+- Repair may recreate Eve-generated helpers and caches. It must not delete Eve History/settings, Murmur data, model caches, or unrecognized startup entries.
+- Uninstall removes program files and current shortcuts but preserves both data roots by default.
+- Any future remove-all-data action must list exact paths, distinguish Eve from Murmur, require confirmation, and default to preserving both.
+
+## Acceptance matrix
+
+### Installer and identity
+
+- Clean Eve install with and without a legacy Murmur data directory.
+- Upgrade from published v0.6.2 and v0.6.3 installers.
+- Existing Murmur install directory and a clean Eve install directory.
+- Reinstall the same Eve version.
+- Interrupted install and repair.
+- Uninstall Eve while preserving Eve data, Murmur data, and model caches.
+- Verify executable, shortcuts, Start menu, taskbar grouping, AppUserModelID, Control Panel entry, uninstaller, and artifact names.
+
+### Data isolation
+
+- Legacy History containing controlled sentinel rows does not appear in Eve.
+- Legacy settings containing controlled sentinel hotwords and external-server values do not appear in Eve.
+- Legacy Chromium storage and diagnostic files are never opened by the Eve process during a traced first launch.
+- Eve creates a distinct settings file and empty History database.
+- Existing valid Eve data is reused without consulting Murmur.
+- Malformed or read-only Eve data produces repair guidance without Murmur fallback.
+- Process/file tracing confirms no read or write under `%APPDATA%\murmur`, except the separately tested narrow PID ownership check if retained.
+- Migration and startup logs contain no transcript, settings, credential, token, device-label, or personal-path values.
+
+### Startup and lifecycle
+
+- Launch-on-login starts disabled even when Murmur previously enabled it.
+- Multiple exact known historical startup registrations are handled safely.
+- An unrecognized similarly named entry remains untouched.
+- Stale, malformed, live-owned, and live-unrecognized legacy PID cases.
+- Rapid restart and crash during first Eve initialization.
+- First launch works without developer tools on a fresh Windows VM.
+
+### Model cache boundary
+
+- Existing verified Hugging Face model cache is reused without reading Murmur userData.
+- Missing cache downloads normally.
+- Custom Hugging Face cache environment remains respected.
+- Eve uninstall does not delete shared model weights.
+
+## P0 and P1 risks
+
+### P0
+
+- Changing `appId` before freezing and validating the NSIS GUID can break upgrade and uninstall continuity.
+- Importing `settings.ts` before setting Eve userData can create or write the wrong directory. The current top-level Electron Store construction makes bootstrap ordering a release blocker.
+- Any fallback to `%APPDATA%\murmur` violates the fresh-profile decision and may expose old personal data.
+- Broad startup-registry cleanup can remove unrelated user entries.
+- Any uninstall configuration that deletes app data can destroy History or settings.
+
+### P1
+
+- Executable renaming can leave stale launch-on-login entries and shortcuts.
+- Changing AppUserModelID can reset notification permissions or taskbar grouping.
+- Reusing shared model caches must not be confused with importing personal Murmur data.
+- Internal `MURMUR_*` churn can break development scripts without improving user-facing identity.
+- The dormant homepage contains old product copy and must remain unpublished until redesigned.
+
+## Explicit no-go actions
+
+Until a later implementation phase is approved:
+
+- do not change `com.murmur.app`, `productName`, executable, installer, shortcut, package, or artifact names;
+- do not add, edit, or remove registry entries or startup registrations;
+- do not read, copy, merge, rename, or delete Murmur History, settings, browser storage, logs, or other personal data;
+- do not move or delete `%APPDATA%\murmur`;
+- do not delete model caches;
+- do not change release tags, historical assets, or update URLs;
+- do not combine visual redesign, signing, thin-client packaging, ASR model work, or dependency upgrades with identity changes;
+- do not rename internal preload bridges or `MURMUR_*` variables for cosmetic consistency.
+
+## First implementation PR after approval
+
+The smallest safe PR is **identity compatibility scaffolding only**:
+
+1. add typed constants for current and proposed identities;
+2. add a bootstrap/userData resolver that still selects the current Murmur path;
+3. freeze the clean-install-verified NSIS GUID and explicitly set `deleteAppDataOnUninstall: false`;
+4. add configuration, bootstrap-order, and path-selection tests;
+5. prove that v0.6.3 userData, installer names, executable, startup behavior, and release artifacts remain unchanged.
+
+It must not import data, create the Eve data directory, or display Eve inside the installed application.
+
+## Consequences
+
+### Positive
+
+- Eve starts without inherited personal state or ambiguous consent.
+- No SQLite, settings, or Chromium migration mechanism is required.
+- The legacy directory remains available for manual rollback without being coupled to Eve.
+- Installer and identity risks remain testable in small stages.
+
+### Negative
+
+- Existing History and preferences do not appear in Eve.
+- Users must configure Eve again.
+- Both data directories may remain on disk until the user deliberately removes one outside the application.
+
+### Mitigation
+
+- State the fresh-profile behavior prominently in release notes and first-run UI.
+- Never call the cutover a data migration.
+- Keep Murmur data untouched and document how to identify both directories without exposing their contents.
+
+## Revisit triggers
+
+Revisit this decision only if the user explicitly requests a manual import feature, Electron Builder changes NSIS GUID behavior, a signed or Store distribution changes installer requirements, or model caches move under application userData.

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -1,0 +1,171 @@
+# Eve identity cutover checklist
+
+## One-minute brief
+
+Eve will be a new Windows application identity, but it must remain in Murmur's existing NSIS upgrade chain. It will start with an empty History and default settings in a separate Eve directory. It will not import or delete Murmur History, settings, hotwords, external-server configuration, browser storage, credentials, logs, or startup preference. The old Murmur data directory stays inactive and untouched. Generic Hugging Face model weights may be reused because they are downloaded runtime assets outside Murmur userData. Implementation is split into compatibility scaffolding, the fresh Eve data boundary, the visible product rename, and the later AppUserModelID cutover. Each step gets its own PR and Windows acceptance gate.
+
+The controlling architecture decision is [ADR-001](adr-001-eve-application-identity-migration.md).
+
+## Fixed decisions
+
+- Repository: `burntcookiedough/eve-windows-dictation`.
+- Display product direction: Eve.
+- Trademark work: deferred, not treated as complete.
+- Murmur personal data: no import, no fallback, no automatic prompt, no deletion.
+- Eve data: a distinct fresh profile.
+- Shared model cache: may be reused without reading Murmur userData.
+- Existing installer chain: preserve through an explicit NSIS GUID.
+- Visual redesign: later phase.
+- Thin-client and new ASR profiles: later phase.
+
+## Audit coverage
+
+The pre-checklist repository audit found 87 tracked files containing `murmur` after excluding the main dependency lockfiles. Many are historical documentation, internal compatibility names, or sample prose rather than public product identity. They must be classified, not replaced mechanically.
+
+High-signal counts at the ADR baseline:
+
+| Pattern | Lines | Files | Treatment |
+|---|---:|---:|---|
+| `com.murmur.app` | 8 | 4 | Installer/AppUserModelID compatibility work. |
+| `%APPDATA%\murmur` | 22 | 5 | Legacy data boundary; Eve must not read or modify it. |
+| `window.murmurMain` | 49 | 9 | Internal preload contract; retain. |
+| `MURMUR_*` | 87 | 27 | Runtime/developer compatibility API; retain during cutover. |
+| `Murmur.exe` | 8 | 5 | Installer, startup, smoke-test, and documentation cutover. |
+| `Uninstall Murmur` | 3 | 3 | Installer upgrade/uninstall verification. |
+| old repository URLs | 5 | 3 | Dormant homepage and a historical setup document; update only in their owning phase. |
+
+These counts are audit evidence, not a target of zero. A zero-result rename would be unsafe because it would erase compatibility constants and historical descriptions.
+
+## File-by-file implementation map
+
+### Gate 1: compatibility scaffolding
+
+These files define identity and startup ordering. The first implementation PR may touch only this group plus focused tests.
+
+| File | Current responsibility | Required change |
+|---|---|---|
+| `app/package.json` | `appId`, `productName`, target, publish configuration | Add the clean-install-verified `nsis.guid` and explicit `deleteAppDataOnUninstall: false`. Keep all visible Murmur values. |
+| `app/src/main/index.ts` | AppUserModelID, single-instance lock, service startup | Split a minimal bootstrap that resolves userData before importing data consumers. Keep `com.murmur.app`. |
+| new identity module | No centralized identity constants exist | Define typed legacy and proposed identifiers without activating Eve values. |
+| `server/tests/test_release_config.py` | Release/build configuration contract | Assert frozen GUID, no-delete policy, unchanged product name, app ID, target, and repository. |
+| new app bootstrap tests | No ordering contract exists | Prove userData selection occurs before settings/History/server modules initialize. |
+
+Exit condition: packaged names, executable, data path, startup behavior, release assets, and v0.6.3 compatibility remain unchanged.
+
+### Gate 2: fresh Eve profile
+
+This group owns mutable state. The fresh-profile PR must not include visible renaming.
+
+| File | Current Murmur dependency | Eve treatment |
+|---|---|---|
+| `app/src/main/services/settings.ts` | Constructs `settings.json` and `internal.json` stores at module load | Initialize only after bootstrap selects Eve userData. Do not read legacy JSON. |
+| `app/src/main/services/history.ts` | Opens `history.db` under userData | Create a new empty Eve database. Never open legacy History. |
+| `app/src/main/services/server-manager.ts` | Uses userData for `server.pid` and `server-settings.json` | Use Eve paths. Allow only a narrow legacy PID ownership check if required for process safety. |
+| `app/src/main/services/clipboard.ts` | Writes paste helper scripts under userData | Generate new Eve helpers. Do not copy old scripts. |
+| `app/scripts/clear-data.js` | Targets the Murmur directory | Replace with an Eve-specific development helper. It must never target both roots. |
+| `server/src/pidfile.py` and `server/justfile` | Standalone fallback paths use `murmur` | Keep compatibility fallbacks unless a separately tested Eve override is passed by the app. |
+| `server/src/config.py` | Accepts `MURMUR_SETTINGS_FILE` | Keep the environment contract; the Electron launcher supplies the new Eve file path. |
+
+Exit condition: traced first launch performs no read or write under `%APPDATA%\murmur`, Eve starts with defaults and empty History, and both directories survive uninstall.
+
+### Gate 3: visible Eve name
+
+This group changes what users see. It follows installer and data isolation gates.
+
+| Area | Files | Required work |
+|---|---|---|
+| Packaged identity | `app/package.json` | Set product/executable/installer/shortcut display values while preserving the explicit NSIS GUID. |
+| App shell | `app/src/main/index.ts`, `app/src/main/services/tray.ts`, `app/src/main/windows/main.ts` | Replace user-facing Murmur strings; do not rename internal APIs in the same PR. |
+| Main window | `TitleBar.svelte`, `SettingsView.svelte`, renderer `index.html` | Replace visible product copy and accessible labels. |
+| Overlay | overlay `index.html` and user-visible warning copy | Replace visible name only. Keep `window.murmur` bridge stable. |
+| Diagnostics | `diagnostics-report.ts`, user-facing server diagnostics | Report Eve as the product while retaining compatibility identifiers only where technically required. |
+| Installation checks | `scripts/installer-smoke.ps1`, `scripts/release-verify.ps1`, related tests | Accept and verify Eve executable, installer, shortcut, uninstaller, and artifact names. Preserve legacy-upgrade fixtures. |
+| Build docs | `README.md`, `BUILDING.md`, active Windows setup docs | Describe Eve current behavior while keeping historical releases labelled Murmur. |
+
+Exit condition: an upgrade from published Murmur succeeds, Eve starts with a fresh profile, old personal data stays untouched, and launch-on-login defaults to disabled.
+
+### Gate 4: AppUserModelID cutover
+
+| File or system | Required work |
+|---|---|
+| `app/package.json` | Change `appId` only after the exact future ID is approved; retain explicit NSIS GUID. |
+| `app/src/main/index.ts` | Change `app.setAppUserModelId()` with the packaged ID. |
+| `app/src/main/ipc/handlers.ts` | Register only Eve launch-on-login after user opt-in; reconcile exact known legacy registrations. |
+| Windows installation | Verify taskbar grouping, notifications, shortcuts, uninstall key, install location, repair, and upgrade. |
+
+Exit condition: no duplicate installer entry, no stale enabled startup entry, and no loss of the existing uninstall/upgrade path.
+
+### Keep stable during the cutover
+
+These names are internal or compatibility surfaces. They are not evidence that public renaming is incomplete.
+
+- `window.murmurMain`, `window.murmur`, preload API types, and renderer call sites;
+- `MURMUR_*` server and development environment variables;
+- Python distribution/CLI names such as `murmur` and `murmur-testui`;
+- version-script lockfile matching for the current Python package;
+- protocol module names and test fixture package paths;
+- historical release names, tags, checksums, PRs, and case-study evidence.
+
+### Defer to later phases
+
+| Scope | Files or assets | Reason |
+|---|---|---|
+| Visual system | `app/resources` icons and renderer styling | Requires its own design and accessibility review. |
+| Public homepage | `homepage/**` and Pages workflow | Current site is dormant and Pages is not configured. Rebuild after visual identity. |
+| Historical research wording | benchmark and VRAM research docs | Update only for clarity; do not rewrite historical measurements as Eve results. |
+| Thin-client distribution | release workflow, component manifests, engine packs | Separate high-risk packaging architecture. |
+| Internal rename cleanup | preload globals, Python packages, env prefix | High churn with no user-facing benefit. |
+
+## Surgical execution order
+
+1. Capture baseline Git ref, installer configuration, release asset inventory, NSIS key, installed files, startup registrations, and both data-root existence states without reading personal contents.
+2. Merge compatibility scaffolding with no behavior change.
+3. Build and install that bridge on a clean VM and over published v0.6.2/v0.6.3.
+4. Implement the fresh Eve data root without visible rename.
+5. Trace filesystem access and prove Murmur personal files are not opened.
+6. Change visible product/installer names while preserving the explicit NSIS GUID.
+7. Repair exact known startup entries and leave unknown entries untouched.
+8. Run the complete upgrade, clean-install, repair, uninstall, and rollback matrix.
+9. Change AppUserModelID only in a later focused PR if the prior release proves stable.
+10. Begin visual design only after identity acceptance is complete.
+
+## Required checks for every implementation PR
+
+- `python scripts/version.py check`;
+- focused app or server tests for the changed boundary;
+- full app tests and production build;
+- full server tests when launcher/server behavior changes;
+- `git diff --check` and exact changed-file scope audit;
+- privacy scan of logs and test artifacts;
+- clean Windows VM acceptance when installer or identity changes;
+- exact pre/post registry, shortcut, install-directory, and data-root comparison;
+- on controlled fixtures, confirmation that `%APPDATA%\murmur` file hashes are unchanged; on a real user profile, confirm through filesystem tracing that Eve never opens the personal files;
+- confirmation that no release, tag, or historical asset changed.
+
+## Remaining-work ledger
+
+| Work | Status | Approval needed |
+|---|---|---|
+| Repository detachment and rename | Complete | No |
+| Placement-ready repository documentation | Complete | No |
+| Fresh-profile ADR and cutover checklist | Current PR | Merge after review |
+| Confirm NSIS key from a clean published v0.6.3 install | Pending | Read-only test authorization and clean VM |
+| Select final Eve data-root casing and AppUserModelID | Pending | Explicit decision before activation |
+| Compatibility-scaffolding implementation | Pending | Explicit implementation approval |
+| Fresh Eve profile implementation | Pending | Separate approval after scaffolding acceptance |
+| Visible installed-product rename | Pending | Separate approval after data isolation passes |
+| AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |
+| Visual identity and homepage | Pending | Later design phase |
+| Thin-client/component packs and ASR profiles | Pending | Later technical phase |
+
+## Stop conditions
+
+Stop the current change immediately if it:
+
+- reads or writes Murmur History, settings, browser storage, credentials, logs, or hotwords;
+- changes the NSIS identity without an explicit verified GUID;
+- creates an Eve startup entry before the user opts in;
+- deletes either data root or shared model cache;
+- produces two active installer/uninstall entries for one upgrade path;
+- requires visual redesign, dependency upgrades, model changes, or release publication to succeed;
+- cannot explain recovery using only the previous installer and untouched data directories.

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -44,10 +44,10 @@ These files define identity and startup ordering. The first implementation PR ma
 
 | File | Current responsibility | Required change |
 |---|---|---|
-| `app/package.json` | `appId`, `productName`, target, publish configuration | Add the clean-install-verified `nsis.guid` and explicit `deleteAppDataOnUninstall: false`. Keep all visible Murmur values. |
+| `app/package.json` | `appId`, `productName`, target, publish configuration | Add the clean-install-verified `build.nsisWeb.guid`; pin `build.nsisWeb.oneClick: true` and `deleteAppDataOnUninstall: false`. Keep all visible Murmur values. |
 | `app/src/main/index.ts` | AppUserModelID, single-instance lock, service startup | Split a minimal bootstrap that resolves userData before importing data consumers. Keep `com.murmur.app`. |
 | new identity module | No centralized identity constants exist | Define typed legacy and proposed identifiers without activating Eve values. |
-| `server/tests/test_release_config.py` | Release/build configuration contract | Assert frozen GUID, no-delete policy, unchanged product name, app ID, target, and repository. |
+| `server/tests/test_release_config.py` | Release/build configuration contract | Assert target-specific `nsisWeb` GUID, one-click/no-delete policy, unchanged product name, app ID, target, and repository. |
 | new app bootstrap tests | No ordering contract exists | Prove userData selection occurs before settings/History/server modules initialize. |
 
 Exit condition: packaged names, executable, data path, startup behavior, release assets, and v0.6.3 compatibility remain unchanged.
@@ -60,13 +60,15 @@ This group owns mutable state. The fresh-profile PR must not include visible ren
 |---|---|---|
 | `app/src/main/services/settings.ts` | Constructs `settings.json` and `internal.json` stores at module load | Initialize only after bootstrap selects Eve userData. Do not read legacy JSON. |
 | `app/src/main/services/history.ts` | Opens `history.db` under userData | Create a new empty Eve database. Never open legacy History. |
-| `app/src/main/services/server-manager.ts` | Uses userData for `server.pid` and `server-settings.json` | Use Eve paths. Allow only a narrow legacy PID ownership check if required for process safety. |
+| `app/src/main/services/server-manager.ts` | Uses userData for `server.pid` and `server-settings.json` | Use Eve paths. Allow only a narrow legacy PID ownership check if required for process safety. Require command-line ownership proof before adopting a healthy recorded process; refuse stale or unrelated PID reuse. |
 | `app/src/main/services/clipboard.ts` | Writes paste helper scripts under userData | Generate new Eve helpers. Do not copy old scripts. |
 | `app/scripts/clear-data.js` | Targets the Murmur directory | Replace with an Eve-specific development helper. It must never target both roots. |
 | `server/src/pidfile.py` and `server/justfile` | Standalone fallback paths use `murmur` | Keep compatibility fallbacks unless a separately tested Eve override is passed by the app. |
 | `server/src/config.py` | Accepts `MURMUR_SETTINGS_FILE` | Keep the environment contract; the Electron launcher supplies the new Eve file path. |
 
-Exit condition: traced first launch performs no read or write under `%APPDATA%\murmur`, Eve starts with defaults and empty History, and both directories survive uninstall.
+Exit condition: traced first launch performs no read or write against Murmur personal files; the only permitted access is the bounded legacy `server.pid` ownership check. Eve starts with defaults and empty History, and both directories survive uninstall.
+
+Focused lifecycle tests must cover a stale PID file, a PID reused by an unrelated process, a healthy endpoint whose recorded PID is not owned, and a verified owned server. No unrelated process may be adopted or terminated.
 
 ### Gate 3: visible Eve name
 
@@ -138,6 +140,7 @@ These names are internal or compatibility surfaces. They are not evidence that p
 - `git diff --check` and exact changed-file scope audit;
 - privacy scan of logs and test artifacts;
 - clean Windows VM acceptance when installer or identity changes;
+- nsis-web uninstall regression proving both Eve and Murmur data roots survive;
 - exact pre/post registry, shortcut, install-directory, and data-root comparison;
 - on controlled fixtures, confirmation that `%APPDATA%\murmur` file hashes are unchanged; on a real user profile, confirm through filesystem tracing that Eve never opens the personal files;
 - confirmation that no release, tag, or historical asset changed.


### PR DESCRIPTION
## Summary

- inventory the installed Murmur identity, NSIS upgrade key, data roots, startup registrations, internal compatibility identifiers, and model-cache boundary
- define a staged Eve identity cutover that freezes installer continuity before changing visible names or AppUserModelID
- make the product decision explicit: Eve starts with a fresh profile and never imports Murmur History, settings, hotwords, external-server configuration, browser storage, credentials, or diagnostics
- leave the complete Murmur data directory untouched and keep shared Hugging Face model weights separate from personal application data
- add a surgical file-by-file cutover checklist, one-minute brief, implementation gates, required checks, remaining-work ledger, and stop conditions

## Scope

Documentation and architecture only. This PR does not change app IDs, product or executable names, installer configuration, registry entries, startup behavior, userData paths, code, releases, tags, assets, models, or user files.

## Validation

- `uv run --no-sync pytest tests/test_docs_consistency.py` — 2 passed
- `python scripts/version.py check` — v0.6.3 passed
- relative Markdown link audit across all changed documents
- `git diff --cached --check`
- staged-scope audit confirming documentation files only
- repository-wide identity inventory: 87 pre-checklist tracked files containing Murmur references after main lockfile exclusions, classified by cutover gate rather than targeted for mechanical replacement

## Next approval gate

The smallest implementation PR would add identity constants and bootstrap/path-selection scaffolding while retaining the current Murmur path and visible behavior. It would also freeze the clean-install-verified NSIS GUID and explicitly preserve app data on uninstall. No implementation is authorized by this design PR.