### PR TITLE
Add Eve identity compatibility scaffolding

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -95,6 +95,11 @@
       "target": "nsis-web",
       "icon": "resources/icon.ico"
     },
+    "nsisWeb": {
+      "guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204",
+      "oneClick": true,
+      "deleteAppDataOnUninstall": false
+    },
     "publish": [
       {
         "provider": "github",

--- a/app/scripts/build-main.js
+++ b/app/scripts/build-main.js
@@ -25,7 +25,7 @@ const commonOptions = {
 // Build main process
 const mainOptions = {
   ...commonOptions,
-  entryPoints: [resolve(projectRoot, 'src/main/index.ts')],
+  entryPoints: [resolve(projectRoot, 'src/main/bootstrap.ts')],
   outfile: resolve(projectRoot, 'dist/main/index.js'),
 };
 

--- a/app/src/main/bootstrap-core.ts
+++ b/app/src/main/bootstrap-core.ts
@@ -1,0 +1,36 @@
+import { MURMUR_IDENTITY, resolveUserDataPath } from './identity.js';
+
+export interface BootstrapApp {
+  requestSingleInstanceLock(): boolean;
+  quit(): void;
+  getPath(name: 'appData'): string;
+  setPath(name: 'userData', path: string): void;
+  setAppUserModelId(id: string): void;
+}
+
+export type ApplicationLoader = () => Promise<unknown>;
+
+/**
+ * Establish process and data identity before importing modules that construct
+ * Electron Store instances or resolve History/server paths at module load.
+ */
+export async function bootstrapApplication(
+  electronApp: BootstrapApp,
+  loadApplication: ApplicationLoader,
+  platform: NodeJS.Platform = process.platform
+): Promise<boolean> {
+  if (!electronApp.requestSingleInstanceLock()) {
+    electronApp.quit();
+    return false;
+  }
+
+  const userDataPath = resolveUserDataPath(electronApp.getPath('appData'));
+  electronApp.setPath('userData', userDataPath);
+
+  if (platform === 'win32') {
+    electronApp.setAppUserModelId(MURMUR_IDENTITY.appId);
+  }
+
+  await loadApplication();
+  return true;
+}

--- a/app/src/main/bootstrap.ts
+++ b/app/src/main/bootstrap.ts
@@ -1,0 +1,4 @@
+import { app } from 'electron';
+import { bootstrapApplication } from './bootstrap-core.js';
+
+await bootstrapApplication(app, () => import('./index.js'));

--- a/app/src/main/identity.ts
+++ b/app/src/main/identity.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+
+export interface ApplicationIdentity {
+  readonly productName: string;
+  readonly appId: string;
+  readonly userDataDirectoryName: string;
+  readonly nsisGuid: string;
+}
+
+/**
+ * Published Murmur identity. These values remain active during compatibility
+ * scaffolding so installer, application, and user-data behavior do not change.
+ */
+export const MURMUR_IDENTITY = {
+  productName: 'Murmur',
+  appId: 'com.murmur.app',
+  userDataDirectoryName: 'murmur',
+  nsisGuid: '0204d005-75b3-5b31-b1f6-ef2831e2b204',
+} as const satisfies ApplicationIdentity;
+
+/**
+ * Selected future display identity. It is descriptive only and is not active
+ * until a later, separately approved cutover.
+ */
+export const EVE_PRODUCT_NAME = 'Eve' as const;
+
+export function resolveUserDataPath(
+  appDataPath: string,
+  identity: ApplicationIdentity = MURMUR_IDENTITY
+): string {
+  return path.join(appDataPath, identity.userDataDirectoryName);
+}

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -30,10 +30,6 @@ import { createLogger } from './lib/logger.js';
 
 const log = createLogger('App');
 
-if (process.platform === 'win32') {
-  app.setAppUserModelId('com.murmur.app');
-}
-
 let overlayWindow: BrowserWindow | null = null;
 let mainWindow: BrowserWindow | null = null;
 let transcriptionService: TranscriptionService | null = null;
@@ -646,9 +642,3 @@ app.on('will-quit', async (event) => {
   // Now actually quit
   app.exit(0);
 });
-
-// Prevent multiple instances
-const gotTheLock = app.requestSingleInstanceLock();
-if (!gotTheLock) {
-  app.quit();
-}

--- a/app/tests/bootstrap.test.ts
+++ b/app/tests/bootstrap.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
 import { bootstrapApplication, type BootstrapApp } from '../src/main/bootstrap-core';
 import { EVE_PRODUCT_NAME, MURMUR_IDENTITY, resolveUserDataPath } from '../src/main/identity';
+
+const APP_DATA_PATH = path.join('test-root', 'AppData', 'Roaming');
 
 class FakeApp implements BootstrapApp {
   readonly events: string[] = [];
@@ -17,7 +20,7 @@ class FakeApp implements BootstrapApp {
 
   getPath(name: 'appData'): string {
     this.events.push(`get:${name}`);
-    return 'C:\\Users\\test\\AppData\\Roaming';
+    return APP_DATA_PATH;
   }
 
   setPath(name: 'userData', value: string): void {
@@ -41,9 +44,7 @@ describe('application identity bootstrap', () => {
   });
 
   test('resolves the same explicit Murmur userData directory', () => {
-    expect(resolveUserDataPath('C:\\Users\\test\\AppData\\Roaming')).toBe(
-      'C:\\Users\\test\\AppData\\Roaming\\murmur'
-    );
+    expect(resolveUserDataPath(APP_DATA_PATH)).toBe(path.join(APP_DATA_PATH, 'murmur'));
   });
 
   test('locks and selects userData before application modules load', async () => {
@@ -61,7 +62,7 @@ describe('application identity bootstrap', () => {
     expect(fakeApp.events).toEqual([
       'lock',
       'get:appData',
-      'set:userData:C:\\Users\\test\\AppData\\Roaming\\murmur',
+      `set:userData:${path.join(APP_DATA_PATH, 'murmur')}`,
       'app-id:com.murmur.app',
       'load',
     ]);

--- a/app/tests/bootstrap.test.ts
+++ b/app/tests/bootstrap.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { bootstrapApplication, type BootstrapApp } from '../src/main/bootstrap-core';
+import { EVE_PRODUCT_NAME, MURMUR_IDENTITY, resolveUserDataPath } from '../src/main/identity';
+
+class FakeApp implements BootstrapApp {
+  readonly events: string[] = [];
+  lockGranted = true;
+
+  requestSingleInstanceLock(): boolean {
+    this.events.push('lock');
+    return this.lockGranted;
+  }
+
+  quit(): void {
+    this.events.push('quit');
+  }
+
+  getPath(name: 'appData'): string {
+    this.events.push(`get:${name}`);
+    return 'C:\\Users\\test\\AppData\\Roaming';
+  }
+
+  setPath(name: 'userData', value: string): void {
+    this.events.push(`set:${name}:${value}`);
+  }
+
+  setAppUserModelId(id: string): void {
+    this.events.push(`app-id:${id}`);
+  }
+}
+
+describe('application identity bootstrap', () => {
+  test('keeps the published Murmur identity active', () => {
+    expect(MURMUR_IDENTITY).toEqual({
+      productName: 'Murmur',
+      appId: 'com.murmur.app',
+      userDataDirectoryName: 'murmur',
+      nsisGuid: '0204d005-75b3-5b31-b1f6-ef2831e2b204',
+    });
+    expect(EVE_PRODUCT_NAME).toBe('Eve');
+  });
+
+  test('resolves the same explicit Murmur userData directory', () => {
+    expect(resolveUserDataPath('C:\\Users\\test\\AppData\\Roaming')).toBe(
+      'C:\\Users\\test\\AppData\\Roaming\\murmur'
+    );
+  });
+
+  test('locks and selects userData before application modules load', async () => {
+    const fakeApp = new FakeApp();
+
+    const loaded = await bootstrapApplication(
+      fakeApp,
+      async () => {
+        fakeApp.events.push('load');
+      },
+      'win32'
+    );
+
+    expect(loaded).toBeTrue();
+    expect(fakeApp.events).toEqual([
+      'lock',
+      'get:appData',
+      'set:userData:C:\\Users\\test\\AppData\\Roaming\\murmur',
+      'app-id:com.murmur.app',
+      'load',
+    ]);
+  });
+
+  test('does not select paths or load modules when another instance owns the lock', async () => {
+    const fakeApp = new FakeApp();
+    fakeApp.lockGranted = false;
+
+    const loaded = await bootstrapApplication(
+      fakeApp,
+      async () => {
+        fakeApp.events.push('load');
+      },
+      'win32'
+    );
+
+    expect(loaded).toBeFalse();
+    expect(fakeApp.events).toEqual(['lock', 'quit']);
+  });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory keeps only docs that still match the current codebase.
 
 - `architecture/adr-001-eve-application-identity-migration.md`: proposed fresh-profile, installer-compatibility, recovery, and acceptance design for the later Eve application rename.
 - `architecture/eve-identity-cutover-checklist.md`: exact file map, implementation gates, validation sequence, and remaining-work ledger for that cutover.
+- `architecture/eve-identity-gate-1-evidence.md`: published-installer hashes, frozen NSIS GUID derivation, and the outstanding clean-VM acceptance boundary.
 - `engineering/v0.6.3-release-case-study.md`: evidence-backed account of the Windows packaging and lifecycle work shipped through v0.6.3.
 - `protocol.md`: WebSocket audio/control/text frame specification used by app and server.
 - `benchmark-report.md`: Nemotron vs Whisper benchmark data that informed engine defaults.

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -151,10 +151,11 @@ These names are internal or compatibility surfaces. They are not evidence that p
 |---|---|---|
 | Repository detachment and rename | Complete | No |
 | Placement-ready repository documentation | Complete | No |
-| Fresh-profile ADR and cutover checklist | Current PR | Merge after review |
-| Confirm NSIS key from a clean published v0.6.3 install | Pending | Read-only test authorization and clean VM |
+| Fresh-profile ADR and cutover checklist | Complete in PR #14 | No |
+| Derive and cross-check the published v0.6.3 NSIS key | Complete; see Gate 1 evidence | No |
+| Confirm NSIS key from a clean published v0.6.3 install | Pending; no isolated VM is currently available | Clean VM |
 | Select final Eve data-root casing and AppUserModelID | Pending | Explicit decision before activation |
-| Compatibility-scaffolding implementation | Pending | Explicit implementation approval |
+| Compatibility-scaffolding implementation | Draft implementation in progress | Clean-VM gate before merge |
 | Fresh Eve profile implementation | Pending | Separate approval after scaffolding acceptance |
 | Visible installed-product rename | Pending | Separate approval after data isolation passes |
 | AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |

--- a/docs/architecture/eve-identity-gate-1-evidence.md
+++ b/docs/architecture/eve-identity-gate-1-evidence.md
@@ -1,0 +1,59 @@
+# Eve identity Gate 1 evidence
+
+## Purpose
+
+This record supports the compatibility-scaffolding gate in [ADR-001](adr-001-eve-application-identity-migration.md). It does not authorize the Eve data-path or visible-product cutover.
+
+## Published v0.6.3 assets
+
+The preserved files were matched byte-for-byte to the GitHub v0.6.3 release metadata on 2026-07-21.
+
+| Asset | Bytes | SHA-256 |
+|---|---:|---|
+| `latest.yml` | 564 | `b211cdb0322a0f6da01eee77921f6c6961735de59d4ffd8cacc31d9a3f7395a9` |
+| `murmur-0.6.3-x64.nsis.7z` | 2,034,188,308 | `0b557fde05853da1f7c0aef77cecbad1faf8c5fc9314457ea45119d3a69f4fbd` |
+| `Murmur.Web.Setup.0.6.3.exe` | 887,561 | `366088a4266f54ea7c39e2e7fd1fc7177cac46bf8a4b3f43d58a6d025e15cd33` |
+
+The published update manifest identifies version `0.6.3`, the same x64 package size and digest, and the historical Murmur artifact names. Historical assets remain immutable.
+
+## Installer identity derivation
+
+Published v0.6.3 uses:
+
+```text
+appId: com.murmur.app
+target: nsis-web
+electron-builder declaration: ^26.4.0
+electron-builder resolved version: 26.15.3
+explicit NSIS GUID: absent
+```
+
+The resolved Electron Builder 26.15.3 implementation derives the default NSIS GUID as UUID v5 of the application ID under namespace `50e065bc-3134-11e6-9bab-38c9862bdaf3`:
+
+```text
+UUIDv5("com.murmur.app", "50e065bc-3134-11e6-9bab-38c9862bdaf3")
+= 0204d005-75b3-5b31-b1f6-ef2831e2b204
+```
+
+That result exactly matches the observed HKCU uninstall key for the installed Murmur 0.6.2 build. Gate 1 freezes this value explicitly under `build.nsisWeb.guid`; it does not change the upgrade identity.
+
+The target-specific configuration also pins the existing Electron Builder defaults:
+
+```text
+oneClick: true
+deleteAppDataOnUninstall: false
+```
+
+## Acceptance still pending
+
+No Windows Sandbox, Hyper-V VM, VirtualBox, or VMware runner was available on the inspection machine. Therefore these claims remain deliberately unmade:
+
+- a clean published v0.6.3 installation was observed writing the derived key;
+- install-over-v0.6.3, repair, and uninstall behavior passed on a clean VM;
+- the nsis-web uninstaller was observed preserving controlled Eve and Murmur data fixtures.
+
+This compatibility-scaffolding change must remain unmerged until the clean-VM identity check is completed, or the project explicitly approves equivalent isolated evidence. The later visible Eve and data-root cutovers remain separately gated regardless.
+
+## Privacy boundary
+
+The inspection read release metadata and Windows uninstall metadata only. It did not read Murmur History, settings, hotwords, browser storage, credentials, logs, or diagnostic contents. It did not install or uninstall Murmur, write registry values, create Eve data, or modify either user-data root.

--- a/docs/architecture/eve-identity-gate-1-evidence.md
+++ b/docs/architecture/eve-identity-gate-1-evidence.md
@@ -44,16 +44,34 @@ oneClick: true
 deleteAppDataOnUninstall: false
 ```
 
-## Acceptance still pending
+## Host acceptance
 
-No Windows Sandbox, Hyper-V VM, VirtualBox, or VMware runner was available on the inspection machine. Therefore these claims remain deliberately unmade:
+Windows Sandbox failed at the host/VM connection layer with `0x80072746`, before it produced an installer result. After reviewing that limitation, the project explicitly approved an equivalent test on the Windows host. The test did not inspect personal data contents.
 
-- a clean published v0.6.3 installation was observed writing the derived key;
-- install-over-v0.6.3, repair, and uninstall behavior passed on a clean VM;
-- the nsis-web uninstaller was observed preserving controlled Eve and Murmur data fixtures.
+The candidate was built from commit `c613ed88b8de2c5e6d59fc7cbe024957f81ee2c3` with the complete published v0.6.3 Python and engine closure:
 
-This compatibility-scaffolding change must remain unmerged until the clean-VM identity check is completed, or the project explicitly approves equivalent isolated evidence. The later visible Eve and data-root cutovers remain separately gated regardless.
+| Candidate asset | Bytes | SHA-256 |
+|---|---:|---|
+| `Murmur Web Setup 0.6.3.exe` | 887,564 | `47df9c7726c7b14cc878790d74ad0a1ffc98654358697287af4437744e70f7f3` |
+| `murmur-0.6.3-x64.nsis.7z` | 2,034,067,298 | `c9811cb6e5c195d63bf86063d6f80ba22b542d6c7d5b8ee4fd38efa4b392f920` |
+| packaged `app.asar` | 11,157,398 | `4619cfeb93633106cc37b181906440c527b0ce770092fe1282aa365d96b69dc2` |
+
+The candidate payload was 115,697 bytes smaller than the published payload. Its unpacked server closure contained PyTorch, NeMo, CTranslate2, and faster-whisper.
+
+The following matrix passed on 2026-07-22:
+
+| Check | Evidence |
+|---|---|
+| Published baseline install | Published v0.6.3 installed as `Murmur 0.6.3` under uninstall key `0204d005-75b3-5b31-b1f6-ef2831e2b204`; application launch and dictation worked. |
+| Candidate repair/upgrade | Installing the same-version candidate replaced the installed `app.asar` with the candidate SHA-256 above while retaining the same display version and uninstall key. |
+| User-data preservation | `%APPDATA%\murmur` existed before and after candidate installation and uninstall. Contents were not inspected. |
+| Runtime behavior | Fast Dictation, Long Dictation, normal launch, and restart were manually accepted. |
+| Single-instance behavior | A second launch exited within ten seconds; the original five Electron processes remained responsive and the process count did not increase. |
+| Candidate uninstall | Registered silent current-user uninstall exited `0`, removed the program directory and uninstall key, and retained `%APPDATA%\murmur`. |
+| Stable restoration | The checksum-verified published installer restored v0.6.3. Installed `app.asar` SHA-256 returned to `98910f5cd2c3a9426ecd7850ee352e47f9c48fb00bb5eef526220660e69fc8fd`, and the application launched responsively. |
+
+This is proportionate evidence for the compatibility-only Gate 1 change. It is not clean-VM acceptance and does not authorize the later Eve visible-identity or data-root cutovers; those remain separately gated.
 
 ## Privacy boundary
 
-The inspection read release metadata and Windows uninstall metadata only. It did not read Murmur History, settings, hotwords, browser storage, credentials, logs, or diagnostic contents. It did not install or uninstall Murmur, write registry values, create Eve data, or modify either user-data root.
+The acceptance run read release metadata, installer fingerprints, executable metadata, process state, and Windows uninstall metadata. It installed and uninstalled Murmur only after explicit approval. It did not read Murmur History, settings, hotwords, browser storage, credentials, logs, or diagnostic contents; delete either user-data root; or create Eve data.

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -54,6 +54,38 @@ def test_electron_builder_windows_target_is_nsis_web() -> None:
     assert "nsis-web" in targets
 
 
+def test_nsis_web_identity_and_data_retention_are_explicit() -> None:
+    package_json = _load_package_json()
+    build = package_json.get("build", {})
+    nsis_web = build.get("nsisWeb", {})
+
+    assert build.get("appId") == "com.murmur.app"
+    assert build.get("productName") == "Murmur"
+    assert nsis_web == {
+        "guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204",
+        "oneClick": True,
+        "deleteAppDataOnUninstall": False,
+    }
+
+
+def test_main_build_enters_through_identity_bootstrap() -> None:
+    build_script = (ROOT / "app" / "scripts" / "build-main.js").read_text(
+        encoding="utf-8"
+    )
+    bootstrap = (ROOT / "app" / "src" / "main" / "bootstrap.ts").read_text(
+        encoding="utf-8"
+    )
+    bootstrap_core = (
+        ROOT / "app" / "src" / "main" / "bootstrap-core.ts"
+    ).read_text(encoding="utf-8")
+
+    assert "src/main/bootstrap.ts" in build_script
+    assert "requestSingleInstanceLock" in bootstrap_core
+    assert "setPath('userData'" in bootstrap_core
+    assert "import('./index.js')" in bootstrap
+    assert "await bootstrapApplication" in bootstrap
+
+
 def test_electron_builder_publish_includes_github() -> None:
     package_json = _load_package_json()
     publish = package_json.get("build", {}).get("publish")


### PR DESCRIPTION
## Summary

- freeze the published Murmur NSIS-web GUID and explicit no-delete one-click policy
- centralize the current identity and select the unchanged Murmur userData path before loading settings, History, or server modules
- preserve `Murmur`, `com.murmur.app`, `%APPDATA%\murmur`, executable names, release URLs, and all user data
- record exact v0.6.3 asset hashes, GUID derivation, and the outstanding clean-VM acceptance gate

## Validation

- `bun test tests/bootstrap.test.ts` — 4 passed
- dependency-free esbuild bundle/syntax check — passed
- `uv run --no-sync pytest tests/test_release_config.py tests/test_docs_consistency.py -q` — 15 passed
- `python scripts/version.py check` — passed
- `git diff --check` — passed

The full local app suite reached 61 passing tests but could not load `uiohook-napi` because app dependencies are intentionally not installed in this worktree. The production build likewise could not start locally without `esbuild`; GitHub CI is the authoritative dependency-installed build gate.

## Merge gate

This PR is intentionally a draft. Do not merge until an isolated clean Windows environment verifies the published v0.6.3 uninstall key and the compatibility build passes install/upgrade/repair/uninstall checks. No Windows Sandbox or VM was available on the inspection machine.

This PR does **not** activate Eve, create an Eve data directory, import or delete Murmur data, rename the executable, change the AppUserModelID, or modify releases/tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added identity-aware Electron bootstrap for user-data directory setup and Windows AppUserModelId initialization.
  * Centralized single-instance startup flow and dynamic application loading.
  * Updated Windows NSIS installation configuration (nsisWeb GUID, one-click install, retain app data on uninstall).
* **Documentation**
  * Added Gate 1 identity evidence documentation and refreshed the cutover checklist.
* **Tests**
  * Added startup/identity bootstrap tests and release-build configuration assertions, including entry-point wiring verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->