### PR TITLE
Activate isolated Eve fresh profile

### DIFF
--- a/app/scripts/clear-data.js
+++ b/app/scripts/clear-data.js
@@ -14,22 +14,22 @@ function getAppDataDir() {
     const home = homedir();
     const match = home.match(/\/mnt\/c\/Users\/([^/]+)/);
     if (match) {
-      return join('/mnt/c/Users', match[1], 'AppData/Roaming/murmur');
+      return join('/mnt/c/Users', match[1], 'AppData/Roaming/Eve');
     }
     // Fallback: try to find it from /mnt/c/Users
     const username = process.env.USER || process.env.USERNAME;
     if (username) {
-      return join('/mnt/c/Users', username, 'AppData/Roaming/murmur');
+      return join('/mnt/c/Users', username, 'AppData/Roaming/Eve');
     }
   }
 
   // Windows native or fallback
   if (process.env.APPDATA) {
-    return join(process.env.APPDATA, 'murmur');
+    return join(process.env.APPDATA, 'Eve');
   }
 
   // Linux/Mac fallback
-  return join(homedir(), '.config', 'murmur');
+  return join(homedir(), '.config', 'Eve');
 }
 
 const appDataDir = getAppDataDir();

--- a/app/src/main/bootstrap-core.ts
+++ b/app/src/main/bootstrap-core.ts
@@ -17,7 +17,7 @@ export type UserDataRootPreparer = (
 
 export interface BootstrapOptions {
   readonly platform?: NodeJS.Platform;
-  readonly userDataDirectoryName?: string;
+  readonly userDataDirectoryName: string;
   readonly prepareUserDataRoot?: UserDataRootPreparer;
 }
 
@@ -28,7 +28,7 @@ export interface BootstrapOptions {
 export async function bootstrapApplication(
   electronApp: BootstrapApp,
   loadApplication: ApplicationLoader,
-  options: BootstrapOptions = {}
+  options: BootstrapOptions
 ): Promise<boolean> {
   if (!electronApp.requestSingleInstanceLock()) {
     electronApp.quit();
@@ -36,11 +36,12 @@ export async function bootstrapApplication(
   }
 
   const appDataPath = electronApp.getPath('appData');
-  const directoryName =
-    options.userDataDirectoryName ?? MURMUR_IDENTITY.userDataDirectoryName;
   const prepareUserDataRoot =
     options.prepareUserDataRoot ?? prepareUserDataRootSync;
-  const userDataPath = prepareUserDataRoot(appDataPath, directoryName);
+  const userDataPath = prepareUserDataRoot(
+    appDataPath,
+    options.userDataDirectoryName
+  );
 
   electronApp.setPath('userData', userDataPath);
   electronApp.setPath('sessionData', userDataPath);

--- a/app/src/main/bootstrap-core.ts
+++ b/app/src/main/bootstrap-core.ts
@@ -1,14 +1,25 @@
 import { MURMUR_IDENTITY, resolveUserDataPath } from './identity.js';
+import { prepareUserDataRootSync } from './user-data-root.js';
 
 export interface BootstrapApp {
   requestSingleInstanceLock(): boolean;
   quit(): void;
   getPath(name: 'appData'): string;
-  setPath(name: 'userData', path: string): void;
+  setPath(name: 'userData' | 'sessionData', path: string): void;
   setAppUserModelId(id: string): void;
 }
 
 export type ApplicationLoader = () => Promise<unknown>;
+export type UserDataRootPreparer = (
+  appDataPath: string,
+  directoryName: string
+) => string;
+
+export interface BootstrapOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly userDataDirectoryName?: string;
+  readonly prepareUserDataRoot?: UserDataRootPreparer;
+}
 
 /**
  * Establish process and data identity before importing modules that construct
@@ -17,17 +28,24 @@ export type ApplicationLoader = () => Promise<unknown>;
 export async function bootstrapApplication(
   electronApp: BootstrapApp,
   loadApplication: ApplicationLoader,
-  platform: NodeJS.Platform = process.platform
+  options: BootstrapOptions = {}
 ): Promise<boolean> {
   if (!electronApp.requestSingleInstanceLock()) {
     electronApp.quit();
     return false;
   }
 
-  const userDataPath = resolveUserDataPath(electronApp.getPath('appData'));
-  electronApp.setPath('userData', userDataPath);
+  const appDataPath = electronApp.getPath('appData');
+  const directoryName =
+    options.userDataDirectoryName ?? MURMUR_IDENTITY.userDataDirectoryName;
+  const prepareUserDataRoot =
+    options.prepareUserDataRoot ?? prepareUserDataRootSync;
+  const userDataPath = prepareUserDataRoot(appDataPath, directoryName);
 
-  if (platform === 'win32') {
+  electronApp.setPath('userData', userDataPath);
+  electronApp.setPath('sessionData', userDataPath);
+
+  if ((options.platform ?? process.platform) === 'win32') {
     electronApp.setAppUserModelId(MURMUR_IDENTITY.appId);
   }
 

--- a/app/src/main/bootstrap-core.ts
+++ b/app/src/main/bootstrap-core.ts
@@ -1,4 +1,4 @@
-import { MURMUR_IDENTITY, resolveUserDataPath } from './identity.js';
+import { MURMUR_IDENTITY } from './identity.js';
 import { prepareUserDataRootSync } from './user-data-root.js';
 
 export interface BootstrapApp {
@@ -30,11 +30,6 @@ export async function bootstrapApplication(
   loadApplication: ApplicationLoader,
   options: BootstrapOptions
 ): Promise<boolean> {
-  if (!electronApp.requestSingleInstanceLock()) {
-    electronApp.quit();
-    return false;
-  }
-
   const appDataPath = electronApp.getPath('appData');
   const prepareUserDataRoot =
     options.prepareUserDataRoot ?? prepareUserDataRootSync;
@@ -45,6 +40,11 @@ export async function bootstrapApplication(
 
   electronApp.setPath('userData', userDataPath);
   electronApp.setPath('sessionData', userDataPath);
+
+  if (!electronApp.requestSingleInstanceLock()) {
+    electronApp.quit();
+    return false;
+  }
 
   if ((options.platform ?? process.platform) === 'win32') {
     electronApp.setAppUserModelId(MURMUR_IDENTITY.appId);

--- a/app/src/main/bootstrap.ts
+++ b/app/src/main/bootstrap.ts
@@ -1,8 +1,11 @@
 import { app, dialog } from 'electron';
 import { bootstrapApplication } from './bootstrap-core.js';
+import { EVE_USER_DATA_DIRECTORY_NAME } from './identity.js';
 
 try {
-  await bootstrapApplication(app, () => import('./index.js'));
+  await bootstrapApplication(app, () => import('./index.js'), {
+    userDataDirectoryName: EVE_USER_DATA_DIRECTORY_NAME,
+  });
 } catch {
   dialog.showErrorBox(
     'Murmur could not start',

--- a/app/src/main/bootstrap.ts
+++ b/app/src/main/bootstrap.ts
@@ -1,4 +1,12 @@
-import { app } from 'electron';
+import { app, dialog } from 'electron';
 import { bootstrapApplication } from './bootstrap-core.js';
 
-await bootstrapApplication(app, () => import('./index.js'));
+try {
+  await bootstrapApplication(app, () => import('./index.js'));
+} catch {
+  dialog.showErrorBox(
+    'Murmur could not start',
+    'Murmur could not initialize its application data folder. Verify that the folder is a regular directory and that your account can write to it, then try again.'
+  );
+  app.quit();
+}

--- a/app/src/main/bootstrap.ts
+++ b/app/src/main/bootstrap.ts
@@ -1,12 +1,17 @@
 import { app, dialog } from 'electron';
 import { bootstrapApplication } from './bootstrap-core.js';
 import { EVE_USER_DATA_DIRECTORY_NAME } from './identity.js';
+import { createLogger } from './lib/logger.js';
+
+const log = createLogger('Bootstrap');
 
 try {
   await bootstrapApplication(app, () => import('./index.js'), {
     userDataDirectoryName: EVE_USER_DATA_DIRECTORY_NAME,
   });
-} catch {
+} catch (error: unknown) {
+  const cause = error instanceof Error ? error : new Error(String(error));
+  log.error('Application data bootstrap failed', { error: cause });
   dialog.showErrorBox(
     'Murmur could not start',
     'Murmur could not initialize its application data folder. Verify that the folder is a regular directory and that your account can write to it, then try again.'

--- a/app/src/main/identity.ts
+++ b/app/src/main/identity.ts
@@ -26,7 +26,7 @@ export const EVE_PRODUCT_NAME = 'Eve' as const;
 
 export function resolveUserDataPath(
   appDataPath: string,
-  identity: ApplicationIdentity = MURMUR_IDENTITY
+  directoryName: string = MURMUR_IDENTITY.userDataDirectoryName
 ): string {
-  return path.join(appDataPath, identity.userDataDirectoryName);
+  return path.join(appDataPath, directoryName);
 }

--- a/app/src/main/identity.ts
+++ b/app/src/main/identity.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 export interface ApplicationIdentity {
   readonly productName: string;
   readonly appId: string;
@@ -8,8 +6,8 @@ export interface ApplicationIdentity {
 }
 
 /**
- * Published Murmur identity. These values remain active during compatibility
- * scaffolding so installer, application, and user-data behavior do not change.
+ * Published Murmur installer and application identity. Gate 2 retains these
+ * compatibility values while selecting the Eve user-data root separately.
  */
 export const MURMUR_IDENTITY = {
   productName: 'Murmur',
@@ -24,10 +22,3 @@ export const MURMUR_IDENTITY = {
  */
 export const EVE_PRODUCT_NAME = 'Eve' as const;
 export const EVE_USER_DATA_DIRECTORY_NAME = 'Eve' as const;
-
-export function resolveUserDataPath(
-  appDataPath: string,
-  directoryName: string
-): string {
-  return path.join(appDataPath, directoryName);
-}

--- a/app/src/main/identity.ts
+++ b/app/src/main/identity.ts
@@ -27,7 +27,7 @@ export const EVE_USER_DATA_DIRECTORY_NAME = 'Eve' as const;
 
 export function resolveUserDataPath(
   appDataPath: string,
-  directoryName: string = MURMUR_IDENTITY.userDataDirectoryName
+  directoryName: string
 ): string {
   return path.join(appDataPath, directoryName);
 }

--- a/app/src/main/identity.ts
+++ b/app/src/main/identity.ts
@@ -23,6 +23,7 @@ export const MURMUR_IDENTITY = {
  * until a later, separately approved cutover.
  */
 export const EVE_PRODUCT_NAME = 'Eve' as const;
+export const EVE_USER_DATA_DIRECTORY_NAME = 'Eve' as const;
 
 export function resolveUserDataPath(
   appDataPath: string,

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, screen } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, screen } from 'electron';
 import { createOverlayWindow, showOverlay, hideOverlay, positionOverlayOnActiveDisplay } from './windows/overlay.js';
 import { createMainWindow, showMainWindow } from './windows/main.js';
 import { setupHotkeyService } from './services/hotkey.js';
@@ -521,7 +521,7 @@ function setupDisplayChangeHandlers() {
   });
 }
 
-app.whenReady().then(async () => {
+async function startApplication(): Promise<void> {
   log.info('Murmur starting');
 
   // Initialize history service early
@@ -628,7 +628,18 @@ app.whenReady().then(async () => {
       });
     }
   });
-});
+}
+
+void app.whenReady()
+  .then(startApplication)
+  .catch(() => {
+    log.error('Application startup failed');
+    dialog.showErrorBox(
+      'Murmur could not start',
+      'Murmur could not initialize its application data. Verify that the application data folder is accessible and valid, then try again.'
+    );
+    app.quit();
+  });
 
 app.on('will-quit', async (event) => {
   // Prevent immediate quit to allow async cleanup

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -632,8 +632,9 @@ async function startApplication(): Promise<void> {
 
 void app.whenReady()
   .then(startApplication)
-  .catch(() => {
-    log.error('Application startup failed');
+  .catch((error: unknown) => {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    log.error('Application startup failed', { error: cause });
     dialog.showErrorBox(
       'Murmur could not start',
       'Murmur could not initialize its application data. Verify that the application data folder is accessible and valid, then try again.'

--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -18,15 +18,7 @@ import {
 } from '../services/server-settings.js';
 import { startHotkeyCapture, cancelHotkeyCapture } from '../services/hotkey.js';
 import { formatHotkey } from '../services/keycodes.js';
-
-/**
- * Apply the launch-on-boot setting using Electron's login item API.
- */
-function applyLaunchOnBoot(enabled: boolean): void {
-  app.setLoginItemSettings({
-    openAtLogin: enabled,
-  });
-}
+import { validateLaunchOnBootUpdate } from '../login-item-policy.js';
 
 let historyServiceRef: HistoryService | null = null;
 let serverManagerRef: ServerManager | null = null;
@@ -39,10 +31,6 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
   if (serverManager) {
     serverManagerRef = serverManager;
   }
-
-  // Sync launch-on-boot setting with OS on startup
-  const settings = getSettings();
-  applyLaunchOnBoot(settings.launchOnBoot);
 
   // Handle clipboard copy requests
   ipcMain.on(IPC_CHANNELS.COMMAND_COPY_TO_CLIPBOARD, (_event, text: string) => {
@@ -72,12 +60,11 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
   ipcMain.handle(
     IPC_CHANNELS.UPDATE_SETTING,
     async (_event, key: keyof Settings, value: Settings[keyof Settings]) => {
-      updateSetting(key, value);
-
-      // Apply launch-on-boot immediately when changed
       if (key === 'launchOnBoot') {
-        applyLaunchOnBoot(value as boolean);
+        validateLaunchOnBootUpdate(value as boolean);
       }
+
+      updateSetting(key, value);
 
       if (key === 'useExternalServer' && value === true && serverManagerRef) {
         await serverManagerRef.stop();

--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -61,7 +61,7 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
     IPC_CHANNELS.UPDATE_SETTING,
     async (_event, key: keyof Settings, value: Settings[keyof Settings]) => {
       if (key === 'launchOnBoot') {
-        validateLaunchOnBootUpdate(value as boolean);
+        validateLaunchOnBootUpdate(value);
       }
 
       updateSetting(key, value);

--- a/app/src/main/login-item-policy.ts
+++ b/app/src/main/login-item-policy.ts
@@ -1,6 +1,9 @@
 export const LOGIN_ITEM_CUTOVER_DEFERRED = 'LOGIN_ITEM_CUTOVER_DEFERRED';
 
-export function validateLaunchOnBootUpdate(enabled: boolean): void {
+export function validateLaunchOnBootUpdate(enabled: unknown): asserts enabled is boolean {
+  if (typeof enabled !== 'boolean') {
+    throw new TypeError('launchOnBoot must be a boolean');
+  }
   if (enabled) {
     throw new Error(LOGIN_ITEM_CUTOVER_DEFERRED);
   }

--- a/app/src/main/login-item-policy.ts
+++ b/app/src/main/login-item-policy.ts
@@ -1,0 +1,7 @@
+export const LOGIN_ITEM_CUTOVER_DEFERRED = 'LOGIN_ITEM_CUTOVER_DEFERRED';
+
+export function validateLaunchOnBootUpdate(enabled: boolean): void {
+  if (enabled) {
+    throw new Error(LOGIN_ITEM_CUTOVER_DEFERRED);
+  }
+}

--- a/app/src/main/services/server-health.ts
+++ b/app/src/main/services/server-health.ts
@@ -2,6 +2,7 @@ import type {
   EngineStatus,
   ModelDownloadState,
   ServerDiagnostics,
+  ServerPidFile,
 } from '../../shared/types.js';
 
 export interface HealthState {
@@ -12,8 +13,38 @@ export interface HealthState {
   engineStatus?: EngineStatus;
 }
 
+export interface ServerProcessSnapshot {
+  processId: number;
+  creationTimeMs: number;
+  executablePath: string;
+  commandLine: string;
+}
+
 const MODEL_DOWNLOAD_STATUSES = new Set(['missing', 'partial', 'downloading', 'ready', 'error']);
 const MODEL_DOWNLOAD_PHASES = new Set(['checking', 'downloading', 'loading', 'ready', 'error']);
+
+export function parseServerPidFile(data: unknown): ServerPidFile {
+  if (!data || typeof data !== 'object') {
+    throw new Error('PID file has invalid structure');
+  }
+  const value = data as Record<string, unknown>;
+  if (
+    !Number.isInteger(value.pid)
+    || Number(value.pid) <= 0
+    || !Number.isInteger(value.port)
+    || Number(value.port) <= 0
+    || Number(value.port) > 65535
+    || !Number.isFinite(value.startedAt)
+    || Number(value.startedAt) <= 0
+  ) {
+    throw new Error('PID file has invalid structure');
+  }
+  return {
+    pid: Number(value.pid),
+    port: Number(value.port),
+    startedAt: Number(value.startedAt),
+  };
+}
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
@@ -105,4 +136,37 @@ export function isMurmurServerCommandLine(commandLine: string): boolean {
     /python(?:w)?\.exe/.test(normalized) &&
     /(?:^|\s|["'])[^"']*\\server\\src\\main\.py(?:["']|\s|$)/.test(normalized)
   );
+}
+
+function normalizeWindowsPath(value: string): string {
+  return value.replaceAll('/', '\\').replace(/^"|"$/g, '').toLowerCase();
+}
+
+export function isOwnedMurmurServerProcess(
+  snapshot: ServerProcessSnapshot,
+  pid: number,
+  recordedStartedAt: number
+): boolean {
+  if (
+    snapshot.processId !== pid ||
+    !Number.isFinite(snapshot.creationTimeMs) ||
+    !Number.isFinite(recordedStartedAt)
+  ) {
+    return false;
+  }
+
+  const executablePath = normalizeWindowsPath(snapshot.executablePath);
+  if (!/\\python(?:w)?\.exe$/.test(executablePath)) {
+    return false;
+  }
+
+  const commandLine = snapshot.commandLine.replaceAll('/', '\\').toLowerCase();
+  const executablePrefix = commandLine.startsWith(`${executablePath} `)
+    || commandLine.startsWith(`"${executablePath}" `);
+  if (!executablePrefix || !isMurmurServerCommandLine(snapshot.commandLine)) {
+    return false;
+  }
+
+  const startDeltaMs = recordedStartedAt - snapshot.creationTimeMs;
+  return startDeltaMs >= -5000 && startDeltaMs <= 60000;
 }

--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -15,9 +15,11 @@ import type {
 } from '../../shared/types.js';
 import { createLogger } from '../lib/logger.js';
 import {
-  isMurmurServerCommandLine,
+  isOwnedMurmurServerProcess,
+  parseServerPidFile,
   parseHealthyResponse,
   type HealthState,
+  type ServerProcessSnapshot,
 } from './server-health.js';
 
 const log = createLogger('ServerManager');
@@ -57,25 +59,19 @@ export class ServerManager {
   /**
    * Read and parse the PID file.
    */
-  private readPidFile(): ServerPidFile | null {
+  private readPidFile(strict = true): ServerPidFile | null {
     const pidPath = this.getPidFilePath();
     try {
-      if (!fs.existsSync(pidPath)) {
+      const content = fs.readFileSync(pidPath, 'utf-8');
+      return parseServerPidFile(JSON.parse(content));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return null;
       }
-      const content = fs.readFileSync(pidPath, 'utf-8');
-      const data = JSON.parse(content) as ServerPidFile;
-      if (
-        typeof data.pid === 'number' &&
-        typeof data.port === 'number' &&
-        typeof data.startedAt === 'number'
-      ) {
-        return data;
-      }
-      log.warn('PID file has invalid structure');
-      return null;
-    } catch (error) {
       log.warn('Failed to read PID file', { error: error as Error });
+      if (strict) {
+        throw new Error('Server PID state is invalid or inaccessible');
+      }
       return null;
     }
   }
@@ -169,7 +165,7 @@ export class ServerManager {
     return true;
   }
 
-  private async isOwnedServerProcess(pid: number): Promise<boolean> {
+  private async isOwnedServerProcess(pid: number, recordedStartedAt: number): Promise<boolean> {
     if (this.childProcess?.pid === pid) return true;
     if (process.platform !== 'win32') return false;
 
@@ -180,12 +176,34 @@ export class ServerManager {
           '-NoProfile',
           '-NonInteractive',
           '-Command',
-          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`,
+          `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; if ($p) { [pscustomobject]@{ ProcessId = $p.ProcessId; CreationTimeMs = ([DateTimeOffset]$p.CreationDate).ToUnixTimeMilliseconds(); ExecutablePath = $p.ExecutablePath; CommandLine = $p.CommandLine } | ConvertTo-Json -Compress }`,
         ],
         { encoding: 'utf8', timeout: 3000, windowsHide: true }
       );
-      const commandLine = stdout.trim();
-      return isMurmurServerCommandLine(commandLine);
+      const snapshot = JSON.parse(stdout.trim()) as {
+        ProcessId?: unknown;
+        CreationTimeMs?: unknown;
+        ExecutablePath?: unknown;
+        CommandLine?: unknown;
+      };
+      if (
+        typeof snapshot.ProcessId !== 'number'
+        || typeof snapshot.CreationTimeMs !== 'number'
+        || typeof snapshot.ExecutablePath !== 'string'
+        || typeof snapshot.CommandLine !== 'string'
+      ) {
+        return false;
+      }
+      return isOwnedMurmurServerProcess(
+        {
+          processId: snapshot.ProcessId,
+          creationTimeMs: snapshot.CreationTimeMs,
+          executablePath: snapshot.ExecutablePath,
+          commandLine: snapshot.CommandLine,
+        } satisfies ServerProcessSnapshot,
+        pid,
+        recordedStartedAt
+      );
     } catch (error) {
       log.warn('Could not verify stale server process ownership', {
         pid,
@@ -319,7 +337,15 @@ export class ServerManager {
       return false;
     }
 
-    // Check health
+    if (!(await this.isOwnedServerProcess(pidData.pid, pidData.startedAt))) {
+      log.warn('PID file belongs to an unverified process; refusing adoption', {
+        pid: pidData.pid,
+      });
+      this.updateStatus('error', 'Server process ownership could not be verified');
+      return false;
+    }
+
+    // Check health only after process ownership is proven.
     const health = await this.getHealthState(pidData.port);
     if (!health.healthy) {
       log.warn('Server process alive but not responding to health checks');
@@ -436,6 +462,14 @@ export class ServerManager {
     // Check for existing server first
     const existingPid = this.readPidFile();
     if (existingPid && this.isProcessAlive(existingPid.pid)) {
+      if (!(await this.isOwnedServerProcess(existingPid.pid, existingPid.startedAt))) {
+        log.warn('PID file belongs to an unverified process; refusing replacement', {
+          pid: existingPid.pid,
+        });
+        this.updateStatus('error', 'Server process ownership could not be verified');
+        return;
+      }
+
       const health = await this.getHealthState(existingPid.port);
       if (health.healthy) {
         log.info('Found existing healthy server, adopting');
@@ -450,21 +484,19 @@ export class ServerManager {
         this.startHealthPolling(existingPid.port);
         return;
       }
-      // A stale PID can be reused by an unrelated process. Only terminate a
-      // command line that still identifies itself as Murmur's Python entry.
-      if (await this.isOwnedServerProcess(existingPid.pid)) {
-        log.warn('Existing Murmur server is not responding; terminating it');
-        try {
-          process.kill(existingPid.pid, 'SIGTERM');
-          await this.waitForProcessExit(existingPid.pid, 5000);
-        } catch {
-          // Ignore errors, proceed with starting a new server.
+      log.warn('Existing owned Murmur server is not responding; terminating it');
+      try {
+        process.kill(existingPid.pid, 'SIGTERM');
+        if (!(await this.waitForProcessExit(existingPid.pid, 5000))) {
+          this.updateStatus('error', 'Existing server did not stop');
+          return;
         }
-      } else {
-        log.warn('Stale PID belongs to an unrelated process; refusing to terminate it', {
-          pid: existingPid.pid,
-        });
+      } catch {
+        this.updateStatus('error', 'Existing server could not be stopped');
+        return;
       }
+      this.cleanupStalePidFile();
+    } else if (existingPid) {
       this.cleanupStalePidFile();
     }
 
@@ -594,7 +626,7 @@ export class ServerManager {
   ): Promise<ServerPidFile | null> {
     const startTime = Date.now();
     while (Date.now() - startTime < timeoutMs) {
-      const pidData = this.readPidFile();
+      const pidData = this.readPidFile(false);
       if (
         pidData &&
         (expectedStartedAfterMs === undefined || pidData.startedAt >= expectedStartedAfterMs)
@@ -700,7 +732,7 @@ export class ServerManager {
         }
       } else if (this.pidFile?.pid) {
         // No child process ref but have PID (shouldn't happen but handle it)
-        if (await this.isOwnedServerProcess(this.pidFile.pid)) {
+        if (await this.isOwnedServerProcess(this.pidFile.pid, this.pidFile.startedAt)) {
           try {
             process.kill(this.pidFile.pid, 'SIGTERM');
           } catch {

--- a/app/src/main/user-data-root.ts
+++ b/app/src/main/user-data-root.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+function normalizeCanonicalPath(value: string): string {
+  return path
+    .normalize(value)
+    .replace(/^\\\\\?\\/, '')
+    .replace(/[\\/]+$/, '')
+    .toLowerCase();
+}
+
+function assertDirectoryName(directoryName: string): void {
+  if (
+    !directoryName ||
+    directoryName === '.' ||
+    directoryName === '..' ||
+    path.basename(directoryName) !== directoryName
+  ) {
+    throw new Error('Invalid application data directory name');
+  }
+}
+
+/**
+ * Create and validate the selected user-data root synchronously so Electron
+ * cannot become ready before userData and sessionData are overridden.
+ */
+export function prepareUserDataRootSync(
+  appDataPath: string,
+  directoryName: string
+): string {
+  assertDirectoryName(directoryName);
+
+  const canonicalAppDataPath = fs.realpathSync.native(appDataPath);
+  const userDataPath = path.join(appDataPath, directoryName);
+  fs.mkdirSync(userDataPath, { recursive: true });
+
+  const stats = fs.lstatSync(userDataPath);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error('Application data path is not a regular directory');
+  }
+
+  const canonicalUserDataPath = fs.realpathSync.native(userDataPath);
+  const expectedCanonicalPath = path.join(canonicalAppDataPath, directoryName);
+  if (
+    normalizeCanonicalPath(canonicalUserDataPath) !==
+    normalizeCanonicalPath(expectedCanonicalPath)
+  ) {
+    throw new Error('Application data directory redirects outside its expected location');
+  }
+
+  const probePath = path.join(
+    userDataPath,
+    `.profile-write-probe-${process.pid}-${randomUUID()}`
+  );
+  const descriptor = fs.openSync(probePath, 'wx');
+  try {
+    // Opening the exclusive probe is the write-access check.
+  } finally {
+    try {
+      fs.closeSync(descriptor);
+    } finally {
+      fs.unlinkSync(probePath);
+    }
+  }
+
+  return userDataPath;
+}

--- a/app/src/main/user-data-root.ts
+++ b/app/src/main/user-data-root.ts
@@ -2,6 +2,24 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 
+export interface UserDataRootFileSystem {
+  realpath(path: string): string;
+  mkdir(path: string): void;
+  lstat(path: string): Pick<fs.Stats, 'isDirectory' | 'isSymbolicLink'>;
+  open(path: string): number;
+  close(descriptor: number): void;
+  unlink(path: string): void;
+}
+
+const nodeFileSystem: UserDataRootFileSystem = {
+  realpath: (value) => fs.realpathSync.native(value),
+  mkdir: (value) => fs.mkdirSync(value, { recursive: true }),
+  lstat: (value) => fs.lstatSync(value),
+  open: (value) => fs.openSync(value, 'wx'),
+  close: (descriptor) => fs.closeSync(descriptor),
+  unlink: (value) => fs.unlinkSync(value),
+};
+
 function normalizeCanonicalPath(value: string): string {
   return path
     .normalize(value)
@@ -27,20 +45,21 @@ function assertDirectoryName(directoryName: string): void {
  */
 export function prepareUserDataRootSync(
   appDataPath: string,
-  directoryName: string
+  directoryName: string,
+  fileSystem: UserDataRootFileSystem = nodeFileSystem
 ): string {
   assertDirectoryName(directoryName);
 
-  const canonicalAppDataPath = fs.realpathSync.native(appDataPath);
+  const canonicalAppDataPath = fileSystem.realpath(appDataPath);
   const userDataPath = path.join(appDataPath, directoryName);
-  fs.mkdirSync(userDataPath, { recursive: true });
+  fileSystem.mkdir(userDataPath);
 
-  const stats = fs.lstatSync(userDataPath);
+  const stats = fileSystem.lstat(userDataPath);
   if (!stats.isDirectory() || stats.isSymbolicLink()) {
     throw new Error('Application data path is not a regular directory');
   }
 
-  const canonicalUserDataPath = fs.realpathSync.native(userDataPath);
+  const canonicalUserDataPath = fileSystem.realpath(userDataPath);
   const expectedCanonicalPath = path.join(canonicalAppDataPath, directoryName);
   if (
     normalizeCanonicalPath(canonicalUserDataPath) !==
@@ -53,14 +72,14 @@ export function prepareUserDataRootSync(
     userDataPath,
     `.profile-write-probe-${process.pid}-${randomUUID()}`
   );
-  const descriptor = fs.openSync(probePath, 'wx');
+  const descriptor = fileSystem.open(probePath);
   try {
     // Opening the exclusive probe is the write-access check.
   } finally {
     try {
-      fs.closeSync(descriptor);
+      fileSystem.close(descriptor);
     } finally {
-      fs.unlinkSync(probePath);
+      fileSystem.unlink(probePath);
     }
   }
 

--- a/app/src/renderer/app/NOT_IMPLEMENTED.md
+++ b/app/src/renderer/app/NOT_IMPLEMENTED.md
@@ -23,7 +23,9 @@ When a feature is fully implemented:
 ## Settings - Behavior Section
 - [x] **Auto-copy**: Persisted and used in pipeline.ts.
 - [x] **Auto-paste**: Persisted and used in pipeline.ts.
-- [ ] **Launch on boot**: Toggle works locally but doesn't do anything. Needs: electron `app.setLoginItemSettings()` + settings persistence.
+- [ ] **Launch on boot**: Gate 2 intentionally rejects and visibly reverts enable attempts
+  without making a login-item or registry write. Eve registration belongs to the later
+  visible identity/AppUserModelID cutover.
 - [ ] **Start minimized**: Toggle works locally but doesn't do anything. Needs: main window logic + settings persistence.
 
 ## Settings - Server Section

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -292,6 +292,17 @@
     window.murmurMain.updateSetting(key, value);
   }
 
+  async function updateLaunchOnBoot(enabled: boolean) {
+    const previous = settings.launchOnBoot;
+    settings.launchOnBoot = enabled;
+    try {
+      await window.murmurMain.updateSetting('launchOnBoot', enabled);
+    } catch {
+      settings.launchOnBoot = previous;
+      toast('Launch on boot is unavailable in this compatibility build', 'error');
+    }
+  }
+
   function updateHotwordsCsl(value: string) {
     settings.hotwordsCsl = value;
     window.murmurMain.updateSetting('hotwordsCsl', value);
@@ -707,7 +718,7 @@
       <SettingsRow label="Launch on boot" description="Start application when system starts">
         <Toggle
           enabled={settings.launchOnBoot}
-          onchange={(v) => updateSetting('launchOnBoot', v)}
+          onchange={(v) => void updateLaunchOnBoot(v)}
           label="Launch on boot"
         />
       </SettingsRow>

--- a/app/tests/bootstrap.test.ts
+++ b/app/tests/bootstrap.test.ts
@@ -50,7 +50,9 @@ describe('application identity bootstrap', () => {
   });
 
   test('resolves the same explicit Murmur userData directory', () => {
-    expect(resolveUserDataPath(APP_DATA_PATH)).toBe(path.join(APP_DATA_PATH, 'murmur'));
+    expect(resolveUserDataPath(APP_DATA_PATH, MURMUR_IDENTITY.userDataDirectoryName)).toBe(
+      path.join(APP_DATA_PATH, 'murmur')
+    );
   });
 
   test('locks and selects userData before application modules load', async () => {
@@ -94,6 +96,7 @@ describe('application identity bootstrap', () => {
       },
       {
         platform: 'win32',
+        userDataDirectoryName: EVE_USER_DATA_DIRECTORY_NAME,
         prepareUserDataRoot: (appDataPath, directoryName) =>
           resolveUserDataPath(appDataPath, directoryName),
       }
@@ -114,6 +117,7 @@ describe('application identity bootstrap', () => {
         },
         {
           platform: 'win32',
+          userDataDirectoryName: EVE_USER_DATA_DIRECTORY_NAME,
           prepareUserDataRoot: () => {
             fakeApp.events.push('prepare:failed');
             throw new Error('write denied');

--- a/app/tests/bootstrap.test.ts
+++ b/app/tests/bootstrap.test.ts
@@ -23,7 +23,7 @@ class FakeApp implements BootstrapApp {
     return APP_DATA_PATH;
   }
 
-  setPath(name: 'userData', value: string): void {
+  setPath(name: 'userData' | 'sessionData', value: string): void {
     this.events.push(`set:${name}:${value}`);
   }
 
@@ -55,14 +55,22 @@ describe('application identity bootstrap', () => {
       async () => {
         fakeApp.events.push('load');
       },
-      'win32'
+      {
+        platform: 'win32',
+        prepareUserDataRoot: (appDataPath, directoryName) => {
+          fakeApp.events.push(`prepare:${directoryName}`);
+          return resolveUserDataPath(appDataPath, directoryName);
+        },
+      }
     );
 
     expect(loaded).toBeTrue();
     expect(fakeApp.events).toEqual([
       'lock',
       'get:appData',
+      'prepare:murmur',
       `set:userData:${path.join(APP_DATA_PATH, 'murmur')}`,
+      `set:sessionData:${path.join(APP_DATA_PATH, 'murmur')}`,
       'app-id:com.murmur.app',
       'load',
     ]);
@@ -77,10 +85,40 @@ describe('application identity bootstrap', () => {
       async () => {
         fakeApp.events.push('load');
       },
-      'win32'
+      {
+        platform: 'win32',
+        prepareUserDataRoot: (appDataPath, directoryName) =>
+          resolveUserDataPath(appDataPath, directoryName),
+      }
     );
 
     expect(loaded).toBeFalse();
     expect(fakeApp.events).toEqual(['lock', 'quit']);
+  });
+
+  test('does not set Electron paths or load modules when root preparation fails', async () => {
+    const fakeApp = new FakeApp();
+
+    await expect(
+      bootstrapApplication(
+        fakeApp,
+        async () => {
+          fakeApp.events.push('load');
+        },
+        {
+          platform: 'win32',
+          prepareUserDataRoot: () => {
+            fakeApp.events.push('prepare:failed');
+            throw new Error('write denied');
+          },
+        }
+      )
+    ).rejects.toThrow('write denied');
+
+    expect(fakeApp.events).toEqual([
+      'lock',
+      'get:appData',
+      'prepare:failed',
+    ]);
   });
 });

--- a/app/tests/bootstrap.test.ts
+++ b/app/tests/bootstrap.test.ts
@@ -5,7 +5,6 @@ import {
   EVE_PRODUCT_NAME,
   EVE_USER_DATA_DIRECTORY_NAME,
   MURMUR_IDENTITY,
-  resolveUserDataPath,
 } from '../src/main/identity';
 
 const APP_DATA_PATH = path.join('test-root', 'AppData', 'Roaming');
@@ -49,13 +48,7 @@ describe('application identity bootstrap', () => {
     expect(EVE_USER_DATA_DIRECTORY_NAME).toBe('Eve');
   });
 
-  test('resolves the same explicit Murmur userData directory', () => {
-    expect(resolveUserDataPath(APP_DATA_PATH, MURMUR_IDENTITY.userDataDirectoryName)).toBe(
-      path.join(APP_DATA_PATH, 'murmur')
-    );
-  });
-
-  test('locks and selects userData before application modules load', async () => {
+  test('selects Eve paths before locking and loading application modules', async () => {
     const fakeApp = new FakeApp();
 
     const loaded = await bootstrapApplication(
@@ -68,24 +61,24 @@ describe('application identity bootstrap', () => {
         userDataDirectoryName: EVE_USER_DATA_DIRECTORY_NAME,
         prepareUserDataRoot: (appDataPath, directoryName) => {
           fakeApp.events.push(`prepare:${directoryName}`);
-          return resolveUserDataPath(appDataPath, directoryName);
+          return path.join(appDataPath, directoryName);
         },
       }
     );
 
     expect(loaded).toBeTrue();
     expect(fakeApp.events).toEqual([
-      'lock',
       'get:appData',
       'prepare:Eve',
       `set:userData:${path.join(APP_DATA_PATH, 'Eve')}`,
       `set:sessionData:${path.join(APP_DATA_PATH, 'Eve')}`,
+      'lock',
       'app-id:com.murmur.app',
       'load',
     ]);
   });
 
-  test('does not select paths or load modules when another instance owns the lock', async () => {
+  test('selects Eve paths but does not load modules when another Eve instance owns the lock', async () => {
     const fakeApp = new FakeApp();
     fakeApp.lockGranted = false;
 
@@ -98,12 +91,18 @@ describe('application identity bootstrap', () => {
         platform: 'win32',
         userDataDirectoryName: EVE_USER_DATA_DIRECTORY_NAME,
         prepareUserDataRoot: (appDataPath, directoryName) =>
-          resolveUserDataPath(appDataPath, directoryName),
+          path.join(appDataPath, directoryName),
       }
     );
 
     expect(loaded).toBeFalse();
-    expect(fakeApp.events).toEqual(['lock', 'quit']);
+    expect(fakeApp.events).toEqual([
+      'get:appData',
+      `set:userData:${path.join(APP_DATA_PATH, 'Eve')}`,
+      `set:sessionData:${path.join(APP_DATA_PATH, 'Eve')}`,
+      'lock',
+      'quit',
+    ]);
   });
 
   test('does not set Electron paths or load modules when root preparation fails', async () => {
@@ -127,7 +126,6 @@ describe('application identity bootstrap', () => {
     ).rejects.toThrow('write denied');
 
     expect(fakeApp.events).toEqual([
-      'lock',
       'get:appData',
       'prepare:failed',
     ]);

--- a/app/tests/bootstrap.test.ts
+++ b/app/tests/bootstrap.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
 import { bootstrapApplication, type BootstrapApp } from '../src/main/bootstrap-core';
-import { EVE_PRODUCT_NAME, MURMUR_IDENTITY, resolveUserDataPath } from '../src/main/identity';
+import {
+  EVE_PRODUCT_NAME,
+  EVE_USER_DATA_DIRECTORY_NAME,
+  MURMUR_IDENTITY,
+  resolveUserDataPath,
+} from '../src/main/identity';
 
 const APP_DATA_PATH = path.join('test-root', 'AppData', 'Roaming');
 
@@ -41,6 +46,7 @@ describe('application identity bootstrap', () => {
       nsisGuid: '0204d005-75b3-5b31-b1f6-ef2831e2b204',
     });
     expect(EVE_PRODUCT_NAME).toBe('Eve');
+    expect(EVE_USER_DATA_DIRECTORY_NAME).toBe('Eve');
   });
 
   test('resolves the same explicit Murmur userData directory', () => {
@@ -57,6 +63,7 @@ describe('application identity bootstrap', () => {
       },
       {
         platform: 'win32',
+        userDataDirectoryName: EVE_USER_DATA_DIRECTORY_NAME,
         prepareUserDataRoot: (appDataPath, directoryName) => {
           fakeApp.events.push(`prepare:${directoryName}`);
           return resolveUserDataPath(appDataPath, directoryName);
@@ -68,9 +75,9 @@ describe('application identity bootstrap', () => {
     expect(fakeApp.events).toEqual([
       'lock',
       'get:appData',
-      'prepare:murmur',
-      `set:userData:${path.join(APP_DATA_PATH, 'murmur')}`,
-      `set:sessionData:${path.join(APP_DATA_PATH, 'murmur')}`,
+      'prepare:Eve',
+      `set:userData:${path.join(APP_DATA_PATH, 'Eve')}`,
+      `set:sessionData:${path.join(APP_DATA_PATH, 'Eve')}`,
       'app-id:com.murmur.app',
       'load',
     ]);

--- a/app/tests/eve-profile-boundary.test.ts
+++ b/app/tests/eve-profile-boundary.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { prepareUserDataRootSync } from '../src/main/user-data-root';
+
+const temporaryRoots: string[] = [];
+
+function createFixtureRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), 'murmur-profile-boundary-'));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('user-data root preparation', () => {
+  test('creates a regular direct child and removes its write probe', () => {
+    const fixture = createFixtureRoot();
+    const appData = path.join(fixture, 'Roaming');
+    mkdirSync(appData);
+
+    const userData = prepareUserDataRootSync(appData, 'murmur');
+
+    expect(userData).toBe(path.join(appData, 'murmur'));
+    expect(readdirSync(userData)).toEqual([]);
+  });
+
+  test('allows a legitimately redirected appData parent', () => {
+    const fixture = createFixtureRoot();
+    const actualAppData = path.join(fixture, 'actual-roaming');
+    const redirectedAppData = path.join(fixture, 'redirected-roaming');
+    mkdirSync(actualAppData);
+    symlinkSync(
+      actualAppData,
+      redirectedAppData,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    );
+
+    const userData = prepareUserDataRootSync(redirectedAppData, 'murmur');
+
+    expect(userData).toBe(path.join(redirectedAppData, 'murmur'));
+    expect(readdirSync(path.join(actualAppData, 'murmur'))).toEqual([]);
+  });
+
+  test('rejects a userData root that is a file', () => {
+    const fixture = createFixtureRoot();
+    const appData = path.join(fixture, 'Roaming');
+    mkdirSync(appData);
+    writeFileSync(path.join(appData, 'murmur'), 'not a directory');
+
+    expect(() => prepareUserDataRootSync(appData, 'murmur')).toThrow();
+  });
+
+  test('rejects a userData root redirected to a controlled legacy fixture', () => {
+    const fixture = createFixtureRoot();
+    const appData = path.join(fixture, 'Roaming');
+    const controlledLegacy = path.join(fixture, 'controlled-legacy');
+    mkdirSync(appData);
+    mkdirSync(controlledLegacy);
+    symlinkSync(
+      controlledLegacy,
+      path.join(appData, 'murmur'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    );
+
+    expect(() => prepareUserDataRootSync(appData, 'murmur')).toThrow(
+      /regular directory|redirects outside/
+    );
+    expect(readdirSync(controlledLegacy)).toEqual([]);
+  });
+});

--- a/app/tests/eve-profile-boundary.test.ts
+++ b/app/tests/eve-profile-boundary.test.ts
@@ -15,6 +15,8 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildSync } from 'esbuild';
 import {
   prepareUserDataRootSync,
   type UserDataRootFileSystem,
@@ -22,6 +24,7 @@ import {
 import { EVE_USER_DATA_DIRECTORY_NAME } from '../src/main/identity';
 
 const temporaryRoots: string[] = [];
+const appRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
 function createFixtureRoot(): string {
   const root = mkdtempSync(path.join(tmpdir(), 'murmur-profile-boundary-'));
@@ -36,6 +39,174 @@ afterEach(() => {
 });
 
 describe('user-data root preparation', () => {
+  test('sets controlled Eve paths before a real Electron singleton lock', () => {
+    if (process.platform !== 'win32') return;
+
+    const fixture = createFixtureRoot();
+    const appData = path.join(fixture, 'Roaming');
+    const localAppData = path.join(fixture, 'Local');
+    const userProfile = path.join(fixture, 'Profile');
+    const temp = path.join(fixture, 'Temp');
+    const legacyRoot = path.join(appData, 'murmur');
+    const legacySentinel = path.join(legacyRoot, 'legacy-sentinel.txt');
+    const bundlePath = path.join(fixture, 'bootstrap-core.cjs');
+    const runnerPath = path.join(fixture, 'electron-bootstrap-smoke.cjs');
+    const resultPath = path.join(fixture, 'electron-bootstrap-result.json');
+    const preBootstrapUserData = path.join(fixture, 'PreBootstrapUserData');
+    const electronPath = path.join(
+      appRoot,
+      'node_modules',
+      'electron',
+      'dist',
+      'electron.exe'
+    );
+
+    mkdirSync(legacyRoot, { recursive: true });
+    mkdirSync(localAppData);
+    mkdirSync(userProfile);
+    mkdirSync(temp);
+    writeFileSync(legacySentinel, 'controlled legacy data');
+
+    buildSync({
+      entryPoints: [path.join(appRoot, 'src', 'main', 'bootstrap-core.ts')],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      target: 'node20',
+      format: 'cjs',
+      logLevel: 'silent',
+    });
+
+    writeFileSync(
+      runnerPath,
+      `
+const fs = require('node:fs');
+const { app } = require('electron');
+const { bootstrapApplication } = require(${JSON.stringify(bundlePath)});
+
+app.setPath('appData', ${JSON.stringify(appData)});
+app.setName('Murmur');
+const events = [];
+const electronApp = {
+  getPath(name) {
+    const value = app.getPath(name);
+    events.push(\`get:\${name}:\${value}\`);
+    return value;
+  },
+  setPath(name, value) {
+    app.setPath(name, value);
+    events.push(\`set:\${name}:\${value}\`);
+  },
+  requestSingleInstanceLock() {
+    events.push(
+      \`lock:userData:\${app.getPath('userData')}:sessionData:\${app.getPath('sessionData')}\`
+    );
+    return app.requestSingleInstanceLock();
+  },
+  quit() {
+    events.push('quit');
+    app.quit();
+  },
+  setAppUserModelId(id) {
+    events.push(\`app-id:\${id}\`);
+    app.setAppUserModelId(id);
+  },
+};
+
+(async () => {
+  try {
+    const loaded = await bootstrapApplication(
+      electronApp,
+      async () => {
+        events.push('load');
+      },
+      { platform: 'win32', userDataDirectoryName: 'Eve' }
+    );
+    fs.writeFileSync(
+      ${JSON.stringify(resultPath)},
+      JSON.stringify({
+        loaded,
+        events,
+        userData: app.getPath('userData'),
+        sessionData: app.getPath('sessionData'),
+        lockHeld: app.hasSingleInstanceLock(),
+        electronVersion: process.versions.electron,
+      })
+    );
+    app.releaseSingleInstanceLock();
+    app.exit(0);
+  } catch (error) {
+    fs.writeFileSync(
+      ${JSON.stringify(resultPath)},
+      JSON.stringify({ events, error: String(error && error.stack ? error.stack : error) })
+    );
+    if (app.hasSingleInstanceLock()) app.releaseSingleInstanceLock();
+    app.exit(1);
+  }
+})();
+`,
+      'utf8'
+    );
+
+    const result = Bun.spawnSync({
+      cmd: [
+        electronPath,
+        `--user-data-dir=${preBootstrapUserData}`,
+        runnerPath,
+      ],
+      cwd: fixture,
+      env: {
+        APPDATA: appData,
+        LOCALAPPDATA: localAppData,
+        USERPROFILE: userProfile,
+        HOME: userProfile,
+        TEMP: temp,
+        TMP: temp,
+        PATH: process.env.PATH,
+        PATHEXT: process.env.PATHEXT,
+        SystemRoot: process.env.SystemRoot,
+        windir: process.env.windir,
+        ComSpec: process.env.ComSpec,
+        ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+      },
+      timeout: 30_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.success).toBeTrue();
+    expect(result.exitCode).toBe(0);
+
+    const smoke = JSON.parse(readFileSync(resultPath, 'utf8')) as {
+      loaded: boolean;
+      events: string[];
+      userData: string;
+      sessionData: string;
+      lockHeld: boolean;
+      electronVersion: string;
+    };
+    const eveRoot = path.join(appData, 'Eve');
+    const { electronVersion, ...smokeState } = smoke;
+
+    expect(electronVersion).toMatch(/^40\./);
+    expect(smokeState).toEqual({
+      loaded: true,
+      events: [
+        `get:appData:${appData}`,
+        `set:userData:${eveRoot}`,
+        `set:sessionData:${eveRoot}`,
+        `lock:userData:${eveRoot}:sessionData:${eveRoot}`,
+        'app-id:com.murmur.app',
+        'load',
+      ],
+      userData: eveRoot,
+      sessionData: eveRoot,
+      lockHeld: true,
+    });
+    expect(readFileSync(legacySentinel, 'utf8')).toBe('controlled legacy data');
+    expect(readdirSync(legacyRoot)).toEqual(['legacy-sentinel.txt']);
+  });
+
   test('creates a regular direct child and removes its write probe', () => {
     const fixture = createFixtureRoot();
     const appData = path.join(fixture, 'Roaming');

--- a/app/tests/eve-profile-boundary.test.ts
+++ b/app/tests/eve-profile-boundary.test.ts
@@ -39,9 +39,7 @@ afterEach(() => {
 });
 
 describe('user-data root preparation', () => {
-  test('sets controlled Eve paths before a real Electron singleton lock', () => {
-    if (process.platform !== 'win32') return;
-
+  test.skipIf(process.platform !== 'win32')('sets controlled Eve paths before a real Electron singleton lock', () => {
     const fixture = createFixtureRoot();
     const appData = path.join(fixture, 'Roaming');
     const localAppData = path.join(fixture, 'Local');

--- a/app/tests/eve-profile-boundary.test.ts
+++ b/app/tests/eve-profile-boundary.test.ts
@@ -2,14 +2,24 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import {
   mkdtempSync,
   mkdirSync,
+  lstatSync,
+  openSync,
+  closeSync,
+  readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { prepareUserDataRootSync } from '../src/main/user-data-root';
+import {
+  prepareUserDataRootSync,
+  type UserDataRootFileSystem,
+} from '../src/main/user-data-root';
+import { EVE_USER_DATA_DIRECTORY_NAME } from '../src/main/identity';
 
 const temporaryRoots: string[] = [];
 
@@ -31,10 +41,58 @@ describe('user-data root preparation', () => {
     const appData = path.join(fixture, 'Roaming');
     mkdirSync(appData);
 
-    const userData = prepareUserDataRootSync(appData, 'murmur');
+    const userData = prepareUserDataRootSync(appData, EVE_USER_DATA_DIRECTORY_NAME);
 
-    expect(userData).toBe(path.join(appData, 'murmur'));
+    expect(userData).toBe(path.join(appData, 'Eve'));
     expect(readdirSync(userData)).toEqual([]);
+  });
+
+  test('records no access to a controlled Murmur sibling', () => {
+    const fixture = createFixtureRoot();
+    const appData = path.join(fixture, 'Roaming');
+    const legacyRoot = path.join(appData, 'murmur');
+    const sentinelPath = path.join(legacyRoot, 'legacy-sentinel.txt');
+    mkdirSync(legacyRoot, { recursive: true });
+    writeFileSync(sentinelPath, 'controlled legacy data');
+    const accesses: string[] = [];
+
+    const tracedFileSystem: UserDataRootFileSystem = {
+      realpath: (value) => {
+        accesses.push(value);
+        return realpathSync.native(value);
+      },
+      mkdir: (value) => {
+        accesses.push(value);
+        mkdirSync(value, { recursive: true });
+      },
+      lstat: (value) => {
+        accesses.push(value);
+        return lstatSync(value);
+      },
+      open: (value) => {
+        accesses.push(value);
+        return openSync(value, 'wx');
+      },
+      close: (descriptor) => closeSync(descriptor),
+      unlink: (value) => {
+        accesses.push(value);
+        unlinkSync(value);
+      },
+    };
+
+    const userData = prepareUserDataRootSync(
+      appData,
+      EVE_USER_DATA_DIRECTORY_NAME,
+      tracedFileSystem
+    );
+
+    expect(userData).toBe(path.join(appData, 'Eve'));
+    expect(
+      accesses.filter(
+        (value) => value === legacyRoot || value.startsWith(`${legacyRoot}${path.sep}`)
+      )
+    ).toEqual([]);
+    expect(readFileSync(sentinelPath, 'utf8')).toBe('controlled legacy data');
   });
 
   test('allows a legitimately redirected appData parent', () => {
@@ -48,19 +106,19 @@ describe('user-data root preparation', () => {
       process.platform === 'win32' ? 'junction' : 'dir'
     );
 
-    const userData = prepareUserDataRootSync(redirectedAppData, 'murmur');
+    const userData = prepareUserDataRootSync(redirectedAppData, EVE_USER_DATA_DIRECTORY_NAME);
 
-    expect(userData).toBe(path.join(redirectedAppData, 'murmur'));
-    expect(readdirSync(path.join(actualAppData, 'murmur'))).toEqual([]);
+    expect(userData).toBe(path.join(redirectedAppData, 'Eve'));
+    expect(readdirSync(path.join(actualAppData, 'Eve'))).toEqual([]);
   });
 
   test('rejects a userData root that is a file', () => {
     const fixture = createFixtureRoot();
     const appData = path.join(fixture, 'Roaming');
     mkdirSync(appData);
-    writeFileSync(path.join(appData, 'murmur'), 'not a directory');
+    writeFileSync(path.join(appData, 'Eve'), 'not a directory');
 
-    expect(() => prepareUserDataRootSync(appData, 'murmur')).toThrow();
+    expect(() => prepareUserDataRootSync(appData, EVE_USER_DATA_DIRECTORY_NAME)).toThrow();
   });
 
   test('rejects a userData root redirected to a controlled legacy fixture', () => {
@@ -71,11 +129,11 @@ describe('user-data root preparation', () => {
     mkdirSync(controlledLegacy);
     symlinkSync(
       controlledLegacy,
-      path.join(appData, 'murmur'),
+      path.join(appData, 'Eve'),
       process.platform === 'win32' ? 'junction' : 'dir'
     );
 
-    expect(() => prepareUserDataRootSync(appData, 'murmur')).toThrow(
+    expect(() => prepareUserDataRootSync(appData, EVE_USER_DATA_DIRECTORY_NAME)).toThrow(
       /regular directory|redirects outside/
     );
     expect(readdirSync(controlledLegacy)).toEqual([]);

--- a/app/tests/login-item-boundary.test.ts
+++ b/app/tests/login-item-boundary.test.ts
@@ -12,4 +12,10 @@ describe('launch-on-login Gate 2 boundary', () => {
   test('allows the fresh-profile disabled value without an OS write', () => {
     expect(() => validateLaunchOnBootUpdate(false)).not.toThrow();
   });
+
+  test('rejects non-boolean IPC values before settings persistence', () => {
+    for (const value of [undefined, null, 0, 1, '', 'false', {}, []]) {
+      expect(() => validateLaunchOnBootUpdate(value)).toThrow(TypeError);
+    }
+  });
 });

--- a/app/tests/login-item-boundary.test.ts
+++ b/app/tests/login-item-boundary.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  LOGIN_ITEM_CUTOVER_DEFERRED,
+  validateLaunchOnBootUpdate,
+} from '../src/main/login-item-policy';
+
+describe('launch-on-login Gate 2 boundary', () => {
+  test('rejects enabling launch-on-login before settings persistence', () => {
+    expect(() => validateLaunchOnBootUpdate(true)).toThrow(LOGIN_ITEM_CUTOVER_DEFERRED);
+  });
+
+  test('allows the fresh-profile disabled value without an OS write', () => {
+    expect(() => validateLaunchOnBootUpdate(false)).not.toThrow();
+  });
+});

--- a/app/tests/server-health.test.ts
+++ b/app/tests/server-health.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  isOwnedMurmurServerProcess,
   isMurmurServerCommandLine,
   parseHealthyResponse,
+  parseServerPidFile,
 } from '../src/main/services/server-health';
 
 describe('server health parsing', () => {
@@ -79,6 +81,10 @@ describe('server health parsing', () => {
 });
 
 describe('server process ownership', () => {
+  const executablePath = 'C:\\Program Files\\Murmur\\resources\\server\\.runtime\\python.exe';
+  const commandLine =
+    `"${executablePath}" "C:\\Program Files\\Murmur\\resources\\server\\src\\main.py"`;
+
   test('recognizes the packaged Murmur Python entry point', () => {
     expect(
       isMurmurServerCommandLine(
@@ -90,5 +96,89 @@ describe('server process ownership', () => {
   test('rejects unrelated Python processes', () => {
     expect(isMurmurServerCommandLine('python.exe C:\\work\\unrelated.py')).toBe(false);
     expect(isMurmurServerCommandLine('notepad.exe')).toBe(false);
+  });
+
+  test('accepts an exact live-process snapshot matching the PID record epoch', () => {
+    expect(
+      isOwnedMurmurServerProcess(
+        {
+          processId: 1234,
+          creationTimeMs: 10_000,
+          executablePath,
+          commandLine,
+        },
+        1234,
+        10_250
+      )
+    ).toBe(true);
+  });
+
+  test('rejects stale or reused PID records', () => {
+    const snapshot = {
+      processId: 1234,
+      creationTimeMs: 100_000,
+      executablePath,
+      commandLine,
+    };
+
+    expect(isOwnedMurmurServerProcess(snapshot, 4321, 100_250)).toBe(false);
+    expect(isOwnedMurmurServerProcess(snapshot, 1234, 10_000)).toBe(false);
+    expect(isOwnedMurmurServerProcess(snapshot, 1234, 200_000)).toBe(false);
+  });
+
+  test('rejects unowned executable and command-line combinations', () => {
+    expect(
+      isOwnedMurmurServerProcess(
+        {
+          processId: 1234,
+          creationTimeMs: 10_000,
+          executablePath: 'C:\\Windows\\System32\\notepad.exe',
+          commandLine,
+        },
+        1234,
+        10_250
+      )
+    ).toBe(false);
+    expect(
+      isOwnedMurmurServerProcess(
+        {
+          processId: 1234,
+          creationTimeMs: 10_000,
+          executablePath,
+          commandLine: `"${executablePath}" C:\\work\\unrelated.py`,
+        },
+        1234,
+        10_250
+      )
+    ).toBe(false);
+  });
+
+  test('accepts a rapid restart only when the new PID epoch matches', () => {
+    const restarted = {
+      processId: 1234,
+      creationTimeMs: 20_000,
+      executablePath,
+      commandLine,
+    };
+
+    expect(isOwnedMurmurServerProcess(restarted, 1234, 10_250)).toBe(false);
+    expect(isOwnedMurmurServerProcess(restarted, 1234, 20_100)).toBe(true);
+  });
+});
+
+describe('server PID state', () => {
+  test('accepts a complete bounded PID record', () => {
+    expect(parseServerPidFile({ pid: 1234, port: 51717, startedAt: 10_000 })).toEqual({
+      pid: 1234,
+      port: 51717,
+      startedAt: 10_000,
+    });
+  });
+
+  test('fails closed on malformed PID state', () => {
+    expect(() => parseServerPidFile(null)).toThrow();
+    expect(() => parseServerPidFile({ pid: 0, port: 51717, startedAt: 10_000 })).toThrow();
+    expect(() => parseServerPidFile({ pid: 1234, port: 65536, startedAt: 10_000 })).toThrow();
+    expect(() => parseServerPidFile({ pid: 1234, port: 51717 })).toThrow();
   });
 });

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Proposed. This document authorizes no runtime, installer, registry, or data-path changes.
+Accepted for staged implementation. Gate 1 compatibility scaffolding merged in PR #15 at
+`5e5b3a3c458d56279e8ece37c51827ce60cfa7a0`. Gate 2 implementation is authorized only
+for the clean Eve data boundary described here; packaging, host installation, registry
+changes, visible renaming, publication, and merge remain separately gated.
 
 The companion [cutover checklist](eve-identity-cutover-checklist.md) maps this decision to exact files, release gates, checks, and remaining work.
 
@@ -26,7 +29,10 @@ The project targets Windows and is maintained by a small team. A direct, explici
 
 ## Current identity inventory
 
-This inventory is based on `trunk` at `fc40ad5a6b37f31b861bd904a0e106813fc81eb8` and a read-only inspection of an installed Windows build. Paths use environment-variable notation and contain no user-specific directory.
+This inventory was established at `fc40ad5a6b37f31b861bd904a0e106813fc81eb8`
+and reconciled after Gate 1 merged at
+`5e5b3a3c458d56279e8ece37c51827ce60cfa7a0`. Paths use environment-variable
+notation and contain no user-specific directory.
 
 ### Installer and Windows identity
 
@@ -53,12 +59,13 @@ Electron Builder documents that NSIS derives a deterministic GUID from `appId` w
 | Window state | `%APPDATA%\murmur\internal.json` | Do not read or copy. |
 | History and Insights | `%APPDATA%\murmur\history.db` plus WAL/SHM when present | Do not open, copy, merge, or index. |
 | Server settings | `%APPDATA%\murmur\server-settings.json` | Do not import. This prevents transfer of external-server details or other saved configuration. |
-| Server PID | `%APPDATA%\murmur\server.pid` | Do not migrate. It may be inspected only to prevent an old owned server from conflicting with Eve startup. A recorded process must pass command-line ownership verification before Eve adopts, stops, or otherwise trusts it, even when the recorded port responds as healthy. |
+| Server PID | `%APPDATA%\murmur\server.pid` | Do not read or migrate. Gate 2 performs zero legacy-root access, including no legacy PID safety check. Eve trusts only its own PID record after process ownership and creation-epoch verification. |
 | Paste helpers | `%APPDATA%\murmur\paste-helper.vbs`, `paste-sendinput.ps1` | Do not copy; Eve regenerates its own helpers. |
 | Chromium storage and caches | `Local Storage`, `Network`, `Cache`, `GPUCache`, and related entries | Do not read or copy. This prevents accidental transfer of cookies, browser state, or cached data. |
 | Diagnostic traces | for example `hotkey-trace.log` | Do not read or copy. |
 
-The complete `%APPDATA%\murmur` directory remains untouched. Eve will use a distinct root such as `%APPDATA%\Eve`, with the final casing and constant approved during implementation.
+The complete `%APPDATA%\murmur` directory remains untouched and inactive. The approved
+Gate 2 root is exactly `%APPDATA%\Eve`.
 
 Electron documents `userData` as an app-name-derived directory that also contains Chromium-managed state. Eve must set its explicit path before any module constructs Electron Store or calls a service that uses `app.getPath('userData')`. See Electron's [app path documentation](https://www.electronjs.org/docs/latest/api/app#appgetpathname).
 
@@ -85,7 +92,9 @@ Eve may reuse an already verified standard model cache to avoid a multi-gigabyte
 
 A read-only machine audit found three historical entries named `Murmur`, `electron.app.Murmur`, and `com.murmur.app`, pointing at an installed executable and different unpacked candidates. Eve must not import the old `launchOnBoot` setting, so it starts with launch-on-login disabled. The cutover must still neutralize stale known Murmur registrations safely.
 
-The implementation must:
+Gate 2 makes no login-item API or registry write, including no disabling write. An attempt
+to enable launch-on-login is rejected before persistence, the visible toggle is reverted,
+and an error is shown. The later visible-identity/AppUserModelID gates must:
 
 1. enumerate through Electron's supported login-item API where possible;
 2. remove only registrations whose names are in an exact compatibility allowlist and whose normalized paths match the published Murmur installation being upgraded;
@@ -126,7 +135,10 @@ This is the smallest safe implementation PR. It changes no visible product or da
 - Do not test for or inspect Murmur settings, History, Chromium state, or diagnostics.
 - Initialize Eve settings, window state, History, server settings, PID file, and generated helpers from clean defaults.
 - If the Eve directory exists, use it normally. If it is malformed or inaccessible, stop with repair guidance; do not fall back to Murmur data.
-- Permit only a narrow legacy PID ownership check when needed to prevent two managed transcription servers from conflicting. Before adopting a process from the recorded PID and port, require the existing command-line ownership proof. Refuse to adopt or terminate a stale or reused PID owned by another process.
+- Perform zero access to the legacy Murmur root, including no legacy PID read.
+- Before adopting or terminating a process referenced by Eve's own PID file, require PID,
+  executable, command-line, and process-creation-epoch ownership proof. Refuse stale,
+  reused, malformed, or unowned records even when the recorded port responds as healthy.
 - Leave `%APPDATA%\murmur` byte-for-byte untouched.
 
 ### Stage C: visible Eve identity with stable installer continuity
@@ -190,7 +202,8 @@ After the compatibility window, internal `MURMUR_*`, Python package, preload bri
 - Eve creates a distinct settings file and empty History database.
 - Existing valid Eve data is reused without consulting Murmur.
 - Malformed or read-only Eve data produces repair guidance without Murmur fallback.
-- Process/file tracing confirms Eve does not open Murmur personal files; the only permitted legacy-root access is the separately tested `server.pid` ownership check.
+- Process/file tracing confirms Eve does not open any path under the controlled Murmur
+  root. No legacy-root exception is permitted.
 - Migration and startup logs contain no transcript, settings, credential, token, device-label, or personal-path values.
 
 ### Startup and lifecycle
@@ -241,17 +254,13 @@ Until a later implementation phase is approved:
 - do not combine visual redesign, signing, thin-client packaging, ASR model work, or dependency upgrades with identity changes;
 - do not rename internal preload bridges or `MURMUR_*` variables for cosmetic consistency.
 
-## First implementation PR after approval
+## Implementation progress
 
-The smallest safe PR is **identity compatibility scaffolding only**:
-
-1. add typed constants for current and proposed identities;
-2. add a bootstrap/userData resolver that still selects the current Murmur path;
-3. freeze the clean-install-verified `build.nsisWeb.guid` and explicitly set `build.nsisWeb.oneClick: true` plus `deleteAppDataOnUninstall: false`;
-4. add configuration, bootstrap-order, and path-selection tests;
-5. prove that v0.6.3 userData, installer names, executable, startup behavior, and release artifacts remain unchanged.
-
-It must not import data, create the Eve data directory, or display Eve inside the installed application.
+Gate 1 compatibility scaffolding is complete in merged PR #15. Gate 2 is a separate,
+test-only compatibility PR that activates `%APPDATA%\Eve` before importing data consumers
+while retaining all published Murmur product and installer identities. Gate 2 must remain
+draft until automated Gate A passes and must not merge until the separately approved,
+disposable-account/VM Gate B matrix and privacy-safe filesystem trace pass.
 
 ## Consequences
 

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -256,11 +256,12 @@ Until a later implementation phase is approved:
 
 ## Implementation progress
 
-Gate 1 compatibility scaffolding is complete in merged PR #15. Gate 2 is a separate,
-test-only compatibility PR that activates `%APPDATA%\Eve` before importing data consumers
-while retaining all published Murmur product and installer identities. Gate 2 must remain
-draft until automated Gate A passes and must not merge until the separately approved,
-disposable-account/VM Gate B matrix and privacy-safe filesystem trace pass.
+Gate 1 compatibility scaffolding is complete in merged PR #15. Gate 2 is a separate
+compatibility PR that activates `%APPDATA%\Eve` before importing data consumers while
+retaining all published Murmur product and installer identities. Its automated Gate A and
+approved Gate B package/lifecycle acceptance are recorded in the companion evidence.
+Filesystem path tracing is explicitly out of scope for this gate: its absence limits the
+available evidence but is not a draft, readiness, or merge criterion.
 
 ## Consequences
 

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -163,7 +163,7 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Select final Eve data-root casing | Complete: exact `%APPDATA%\Eve` | No |
 | Select final AppUserModelID | Pending; Gate 4 only | Separate approval |
 | Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
-| Fresh Eve profile implementation | Gate A passes on `codex/eve-fresh-profile-gate-2`; Gate B candidate Fast/Long smoke, repair, normal uninstall preservation, and rollback evidence captured; path tracing is an out-of-scope evidence limitation | Fresh CI and substantive review before Ready |
+| Fresh Eve profile implementation | Gate A passes on `codex/eve-fresh-profile-gate-2`; Gate B candidate Fast/Long smoke, repair, normal uninstall preservation, and rollback evidence captured; path tracing is an out-of-scope evidence limitation | Fresh CI and substantive review passed; merge remains separately approved |
 | Visible installed-product rename | Pending | Separate approval after data isolation passes |
 | AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |
 | Visual identity and homepage | Pending | Later design phase |

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -162,7 +162,7 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Select final Eve data-root casing | Complete: exact `%APPDATA%\Eve` | No |
 | Select final AppUserModelID | Pending; Gate 4 only | Separate approval |
 | Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
-| Fresh Eve profile implementation | Gate A implementation in progress on `codex/eve-fresh-profile-gate-2`; packaged Gate B pending | Separate approval for Gate B |
+| Fresh Eve profile implementation | Gate A passes on `codex/eve-fresh-profile-gate-2`; Gate B candidate launch/rollback evidence captured; path tracing is an out-of-scope evidence limitation, while same-version repair did not pass | Successful supported repair check before Ready |
 | Visible installed-product rename | Pending | Separate approval after data isolation passes |
 | AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |
 | Visual identity and homepage | Pending | Later design phase |

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -66,9 +66,10 @@ This group owns mutable state. The fresh-profile PR must not include visible ren
 | `server/src/pidfile.py` and `server/justfile` | Standalone fallback paths use `murmur` | Keep compatibility fallbacks unless a separately tested Eve override is passed by the app. |
 | `server/src/config.py` | Accepts `MURMUR_SETTINGS_FILE` | Keep the environment contract; the Electron launcher supplies the new Eve file path. |
 
-Exit condition: traced first launch performs zero access against the controlled Murmur
-root, with no legacy PID exception. Eve starts with defaults and empty History, and both
-directories survive uninstall.
+Exit condition: available static, controlled-fixture, and packaged runtime evidence
+shows no legacy PID exception; filesystem path tracing is explicitly out of scope for
+this gate. Eve starts with defaults and empty History, and both directories survive a
+normal candidate uninstall.
 
 Focused lifecycle tests must cover a stale PID file, a PID reused by an unrelated process, a healthy endpoint whose recorded PID is not owned, and a verified owned server. No unrelated process may be adopted or terminated.
 
@@ -126,7 +127,8 @@ These names are internal or compatibility surfaces. They are not evidence that p
 2. Merge compatibility scaffolding with no behavior change.
 3. Build and install that bridge on a clean VM and over published v0.6.2/v0.6.3.
 4. Implement the fresh Eve data root without visible rename.
-5. Trace filesystem access and prove Murmur personal files are not opened.
+5. Capture the approved boundary evidence. Filesystem path tracing is explicitly out of
+   scope for this gate and must not be represented as a pass requirement.
 6. Change visible product/installer names while preserving the explicit NSIS GUID.
 7. Repair exact known startup entries and leave unknown entries untouched.
 8. Run the complete upgrade, clean-install, repair, uninstall, and rollback matrix.
@@ -145,8 +147,7 @@ These names are internal or compatibility surfaces. They are not evidence that p
 - nsis-web uninstall regression proving both Eve and Murmur data roots survive;
 - exact pre/post registry, shortcut, install-directory, and data-root comparison;
 - on controlled fixtures, confirmation that `%APPDATA%\murmur` sentinel hashes are
-  unchanged; in a disposable Windows account/VM, use a privacy-normalized filesystem
-  trace to prove the candidate never opens the controlled legacy root. Never trace or
+  unchanged. Filesystem path tracing is out of scope for this gate; never trace or
   inspect a real user's Murmur contents;
 - confirmation that no release, tag, or historical asset changed.
 
@@ -162,7 +163,7 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Select final Eve data-root casing | Complete: exact `%APPDATA%\Eve` | No |
 | Select final AppUserModelID | Pending; Gate 4 only | Separate approval |
 | Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
-| Fresh Eve profile implementation | Gate A passes on `codex/eve-fresh-profile-gate-2`; Gate B candidate launch/rollback evidence captured; path tracing is an out-of-scope evidence limitation, while same-version repair did not pass | Successful supported repair check before Ready |
+| Fresh Eve profile implementation | Gate A passes on `codex/eve-fresh-profile-gate-2`; Gate B candidate Fast/Long smoke, repair, normal uninstall preservation, and rollback evidence captured; path tracing is an out-of-scope evidence limitation | Fresh CI and substantive review before Ready |
 | Visible installed-product rename | Pending | Separate approval after data isolation passes |
 | AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |
 | Visual identity and homepage | Pending | Later design phase |

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -60,13 +60,15 @@ This group owns mutable state. The fresh-profile PR must not include visible ren
 |---|---|---|
 | `app/src/main/services/settings.ts` | Constructs `settings.json` and `internal.json` stores at module load | Initialize only after bootstrap selects Eve userData. Do not read legacy JSON. |
 | `app/src/main/services/history.ts` | Opens `history.db` under userData | Create a new empty Eve database. Never open legacy History. |
-| `app/src/main/services/server-manager.ts` | Uses userData for `server.pid` and `server-settings.json` | Use Eve paths. Allow only a narrow legacy PID ownership check if required for process safety. Require command-line ownership proof before adopting a healthy recorded process; refuse stale or unrelated PID reuse. |
+| `app/src/main/services/server-manager.ts` | Uses userData for `server.pid` and `server-settings.json` | Use Eve paths supplied through the existing app-side overrides. Do not read the legacy PID. Require PID, executable, command-line, and creation-epoch ownership proof before adopting or terminating a process referenced by Eve's PID file. |
 | `app/src/main/services/clipboard.ts` | Writes paste helper scripts under userData | Generate new Eve helpers. Do not copy old scripts. |
 | `app/scripts/clear-data.js` | Targets the Murmur directory | Replace with an Eve-specific development helper. It must never target both roots. |
 | `server/src/pidfile.py` and `server/justfile` | Standalone fallback paths use `murmur` | Keep compatibility fallbacks unless a separately tested Eve override is passed by the app. |
 | `server/src/config.py` | Accepts `MURMUR_SETTINGS_FILE` | Keep the environment contract; the Electron launcher supplies the new Eve file path. |
 
-Exit condition: traced first launch performs no read or write against Murmur personal files; the only permitted access is the bounded legacy `server.pid` ownership check. Eve starts with defaults and empty History, and both directories survive uninstall.
+Exit condition: traced first launch performs zero access against the controlled Murmur
+root, with no legacy PID exception. Eve starts with defaults and empty History, and both
+directories survive uninstall.
 
 Focused lifecycle tests must cover a stale PID file, a PID reused by an unrelated process, a healthy endpoint whose recorded PID is not owned, and a verified owned server. No unrelated process may be adopted or terminated.
 
@@ -142,7 +144,10 @@ These names are internal or compatibility surfaces. They are not evidence that p
 - clean Windows VM acceptance when installer or identity changes;
 - nsis-web uninstall regression proving both Eve and Murmur data roots survive;
 - exact pre/post registry, shortcut, install-directory, and data-root comparison;
-- on controlled fixtures, confirmation that `%APPDATA%\murmur` file hashes are unchanged; on a real user profile, confirm through filesystem tracing that Eve never opens the personal files;
+- on controlled fixtures, confirmation that `%APPDATA%\murmur` sentinel hashes are
+  unchanged; in a disposable Windows account/VM, use a privacy-normalized filesystem
+  trace to prove the candidate never opens the controlled legacy root. Never trace or
+  inspect a real user's Murmur contents;
 - confirmation that no release, tag, or historical asset changed.
 
 ## Remaining-work ledger
@@ -153,10 +158,11 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Placement-ready repository documentation | Complete | No |
 | Fresh-profile ADR and cutover checklist | Complete in PR #14 | No |
 | Derive and cross-check the published v0.6.3 NSIS key | Complete; see Gate 1 evidence | No |
-| Confirm NSIS key from a clean published v0.6.3 install | Pending; no isolated VM is currently available | Clean VM |
-| Select final Eve data-root casing and AppUserModelID | Pending | Explicit decision before activation |
-| Compatibility-scaffolding implementation | Draft implementation in progress | Clean-VM gate before merge |
-| Fresh Eve profile implementation | Pending | Separate approval after scaffolding acceptance |
+| Confirm NSIS key from published v0.6.3 installation | Complete in Gate 1 host acceptance | No |
+| Select final Eve data-root casing | Complete: exact `%APPDATA%\Eve` | No |
+| Select final AppUserModelID | Pending; Gate 4 only | Separate approval |
+| Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
+| Fresh Eve profile implementation | Gate A implementation in progress on `codex/eve-fresh-profile-gate-2`; packaged Gate B pending | Separate approval for Gate B |
 | Visible installed-product rename | Pending | Separate approval after data isolation passes |
 | AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |
 | Visual identity and homepage | Pending | Later design phase |

--- a/docs/architecture/eve-identity-gate-2-evidence.md
+++ b/docs/architecture/eve-identity-gate-2-evidence.md
@@ -92,8 +92,8 @@ deletes the shared cache.
 The injectable access record is evidence about root preparation, not proof of all
 filesystem behavior. The unpackaged Electron subprocess demonstrates actual singleton
 path selection and controlled-sibling preservation, but it is not a packaged filesystem
-trace. Neither check may be represented as final full-process non-access proof; that
-acceptance remains Gate B.
+trace. Neither check may be represented as final full-process non-access proof. Path-level
+tracing is explicitly out of scope for this gate and is not a readiness criterion.
 
 ### Local smoke-harness correction
 

--- a/docs/architecture/eve-identity-gate-2-evidence.md
+++ b/docs/architecture/eve-identity-gate-2-evidence.md
@@ -11,8 +11,8 @@ standalone repository's exact merged Gate 1 trunk commit
 This gate activates exactly `%APPDATA%\Eve` while retaining `com.murmur.app`, product
 name `Murmur`, `Murmur.exe`, installer/shortcut/artifact names, the explicit NSIS GUID,
 publish/update configuration, preload globals, `MURMUR_*` names, Python package names,
-visuals, and version `0.6.3`. It does not package, install, publish, tag, mark ready, or
-merge a release.
+visuals, and version `0.6.3`. Gate B built and exercised a local Windows candidate, but
+did not publish, tag, merge, or change a release.
 
 ## Commit and rollback boundaries
 
@@ -76,7 +76,7 @@ deletes the shared cache.
 |---|---|
 | Exact `%APPDATA%\Eve` selected | `bootstrap.test.ts` ordering assertions plus the real Electron controlled-root subprocess smoke check |
 | Selection precedes singleton acquisition, Store, History, server, helper, and session consumers | Real Electron lock-time path record, mocked regression ordering, dynamic-import ordering, and successful full main-process build |
-| Zero legacy-root access, including no legacy PID read | Injectable filesystem access record and real Electron controlled-sibling preservation check in `eve-profile-boundary.test.ts`; source/diff audit; privacy-normalized packaged Process Monitor/ETW proof remains Gate B |
+| Zero legacy-root access, including no legacy PID read | Injectable filesystem access record and real Electron controlled-sibling preservation check in `eve-profile-boundary.test.ts`; source/diff audit; packaged candidate selected Eve and the Murmur manifest remained byte-identical until the published rollback was launched. Path-level tracing was removed from this gate, so its absence is an evidence limitation rather than a failed requirement. |
 | Redirected parent APPDATA remains supported | Controlled redirected-parent fixture |
 | Eve root cannot alias the controlled Murmur fixture | Controlled symlink/junction rejection fixture |
 | Missing root initializes; malformed/file/inaccessible root fails closed | Root creation, file-root, canonical-alias, and write-probe tests; sanitized bootstrap error path |
@@ -86,7 +86,7 @@ deletes the shared cache.
 | Existing `MURMUR_*` overrides are sufficient | App launcher injects Eve PID/settings paths; no Python server-file diff |
 | Shared model cache behavior unchanged | Environment/diff audit; Gate B cache reuse/preservation checks |
 | Gate 1 product/installer/release identity unchanged | `server/tests/test_release_config.py`, version consistency, manifest diff audit |
-| Uninstall preserves both roots | Frozen `deleteAppDataOnUninstall: false`; actual install/repair/uninstall proof deferred to Gate B |
+| Uninstall preserves both roots | Frozen `deleteAppDataOnUninstall: false`; the NSIS repair failure removed the installed candidate while preserving both roots. A normal same-version repair/uninstall cycle did not complete and is not claimed as passed. |
 | No sensitive test artifacts | Fixtures use generated temporary roots and synthetic sentinel text; logs and tracked files are scanned before push |
 
 The injectable access record is evidence about root preparation, not proof of all
@@ -127,29 +127,50 @@ its native `uiohook-napi` postinstall could not link one existing object file lo
 No manifest or lockfile changed; app tests and production builds passed with the
 available Windows dependencies. CI performs a clean frozen install.
 
-## Gate B: packaged disposable Windows acceptance
+## Gate B: packaged Windows acceptance
 
-Gate B requires separate approval and must pass before merge. It uses a disposable
-Windows account or VM, never the real user profile:
+The user approved a current-profile exception after both roots were copied byte-for-byte
+to an E:-resident evidence area. File contents and transcript/history data are not
+recorded in repository evidence. Shared Hugging Face caches were reused read-only and
+were not copied, moved, deleted, or downloaded.
 
-- install published v0.6.3, then install the same-version Gate 2 candidate;
-- same-version repair and rapid restart;
-- controlled Murmur fixtures containing synthetic settings, History/WAL/SHM, Chromium,
-  PID, helper, log, credential-like, and startup-preference sentinels;
-- clean first launch proving Eve defaults, empty History, fresh browser state, fresh
-  server state, and Eve helper generation;
-- stale, reused, malformed, owned, unowned, and healthy-but-unowned Eve PID cases;
-- shared Hugging Face cache reuse without moving or deleting it;
-- uninstall preserving both controlled roots and the shared cache;
-- rollback to checksum-verified published v0.6.3 and responsive launch;
-- exact before/after snapshots of uninstall identity, install files, shortcuts,
-  login-item registrations, roots, tags, releases, and published assets.
+| Check | Result |
+|---|---|
+| Reviewed source | Exact PR head `758a175203006cf27e3bf5881654c814978eb8e4`; tracked tree clean before packaging |
+| Full-runtime candidate | Build duration: 825.792 seconds. Installer: 887,569 bytes, SHA-256 `648667AA31CE094917622DF701F95F626221F5F901D25879C4CD4EE8514D987B`; payload: 2,033,993,463 bytes, SHA-256 `8AA10BFA24C7C70F46833A70FBEF56D7DAA4C3C05D9A6AC90F93C7E60AF928F2` |
+| Runtime closure | Packaged `.runtime\python.exe` imported faster-whisper/CTranslate2, Torch, Torchaudio, and NeMo/Nemotron; required CUDA/native libraries were present; packaged server smoke was healthy at `0.6.3` |
+| Fast/Long dictation exercise | **Not completed.** Import, CUDA/native closure, engine discovery, and packaged server smoke passed, but the candidate was removed before both packaged transcription paths were exercised. No dictation acceptance is claimed. |
+| Frozen identity | Product/app/executable/installer/artifact names, `com.murmur.app`, NSIS GUID, version, publish/update target, and v0.6.3 release assets remained unchanged |
+| Candidate first launch | Exact `%APPDATA%\Eve` initialized; the packaged server PID was owned by the installed runtime and its dynamic endpoint became healthy at `0.6.3` |
+| Rapid restart/singleton | Second launch exited successfully; the process tree stabilized to one main process |
+| Murmur preservation before rollback | The 108-file Murmur manifest remained byte-for-byte identical through candidate install, launch, and removal |
+| Eve preservation | The 44-file Eve candidate fingerprint remained identical through candidate removal and published rollback |
+| Login registrations | The 21-entry canonical Run/StartupApproved snapshot remained unchanged |
+| Candidate same-version repair | **Not passed.** The initial NSIS-web install consumed its local payload. The repair invocation therefore lacked that payload and removed the candidate before it was stopped. Both profile roots remained preserved. No rebuild was performed. |
+| Candidate uninstall | Candidate files were removed by the failed repair path and both roots survived, but a normal repair/uninstall sequence was not completed and is not claimed as passed |
+| Published rollback | Official v0.6.3 installer (887,561 bytes, SHA-256 `366088A4266F54EA7C39E2E7FD1FC7177CAC46BF8A4B3F43D58A6D025E15CD33`) and payload (2,034,188,308 bytes, SHA-256 `0B557FDE05853DA1F7C0AEF77CECBAD1FAF8C5FC9314457EA45119D3A69F4FBD`) matched GitHub release metadata; installed `app.asar` matched `98910F5CD2C3A9426ECD7850EE352E47F9C48FB00BB5EEF526220660E69FC8FD`; the server became healthy at `0.6.3` |
+| Murmur state after published launch | The exact 108-file backup matched immediately before rollback launch. Published v0.6.3 then legitimately wrote to its own Murmur profile, leaving 113 files and 21 manifest differences; post-launch byte identity is not claimed |
+| Path-level tracing | **Out-of-scope evidence limitation.** ProcMon/WPR/path tracing was explicitly removed from this gate. No path-trace pass or failure is claimed. Static audit, mocked tests, a real Electron controlled-root subprocess, packaged Eve initialization/ownership/readiness, and before/after manifests remain the available boundary evidence |
 
-Process Monitor or ETW filters must be scoped to the candidate process tree and the two
-controlled fixture roots. Exported evidence must replace account names and temporary
-prefixes with stable tokens, retain operation/result/path-class fields needed for audit,
-exclude file contents and unrelated processes, and prove zero operation beneath the
-controlled Murmur token. Real `%APPDATA%\murmur` contents must never be read or traced.
+The residual standard local account `CodexEveGateB16` was created by the user, was not
+used for this acceptance path, and expires on 2026-07-25. It remains controlled host
+state for later cleanup.
+
+### Fresh Gate A rerun after Gate B
+
+| Command | Result on 2026-07-24 |
+|---|---|
+| `python scripts/version.py check` | Pass; `0.6.3` |
+| `bun test` | Pass; 87 tests, 273 assertions |
+| `bun run test:history` | Pass |
+| `bun run build` | Pass |
+| `uv sync --extra whisper --group dev --frozen` | Pass in an isolated E:-resident environment; tracked manifests and locks unchanged |
+| `uv run --no-sync pytest` | Pass; 138 tests |
+
+Gate B is incomplete because the failed same-version repair cannot be normalized into a
+successful repair/uninstall result. Path tracing is not a readiness blocker because it
+was explicitly removed from this gate; its absence only limits the available evidence.
+PR readiness requires a later successful supported repair check.
 
 ## Stop conditions
 
@@ -165,5 +186,6 @@ Stop and revert the latest commit if the implementation:
   overrides;
 - requires packaging or real-host mutation to make Gate A pass.
 
-Packaging, host installation, registry mutation, marking ready, merging, tags, and
-release publication remain explicit no-go actions until their later approvals.
+The approved Gate B host work is recorded above. Further host remediation, marking
+ready, merging, tags, and release publication remain no-go actions unless separately
+approved; this evidence does not authorize them.

--- a/docs/architecture/eve-identity-gate-2-evidence.md
+++ b/docs/architecture/eve-identity-gate-2-evidence.md
@@ -1,0 +1,146 @@
+# Eve identity Gate 2 evidence
+
+## Scope and baseline
+
+Gate 2 is the clean Eve data-boundary change from
+[ADR-001](adr-001-eve-application-identity-migration.md). Implementation began from the
+standalone repository's exact merged Gate 1 trunk commit
+`5e5b3a3c458d56279e8ece37c51827ce60cfa7a0` on
+`codex/eve-fresh-profile-gate-2`.
+
+This gate activates exactly `%APPDATA%\Eve` while retaining `com.murmur.app`, product
+name `Murmur`, `Murmur.exe`, installer/shortcut/artifact names, the explicit NSIS GUID,
+publish/update configuration, preload globals, `MURMUR_*` names, Python package names,
+visuals, and version `0.6.3`. It does not package, install, publish, tag, mark ready, or
+merge a release.
+
+## Commit and rollback boundaries
+
+| Commit | Boundary | Focused proof | Rollback |
+|---|---|---|---|
+| `22243b6` | Prepare and validate a profile root; set `userData` and `sessionData` before application imports | Bootstrap and controlled-root tests; main-process build | Revert `22243b6` to return to merged Gate 1 |
+| `8e13e21` | Activate exact `Eve`; block login-item writes; route app-side server/helper state; require PID ownership | 25 focused checks; main and renderer builds | Revert `8e13e21` to retain only pre-import scaffolding |
+| audit/evidence commit | Remove the bootstrap's legacy default so every caller must select a root; correct the ledger and record Gate A/Gate B boundaries | Bootstrap tests, builds, `git diff --check`, and changed-file audit | Revert this commit to `8e13e21`, then do not ship until the legacy default is removed another way |
+
+The PR ceiling is exactly 20 changed files relative to Gate 1. Python server files,
+dependency manifests/locks, workflows, package identity, and release configuration are
+outside the allowed diff.
+
+## Data-boundary behavior
+
+The bootstrap order is:
+
+1. obtain the single-instance lock;
+2. resolve Electron's `appData` parent;
+3. create and validate its direct `Eve` child, including an exclusive write probe;
+4. reject files, symbolic-link/junction roots, canonical redirects, and inaccessible
+   roots;
+5. set both Electron `userData` and `sessionData` to the prepared root;
+6. retain `com.murmur.app`;
+7. dynamically import the application.
+
+Only after step 7 can top-level Electron Store construction occur. `settings.json` and
+`internal.json` therefore initialize under Eve; `HistoryService` opens Eve's
+`history.db` and SQLite owns any WAL/SHM siblings there; Chromium session state uses
+Eve's `sessionData`; the server receives Eve `server.pid` and `server-settings.json`
+through the existing `MURMUR_PID_FILE`/`MURMUR_SETTINGS_FILE` overrides; and clipboard
+helpers are generated beneath Eve through the already-overridden `userData`.
+
+Every bootstrap caller must supply a directory name; there is no legacy default or
+Murmur fallback. Missing state initializes normally. A malformed or inaccessible selected root throws
+before data-consuming imports and shows bounded repair guidance with no fallback.
+Malformed/inaccessible Eve PID state fails closed. No generalized migration mechanism
+and no server fallback changes were added.
+
+Gate 2 makes zero call to `app.setLoginItemSettings`, including no `false` call. A fresh
+profile reads the existing `launchOnBoot: false` default. An enable attempt is rejected
+before persistence; the renderer reverts the optimistic toggle and displays an error.
+Old Windows registrations are neither read nor edited.
+
+Hugging Face cache discovery remains unchanged. Gate 2 neither redirects, moves, nor
+deletes the shared cache.
+
+## Definition of done
+
+| Requirement | Test or evidence |
+|---|---|
+| Exact `%APPDATA%\Eve` selected | `bootstrap.test.ts` identity and ordering assertions |
+| Selection precedes Store, History, server, helper, and session consumers | Dynamic-import ordering test plus successful full main-process build |
+| Zero legacy-root access, including no legacy PID read | Injectable filesystem access record in `eve-profile-boundary.test.ts`; controlled sibling sentinel remains unchanged; source/diff audit; full-process proof deferred to Gate B |
+| Redirected parent APPDATA remains supported | Controlled redirected-parent fixture |
+| Eve root cannot alias the controlled Murmur fixture | Controlled symlink/junction rejection fixture |
+| Missing root initializes; malformed/file/inaccessible root fails closed | Root creation, file-root, canonical-alias, and write-probe tests; sanitized bootstrap error path |
+| Fresh settings/window state/History/session/server/helper paths | `userData`/`sessionData` assertions, unchanged consumer path audit, History migration check, and Gate B first-launch artifact inventory |
+| No login-item/registry write and no misleading enable result | `login-item-boundary.test.ts`, zero source occurrences of `setLoginItemSettings`, renderer revert/error path, Gate B registry snapshot |
+| Malformed, stale, reused, unowned, and rapid-restart PID cases | `server-health.test.ts` PID parser and process-snapshot ownership cases |
+| Existing `MURMUR_*` overrides are sufficient | App launcher injects Eve PID/settings paths; no Python server-file diff |
+| Shared model cache behavior unchanged | Environment/diff audit; Gate B cache reuse/preservation checks |
+| Gate 1 product/installer/release identity unchanged | `server/tests/test_release_config.py`, version consistency, manifest diff audit |
+| Uninstall preserves both roots | Frozen `deleteAppDataOnUninstall: false`; actual install/repair/uninstall proof deferred to Gate B |
+| No sensitive test artifacts | Fixtures use generated temporary roots and synthetic sentinel text; logs and tracked files are scanned before push |
+
+The injectable access record is evidence about root preparation, not proof of all
+filesystem behavior. A passing unit test must not be represented as full-process
+non-access proof.
+
+## Gate A: automated controlled fixtures
+
+Gate A is sufficient to open a draft PR:
+
+| Command | Result on 2026-07-23 |
+|---|---|
+| `python scripts/version.py check` | Pass; `0.6.3` |
+| `bun test` | Pass; 86 tests, 260 assertions |
+| `bun run test:history` | Pass |
+| `bun run build` | Pass |
+| focused Gate 2 tests | Pass; 25 tests, 51 assertions |
+| `git diff --check` | Pass before each implementation commit; rerun on final diff |
+| `uv sync --extra whisper --group dev --frozen` | Pass; CI-equivalent Windows environment prepared without changing tracked manifests or locks |
+| `uv run --no-sync pytest` | Pass; 138 tests |
+| explicit standalone tag/release audit | Pass; tag refs unchanged and v0.6.3 asset names, sizes, and SHA-256 digests match Gate 1 evidence |
+
+`bun install --frozen-lockfile` populated the existing ignored dependency directory but
+its native `uiohook-napi` postinstall could not link one existing object file locally.
+No manifest or lockfile changed; app tests and production builds passed with the
+available Windows dependencies. CI performs a clean frozen install.
+
+## Gate B: packaged disposable Windows acceptance
+
+Gate B requires separate approval and must pass before merge. It uses a disposable
+Windows account or VM, never the real user profile:
+
+- install published v0.6.3, then install the same-version Gate 2 candidate;
+- same-version repair and rapid restart;
+- controlled Murmur fixtures containing synthetic settings, History/WAL/SHM, Chromium,
+  PID, helper, log, credential-like, and startup-preference sentinels;
+- clean first launch proving Eve defaults, empty History, fresh browser state, fresh
+  server state, and Eve helper generation;
+- stale, reused, malformed, owned, unowned, and healthy-but-unowned Eve PID cases;
+- shared Hugging Face cache reuse without moving or deleting it;
+- uninstall preserving both controlled roots and the shared cache;
+- rollback to checksum-verified published v0.6.3 and responsive launch;
+- exact before/after snapshots of uninstall identity, install files, shortcuts,
+  login-item registrations, roots, tags, releases, and published assets.
+
+Process Monitor or ETW filters must be scoped to the candidate process tree and the two
+controlled fixture roots. Exported evidence must replace account names and temporary
+prefixes with stable tokens, retain operation/result/path-class fields needed for audit,
+exclude file contents and unrelated processes, and prove zero operation beneath the
+controlled Murmur token. Real `%APPDATA%\murmur` contents must never be read or traced.
+
+## Stop conditions
+
+Stop and revert the latest commit if the implementation:
+
+- opens any controlled legacy-root path;
+- falls back to Murmur after an Eve failure;
+- adopts or terminates an unverified process;
+- makes any login-item or registry write;
+- changes product, installer, AppUserModelID, package, internal bridge, environment,
+  visual, dependency, version, tag, release, or update identity;
+- touches a Python server file without a demonstrated failure of the explicit app-side
+  overrides;
+- requires packaging or real-host mutation to make Gate A pass.
+
+Packaging, host installation, registry mutation, marking ready, merging, tags, and
+release publication remain explicit no-go actions until their later approvals.

--- a/docs/architecture/eve-identity-gate-2-evidence.md
+++ b/docs/architecture/eve-identity-gate-2-evidence.md
@@ -113,10 +113,10 @@ Gate A is sufficient to open a draft PR:
 | Command | Result on 2026-07-23 |
 |---|---|
 | `python scripts/version.py check` | Pass; `0.6.3` |
-| `bun test` | Pass; 86 tests, 265 assertions, including the controlled real-Electron singleton smoke check |
+| `bun test` | Pass; 87 tests, 273 assertions, including the controlled real-Electron singleton smoke check |
 | `bun run test:history` | Pass |
 | `bun run build` | Pass |
-| focused Gate 2 tests | Pass; 25 tests, 56 assertions |
+| focused Gate 2 tests | Pass; 26 tests, 64 assertions |
 | `git diff --check` | Pass before each implementation commit; rerun on final diff |
 | `uv sync --extra whisper --group dev --frozen` | Pass; CI-equivalent Windows environment prepared without changing tracked manifests or locks |
 | `uv run --no-sync pytest` | Pass; 138 tests |

--- a/docs/architecture/eve-identity-gate-2-evidence.md
+++ b/docs/architecture/eve-identity-gate-2-evidence.md
@@ -86,7 +86,7 @@ deletes the shared cache.
 | Existing `MURMUR_*` overrides are sufficient | App launcher injects Eve PID/settings paths; no Python server-file diff |
 | Shared model cache behavior unchanged | Environment/diff audit; Gate B cache reuse/preservation checks |
 | Gate 1 product/installer/release identity unchanged | `server/tests/test_release_config.py`, version consistency, manifest diff audit |
-| Uninstall preserves both roots | Frozen `deleteAppDataOnUninstall: false`; the NSIS repair failure removed the installed candidate while preserving both roots. A normal same-version repair/uninstall cycle did not complete and is not claimed as passed. |
+| Uninstall preserves both roots | **Passed.** Frozen `deleteAppDataOnUninstall: false`; the supported candidate uninstaller removed application files while both current profile manifests and the login snapshot remained exact. |
 | No sensitive test artifacts | Fixtures use generated temporary roots and synthetic sentinel text; logs and tracked files are scanned before push |
 
 The injectable access record is evidence about root preparation, not proof of all
@@ -103,8 +103,9 @@ that variable, so the subprocess selected the actual user's Eve root before exit
 did not select the Murmur root. The Eve location was not inspected or removed. The
 committed harness instead sets a controlled Electron `appData` path before invoking the
 production bootstrap and supplies a controlled pre-bootstrap `--user-data-dir`. This
-incident is another reason the packaged privacy boundary is not finally accepted until
-Gate B tracing passes.
+incident is another reason to retain the available packaged boundary evidence with its
+stated limitations. ProcMon/WPR/path tracing is explicitly out of scope for this gate
+and is neither a pass criterion nor a readiness blocker.
 
 ## Gate A: automated controlled fixtures
 
@@ -137,19 +138,19 @@ were not copied, moved, deleted, or downloaded.
 | Check | Result |
 |---|---|
 | Reviewed source | Exact PR head `758a175203006cf27e3bf5881654c814978eb8e4`; tracked tree clean before packaging |
-| Full-runtime candidate | Build duration: 825.792 seconds. Installer: 887,569 bytes, SHA-256 `648667AA31CE094917622DF701F95F626221F5F901D25879C4CD4EE8514D987B`; payload: 2,033,993,463 bytes, SHA-256 `8AA10BFA24C7C70F46833A70FBEF56D7DAA4C3C05D9A6AC90F93C7E60AF928F2` |
+| Full-runtime candidate | The preserved full-runtime source produced a 887,569-byte recovery installer (SHA-256 `D58922D65215668D30D7A339F114D9715C0AB889BAFAA1C13777B219C07ADF52`) and payload (2,033,993,463 bytes, SHA-256 `8AA10BFA24C7C70F46833A70FBEF56D7DAA4C3C05D9A6AC90F93C7E60AF928F2`). The application payload/closure was equivalent to the earlier verified candidate; only the wrapper hash differed. |
 | Runtime closure | Packaged `.runtime\python.exe` imported faster-whisper/CTranslate2, Torch, Torchaudio, and NeMo/Nemotron; required CUDA/native libraries were present; packaged server smoke was healthy at `0.6.3` |
-| Fast/Long dictation exercise | **Not completed.** Import, CUDA/native closure, engine discovery, and packaged server smoke passed, but the candidate was removed before both packaged transcription paths were exercised. No dictation acceptance is claimed. |
+| Fast/Long dictation exercise | **Passed on the recovered full-runtime candidate.** A repository-controlled WAV fixture was converted in memory to 16 kHz mono without persisting content. Fast Dictation delivered a final result for 10.0 seconds through faster-whisper; Long Dictation delivered a final result for 47.334 seconds and emitted `long_dictation_started` plus processing status. Only engine, status, duration, timing, and output-presence metadata were retained. |
 | Frozen identity | Product/app/executable/installer/artifact names, `com.murmur.app`, NSIS GUID, version, publish/update target, and v0.6.3 release assets remained unchanged |
-| Candidate first launch | Exact `%APPDATA%\Eve` initialized; the packaged server PID was owned by the installed runtime and its dynamic endpoint became healthy at `0.6.3` |
+| Candidate first launch | Exact `%APPDATA%\Eve` initialized; the packaged server PID was owned by the installed runtime and its current PID-file port `51908` became healthy at `0.6.3` |
 | Rapid restart/singleton | Second launch exited successfully; the process tree stabilized to one main process |
-| Murmur preservation before rollback | The 108-file Murmur manifest remained byte-for-byte identical through candidate install, launch, and removal |
-| Eve preservation | The 44-file Eve candidate fingerprint remained identical through candidate removal and published rollback |
-| Login registrations | The 21-entry canonical Run/StartupApproved snapshot remained unchanged |
-| Candidate same-version repair | **Not passed.** The initial NSIS-web install consumed its local payload. The repair invocation therefore lacked that payload and removed the candidate before it was stopped. Both profile roots remained preserved. No rebuild was performed. |
-| Candidate uninstall | Candidate files were removed by the failed repair path and both roots survived, but a normal repair/uninstall sequence was not completed and is not claimed as passed |
-| Published rollback | Official v0.6.3 installer (887,561 bytes, SHA-256 `366088A4266F54EA7C39E2E7FD1FC7177CAC46BF8A4B3F43D58A6D025E15CD33`) and payload (2,034,188,308 bytes, SHA-256 `0B557FDE05853DA1F7C0AEF77CECBAD1FAF8C5FC9314457EA45119D3A69F4FBD`) matched GitHub release metadata; installed `app.asar` matched `98910F5CD2C3A9426ECD7850EE352E47F9C48FB00BB5EEF526220660E69FC8FD`; the server became healthy at `0.6.3` |
-| Murmur state after published launch | The exact 108-file backup matched immediately before rollback launch. Published v0.6.3 then legitimately wrote to its own Murmur profile, leaving 113 files and 21 manifest differences; post-launch byte identity is not claimed |
+| Murmur preservation before repaired relaunch | **Passed.** The fresh current-profile baseline (113 files, 12,673,961 bytes) was byte-identical after candidate install, dictation, repair, and candidate uninstall. This is manifest evidence, not a filesystem trace. |
+| Eve preservation | Eve was the active root. The repair and normal candidate uninstall both preserved its exact pre-operation manifest. |
+| Login registrations | The current 21-entry Run/StartupApproved raw snapshot (SHA-256 `120B24D7724A3E0106EE1144170519B33D8F7AF56D3ECDF17DF2EDF72424F014`) remained exact across repair and normal candidate uninstall. |
+| Candidate same-version repair | **Passed.** An independent, hash-verified Set B payload ran the supported NSIS-web repair with exit `0` in 288.316 seconds. Candidate `app.asar` and runtime closure remained intact; both profiles and the login snapshot were exact; repaired relaunch used its current PID-file port `50452` and became healthy at `0.6.3`. An earlier apparent health failure was an acceptance-harness error: its later probes reused the preceding launch's port `51003` instead of the repaired PID file's port `65325`. No product source change was warranted. |
+| Candidate uninstall | **Passed.** The supported uninstaller exited `0` in 20.397 seconds, removed the install root and matching uninstall entry, and preserved both exact pre-uninstall profile manifests and the login snapshot. |
+| Published rollback | Official v0.6.3 installer (887,561 bytes, SHA-256 `366088A4266F54EA7C39E2E7FD1FC7177CAC46BF8A4B3F43D58A6D025E15CD33`) and re-downloaded immutable payload (2,034,188,308 bytes, SHA-256 `0B557FDE05853DA1F7C0AEF77CECBAD1FAF8C5FC9314457EA45119D3A69F4FBD`) matched GitHub release metadata. The installer exited `0` in 217.273 seconds; installed `app.asar` matched `98910F5CD2C3A9426ECD7850EE352E47F9C48FB00BB5EEF526220660E69FC8FD`; the server became healthy at `0.6.3` on its current PID-file port `60173`. |
+| Murmur state after published launch | The 113-file candidate-cycle baseline matched immediately before rollback launch. Published v0.6.3 may legitimately write to its own Murmur profile after launch; post-launch byte identity is not claimed. |
 | Path-level tracing | **Out-of-scope evidence limitation.** ProcMon/WPR/path tracing was explicitly removed from this gate. No path-trace pass or failure is claimed. Static audit, mocked tests, a real Electron controlled-root subprocess, packaged Eve initialization/ownership/readiness, and before/after manifests remain the available boundary evidence |
 
 The residual standard local account `CodexEveGateB16` was created by the user, was not
@@ -167,10 +168,11 @@ state for later cleanup.
 | `uv sync --extra whisper --group dev --frozen` | Pass in an isolated E:-resident environment; tracked manifests and locks unchanged |
 | `uv run --no-sync pytest` | Pass; 138 tests |
 
-Gate B is incomplete because the failed same-version repair cannot be normalized into a
-successful repair/uninstall result. Path tracing is not a readiness blocker because it
-was explicitly removed from this gate; its absence only limits the available evidence.
-PR readiness requires a later successful supported repair check.
+Gate B lifecycle acceptance is complete. The repaired-health incident was traced to a
+stale-port acceptance probe, not the product: `MURMUR_PORT=0` assigns a new port for
+each launch, the server writes it to the PID file, and the shipped server manager polls
+that current `pidData.port`. Path tracing is not a readiness blocker because it was
+explicitly removed from this gate; its absence only limits the available evidence.
 
 ## Stop conditions
 

--- a/docs/architecture/eve-identity-gate-2-evidence.md
+++ b/docs/architecture/eve-identity-gate-2-evidence.md
@@ -30,12 +30,12 @@ outside the allowed diff.
 
 The bootstrap order is:
 
-1. obtain the single-instance lock;
-2. resolve Electron's `appData` parent;
-3. create and validate its direct `Eve` child, including an exclusive write probe;
-4. reject files, symbolic-link/junction roots, canonical redirects, and inaccessible
+1. resolve Electron's `appData` parent;
+2. create and validate its direct `Eve` child, including an exclusive write probe;
+3. reject files, symbolic-link/junction roots, canonical redirects, and inaccessible
    roots;
-5. set both Electron `userData` and `sessionData` to the prepared root;
+4. set both Electron `userData` and `sessionData` to the prepared root;
+5. obtain the single-instance lock scoped to the prepared Eve root;
 6. retain `com.murmur.app`;
 7. dynamically import the application.
 
@@ -52,6 +52,16 @@ before data-consuming imports and shows bounded repair guidance with no fallback
 Malformed/inaccessible Eve PID state fails closed. No generalized migration mechanism
 and no server fallback changes were added.
 
+This ordering is not inferred only from a mocked Electron app. The Electron 40.1.0
+source for `App::RequestSingleInstanceLock` resolves and creates
+`chrome::DIR_USER_DATA`, then constructs `ProcessSingleton` with that path. Gate 2
+therefore sets the two Eve paths before calling the real API. The frozen dependency
+environment currently runs Electron 40.10.6. A Windows Electron 40.x subprocess smoke
+check compiles the actual `bootstrapApplication` implementation into a temporary
+controlled fixture, records the real paths at singleton acquisition, and confirms that
+the controlled Murmur sibling gains no files and its synthetic sentinel remains
+unchanged.
+
 Gate 2 makes zero call to `app.setLoginItemSettings`, including no `false` call. A fresh
 profile reads the existing `launchOnBoot: false` default. An enable attempt is rejected
 before persistence; the renderer reverts the optimistic toggle and displays an error.
@@ -64,9 +74,9 @@ deletes the shared cache.
 
 | Requirement | Test or evidence |
 |---|---|
-| Exact `%APPDATA%\Eve` selected | `bootstrap.test.ts` identity and ordering assertions |
-| Selection precedes Store, History, server, helper, and session consumers | Dynamic-import ordering test plus successful full main-process build |
-| Zero legacy-root access, including no legacy PID read | Injectable filesystem access record in `eve-profile-boundary.test.ts`; controlled sibling sentinel remains unchanged; source/diff audit; full-process proof deferred to Gate B |
+| Exact `%APPDATA%\Eve` selected | `bootstrap.test.ts` ordering assertions plus the real Electron controlled-root subprocess smoke check |
+| Selection precedes singleton acquisition, Store, History, server, helper, and session consumers | Real Electron lock-time path record, mocked regression ordering, dynamic-import ordering, and successful full main-process build |
+| Zero legacy-root access, including no legacy PID read | Injectable filesystem access record and real Electron controlled-sibling preservation check in `eve-profile-boundary.test.ts`; source/diff audit; privacy-normalized packaged Process Monitor/ETW proof remains Gate B |
 | Redirected parent APPDATA remains supported | Controlled redirected-parent fixture |
 | Eve root cannot alias the controlled Murmur fixture | Controlled symlink/junction rejection fixture |
 | Missing root initializes; malformed/file/inaccessible root fails closed | Root creation, file-root, canonical-alias, and write-probe tests; sanitized bootstrap error path |
@@ -80,8 +90,21 @@ deletes the shared cache.
 | No sensitive test artifacts | Fixtures use generated temporary roots and synthetic sentinel text; logs and tracked files are scanned before push |
 
 The injectable access record is evidence about root preparation, not proof of all
-filesystem behavior. A passing unit test must not be represented as full-process
-non-access proof.
+filesystem behavior. The unpackaged Electron subprocess demonstrates actual singleton
+path selection and controlled-sibling preservation, but it is not a packaged filesystem
+trace. Neither check may be represented as final full-process non-access proof; that
+acceptance remains Gate B.
+
+### Local smoke-harness correction
+
+An initial uncommitted smoke-harness invocation attempted to redirect Electron with the
+child `APPDATA` environment variable alone. Windows known-folder resolution ignored
+that variable, so the subprocess selected the actual user's Eve root before exiting. It
+did not select the Murmur root. The Eve location was not inspected or removed. The
+committed harness instead sets a controlled Electron `appData` path before invoking the
+production bootstrap and supplies a controlled pre-bootstrap `--user-data-dir`. This
+incident is another reason the packaged privacy boundary is not finally accepted until
+Gate B tracing passes.
 
 ## Gate A: automated controlled fixtures
 
@@ -90,10 +113,10 @@ Gate A is sufficient to open a draft PR:
 | Command | Result on 2026-07-23 |
 |---|---|
 | `python scripts/version.py check` | Pass; `0.6.3` |
-| `bun test` | Pass; 86 tests, 260 assertions |
+| `bun test` | Pass; 86 tests, 265 assertions, including the controlled real-Electron singleton smoke check |
 | `bun run test:history` | Pass |
 | `bun run build` | Pass |
-| focused Gate 2 tests | Pass; 25 tests, 51 assertions |
+| focused Gate 2 tests | Pass; 25 tests, 56 assertions |
 | `git diff --check` | Pass before each implementation commit; rerun on final diff |
 | `uv sync --extra whisper --group dev --frozen` | Pass; CI-equivalent Windows environment prepared without changing tracked manifests or locks |
 | `uv run --no-sync pytest` | Pass; 138 tests |

--- a/scripts/installer-smoke.ps1
+++ b/scripts/installer-smoke.ps1
@@ -5,7 +5,7 @@ param(
     [string]$Model = "",
     [int]$HealthTimeoutSec = 180,
     [int]$DownloadTimeoutSec = 1200,
-    [string]$PidFilePath = "$env:APPDATA\murmur\server.pid",
+    [string]$PidFilePath = "$env:APPDATA\Eve\server.pid",
     [string]$ExpectedVersion = "",
     [switch]$SkipUninstall,
     [switch]$SkipLaunch,


### PR DESCRIPTION
## Summary

- select exact `%APPDATA%\Eve` before singleton acquisition and before importing Electron Store, History, server, clipboard, or session consumers
- fail closed on invalid/inaccessible Eve state with no Murmur fallback or legacy PID read
- make zero login-item writes and visibly revert rejected enable attempts
- require PID, executable, command-line, and creation-epoch proof before adopting or terminating an Eve-recorded server process
- preserve all Gate 1 product, installer, internal API, update, version, and shared model-cache behavior

## Fresh Gate A

- `python scripts/version.py check`: pass (`0.6.3`)
- `bun test`: 87 passed / 273 assertions
- `bun run test:history`: pass
- `bun run build`: pass
- `uv sync --extra whisper --group dev --frozen`: pass in an isolated E:-resident environment; no manifest/lock changes
- `uv run --no-sync pytest`: 138 passed
- `git diff --check`: pass
- exact changed-file ceiling: 20

## Gate B lifecycle acceptance

- full-runtime closure verified: faster-whisper/CTranslate2, Torch/Torchaudio, NeMo/Nemotron, CUDA/native libraries, and packaged server health
- packaged Fast and Long Dictation passed with a repository-controlled audio fixture; only engine/status/duration/timing/output-presence metadata was retained
- candidate selected exact `%APPDATA%\Eve`; its owned server and dynamic PID-file port were healthy at `0.6.3`; singleton stabilization passed
- supported same-version NSIS-web repair exited `0`, preserved the exact pre-repair Murmur/Eve manifests and 21-entry login snapshot, and repaired relaunch passed on its freshly read PID-file port
- supported uninstaller exited `0`, removed install/uninstall registration, and preserved both exact pre-uninstall roots and login snapshot
- checksum-verified published v0.6.3 was restored; installed `app.asar` matched the published digest and its server became healthy at `0.6.3`
- path tracing was explicitly removed from this gate; its absence is an evidence limitation, not a readiness blocker

An earlier apparent repaired-health failure was diagnosed as an acceptance-harness stale-port probe, not a product defect: `MURMUR_PORT=0` assigns a new port per launch and the shipped manager reads the current PID-file port. No production code change was warranted.

Detailed non-sensitive evidence, lifecycle results, and limits are in `docs/architecture/eve-identity-gate-2-evidence.md`.

## Readiness

This PR remains **draft** while CI and an explicit incremental CodeRabbit review run on the new evidence head. No release, tag, published asset, or merge was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application data is now stored in the `Eve` directory across supported platforms.
  * Startup uses a controlled `userData` location, and session data is stored alongside it.
* **Bug Fixes**
  * Improved startup failure handling with a blocking error and guidance when application data can’t be used.
  * Safer server recovery: stale, invalid, or unrecognized server processes are now rejected/handled more reliably.
* **Settings**
  * “Launch on boot” updates are validated; unsupported enable attempts are rejected, reverted, and surfaced to the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->