### PR TITLE
feat: cut over visible product identity to Eve

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,9 @@
-# Building Murmur
+# Building Eve
 
-Complete guide for setting up, developing, and packaging Murmur.
+Complete guide for setting up, developing, and packaging Eve for Windows.
+
+The repository directory, package name, Python interfaces, and `MURMUR_*`
+environment variables remain intentionally stable for compatibility.
 
 ## Prerequisites
 
@@ -278,7 +281,7 @@ In production (`app.isPackaged === true`), the Electron app:
 3. Stores mutable server settings under Electron's per-user data directory, then waits for the server to write a PID file and respond to health checks
 4. Begins health polling every 3 seconds
 
-The server writes a PID file to `%APPDATA%/murmur/server.pid` (JSON with `pid`, `port`, `startedAt`) so the app can track it.
+The server writes a PID file to `%APPDATA%/Eve/server.pid` (JSON with `pid`, `port`, `startedAt`) so the app can track it.
 
 ### 5. Server lifecycle in production
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Local dictation for Windows, built as an Electron desktop client with a packaged
 <img src="https://img.shields.io/badge/v0.6.3-orange?style=flat-square" alt="v0.6.3">
 
 > [!IMPORTANT]
-> Eve is the repository and future product identity. The current v0.6.3 download still uses the **Murmur** application and installer, the `com.murmur.app` app ID, and the `%APPDATA%\murmur` data path. The later Eve application will start with a separate, fresh data profile; it will not import or delete Murmur History, settings, or other personal state.
+> Current source builds use the visible **Eve** product, executable, installer, and shortcut names with a separate `%APPDATA%\Eve` profile. The published v0.6.3 download remains **Murmur** and is listed below unchanged. The bridge release deliberately retains the `com.murmur.app` AppUserModelID, installer GUID, internal `murmur` package name, and `MURMUR_*` interfaces for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.
 
 ## What works today
 

--- a/app/package.json
+++ b/app/package.json
@@ -52,7 +52,8 @@
   },
   "build": {
     "appId": "com.murmur.app",
-    "productName": "Murmur",
+    "productName": "Eve",
+    "executableName": "Eve",
     "directories": {
       "output": "release"
     },
@@ -98,7 +99,10 @@
     "nsisWeb": {
       "guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204",
       "oneClick": true,
-      "deleteAppDataOnUninstall": false
+      "deleteAppDataOnUninstall": false,
+      "artifactName": "Eve.Web.Setup.${version}.${ext}",
+      "shortcutName": "Eve",
+      "uninstallDisplayName": "Eve ${version}"
     },
     "publish": [
       {

--- a/app/src/main/bootstrap.ts
+++ b/app/src/main/bootstrap.ts
@@ -13,8 +13,8 @@ try {
   const cause = error instanceof Error ? error : new Error(String(error));
   log.error('Application data bootstrap failed', { error: cause });
   dialog.showErrorBox(
-    'Murmur could not start',
-    'Murmur could not initialize its application data folder. Verify that the folder is a regular directory and that your account can write to it, then try again.'
+    'Eve could not start',
+    'Eve could not initialize its application data folder. Verify that the folder is a regular directory and that your account can write to it, then try again.'
   );
   app.quit();
 }

--- a/app/src/main/identity.ts
+++ b/app/src/main/identity.ts
@@ -6,8 +6,8 @@ export interface ApplicationIdentity {
 }
 
 /**
- * Published Murmur installer and application identity. Gate 2 retains these
- * compatibility values while selecting the Eve user-data root separately.
+ * Published Murmur compatibility identity. The explicit installer GUID and
+ * AppUserModelID remain active through the visible Eve-name bridge release.
  */
 export const MURMUR_IDENTITY = {
   productName: 'Murmur',
@@ -17,8 +17,7 @@ export const MURMUR_IDENTITY = {
 } as const satisfies ApplicationIdentity;
 
 /**
- * Selected future display identity. It is descriptive only and is not active
- * until a later, separately approved cutover.
+ * Active visible product name and isolated user-data directory.
  */
 export const EVE_PRODUCT_NAME = 'Eve' as const;
 export const EVE_USER_DATA_DIRECTORY_NAME = 'Eve' as const;

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -187,7 +187,7 @@ async function startRecording(source: 'lab' | 'normal', sessionMode: DictationSe
     const progressSummary = getModelProgressShortSummary(serverState?.modelDownload);
     const message = engineStatus?.status === 'error'
       ? (engineStatus.message ?? 'The transcription engine failed to load. Open Server settings for details.')
-      : progressSummary ?? 'The speech model is still loading. Keep Murmur open and try again when the Server status is ready.';
+      : progressSummary ?? 'The speech model is still loading. Keep Eve open and try again when the Server status is ready.';
     log.warn('Cannot start recording: transcription engine is not ready', {
       engine: engineStatus?.current,
       engineStatus: engineStatus?.status ?? 'unknown',
@@ -522,7 +522,7 @@ function setupDisplayChangeHandlers() {
 }
 
 async function startApplication(): Promise<void> {
-  log.info('Murmur starting');
+  log.info('Eve starting');
 
   // Initialize history service early
   historyService = new HistoryService();
@@ -614,7 +614,7 @@ async function startApplication(): Promise<void> {
     }
   }
 
-  log.info('Murmur ready');
+  log.info('Eve ready');
 
   // Handle app lifecycle
   app.on('window-all-closed', () => {
@@ -636,8 +636,8 @@ void app.whenReady()
     const cause = error instanceof Error ? error : new Error(String(error));
     log.error('Application startup failed', { error: cause });
     dialog.showErrorBox(
-      'Murmur could not start',
-      'Murmur could not initialize its application data. Verify that the application data folder is accessible and valid, then try again.'
+      'Eve could not start',
+      'Eve could not initialize its application data. Verify that the application data folder is accessible and valid, then try again.'
     );
     app.quit();
   });

--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -93,7 +93,7 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
   ipcMain.handle(IPC_CHANNELS.HOTWORDS_EXPORT, async (_event, hotwordsCsl: string) => {
     const result = await dialog.showSaveDialog({
       title: 'Export Hotwords',
-      defaultPath: 'murmur-hotwords.csv',
+      defaultPath: 'eve-hotwords.csv',
       filters: [
         { name: 'CSV', extensions: ['csv'] },
         { name: 'Text', extensions: ['txt'] },

--- a/app/src/main/services/diagnostics-report.ts
+++ b/app/src/main/services/diagnostics-report.ts
@@ -36,7 +36,7 @@ const SAFE_DRIVER_VERSION = /^[0-9.]{1,30}$/;
 
 const WARNING_MESSAGES: Record<string, string> = {
   vc_redist_missing: 'The required Microsoft Visual C++ runtime was not detected.',
-  cuda_unavailable: 'CUDA is unavailable; Murmur may use CPU mode.',
+  cuda_unavailable: 'CUDA is unavailable; Eve may use CPU mode.',
   cuda_dll_missing: 'One or more required CUDA runtime files were not detected.',
   nvidia_driver_old: 'The NVIDIA driver is older than the supported minimum.',
 };
@@ -119,7 +119,7 @@ export function formatDiagnosticsReport(input: DiagnosticsReportInput): string {
   const managed = typeof state?.managed === 'boolean' ? (state.managed ? 'managed' : 'external') : 'unknown';
   const serverStatus = enumString(state?.status, SERVER_STATUSES) ?? 'unknown';
   const lines = [
-    'Murmur diagnostics',
+    'Eve diagnostics',
     `App version: ${appVersion}`,
     `Windows: ${windowsRelease} (${architecture})`,
     `Server mode: ${managed}`,

--- a/app/src/main/services/tray.ts
+++ b/app/src/main/services/tray.ts
@@ -6,18 +6,18 @@ let tray: Tray | null = null;
 function getTrayIcon(): Electron.NativeImage {
   const icon = getMurmurTrayIcon();
   if (!icon) {
-    throw new Error('Murmur tray icon resource is missing or invalid');
+    throw new Error('Eve tray icon resource is missing or invalid');
   }
   return icon;
 }
 
 export function setupTray(onShowMainWindow?: () => void): void {
   tray = new Tray(getTrayIcon());
-  tray.setToolTip('Murmur - Press Ctrl+Win to dictate');
+  tray.setToolTip('Eve - Press Ctrl+Win to dictate');
 
   const contextMenu = Menu.buildFromTemplate([
     {
-      label: 'Murmur',
+      label: 'Eve',
       enabled: false,
     },
     { type: 'separator' },
@@ -48,9 +48,9 @@ export function updateTrayState(state: 'idle' | 'recording' | 'error'): void {
   if (!tray) return;
 
   const tooltips: Record<typeof state, string> = {
-    idle: 'Murmur - Press Ctrl+Win to dictate',
-    recording: 'Murmur - Recording...',
-    error: 'Murmur - Error occurred',
+    idle: 'Eve - Press Ctrl+Win to dictate',
+    recording: 'Eve - Recording...',
+    error: 'Eve - Error occurred',
   };
 
   tray.setToolTip(tooltips[state]);

--- a/app/src/renderer/app/components/TitleBar.svelte
+++ b/app/src/renderer/app/components/TitleBar.svelte
@@ -16,8 +16,8 @@
 
 <div class="flex items-center justify-between h-9 bg-[#0f0f0f] border-b border-[#1f1f1f] select-none">
   <div class="flex-1 flex items-center h-full pl-3 gap-2 [-webkit-app-region:drag]">
-    <img src={iconUrl} alt="Murmur" class="w-5 h-5 rounded-[4px] shrink-0" />
-    <span class="text-[13px] font-medium text-[#a1a1a1] tracking-wide">Murmur</span>
+    <img src={iconUrl} alt="Eve" class="w-5 h-5 rounded-[4px] shrink-0" />
+    <span class="text-[13px] font-medium text-[#a1a1a1] tracking-wide">Eve</span>
   </div>
 
   <div class="flex items-center gap-2 px-3 [-webkit-app-region:no-drag]">

--- a/app/src/renderer/app/index.html
+++ b/app/src/renderer/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
-    <title>Murmur</title>
+    <title>Eve</title>
   </head>
   <body>
     <div id="app"></div>

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -952,7 +952,7 @@
     </SettingsSection>
 
     <SettingsSection title="About">
-      <SettingsRow label="Version" description="Installed Murmur build version">
+      <SettingsRow label="Version" description="Installed Eve build version">
         <button
           type="button"
           onclick={copyVersionToClipboard}
@@ -981,7 +981,7 @@
           <div bind:this={externalServerCard} class="mt-2 p-4 bg-zinc-900/50 rounded-xl border border-zinc-800 w-full">
             <p class="text-sm text-zinc-200 mb-1">Custom server endpoint</p>
             <p class="text-xs text-zinc-500 mb-3">
-              Set the host and port for your transcription server. Murmur connects to <span class="font-mono">/transcribe</span>.
+              Set the host and port for your transcription server. Eve connects to <span class="font-mono">/transcribe</span>.
             </p>
 
             {#if externalServerError}

--- a/app/src/renderer/overlay/index.html
+++ b/app/src/renderer/overlay/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; media-src 'self' mediastream:;" />
-    <title>Murmur Overlay</title>
+    <title>Eve Overlay</title>
   </head>
   <body class="w-full h-full overflow-hidden bg-transparent">
     <div id="app" class="w-full h-full flex flex-col items-center justify-end pb-4"></div>

--- a/app/src/shared/model-progress.ts
+++ b/app/src/shared/model-progress.ts
@@ -113,8 +113,8 @@ export function getModelProgressView(
     stepLabel: 'Step 2 of 3',
     title: `Downloading ${state.model}`,
     summary: state.current_file
-      ? `Fetching ${state.current_file}. Keep Murmur open.`
-      : 'Fetching the speech model. Keep Murmur open.',
+      ? `Fetching ${state.current_file}. Keep Eve open.`
+      : 'Fetching the speech model. Keep Eve open.',
     metrics: metricParts.join(' • '),
     progressPercent,
   };

--- a/app/tests/bootstrap.test.ts
+++ b/app/tests/bootstrap.test.ts
@@ -37,7 +37,7 @@ class FakeApp implements BootstrapApp {
 }
 
 describe('application identity bootstrap', () => {
-  test('keeps the published Murmur identity active', () => {
+  test('keeps the published Murmur compatibility identity while Eve is visible', () => {
     expect(MURMUR_IDENTITY).toEqual({
       productName: 'Murmur',
       appId: 'com.murmur.app',

--- a/app/tests/diagnostics-report.test.ts
+++ b/app/tests/diagnostics-report.test.ts
@@ -32,7 +32,7 @@ describe('privacy-safe diagnostics report', () => {
         vc_redist: { installed: true },
         warnings: [],
       },
-    })).toBe(`Murmur diagnostics
+    })).toBe(`Eve diagnostics
 App version: 0.6.2
 Windows: 10.0.26100 (x64)
 Server mode: managed
@@ -115,7 +115,7 @@ VC++ runtime installed: yes
 
     expect(output).toContain('Server mode: external');
     expect(output).toContain('Model: custom/local model');
-    expect(output).toContain('- cuda_unavailable: CUDA is unavailable; Murmur may use CPU mode.');
+    expect(output).toContain('- cuda_unavailable: CUDA is unavailable; Eve may use CPU mode.');
     expect(output).toContain('- unknown_warning: Additional details omitted for privacy.');
     for (const sensitive of sensitiveValues) expect(output).not.toContain(sensitive);
     expect(output).not.toContain('51717');

--- a/app/tests/eve-visible-identity.test.ts
+++ b/app/tests/eve-visible-identity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const APP_ROOT = path.resolve(import.meta.dir, '..');
+
+const VISIBLE_PRODUCT_FILES = [
+  'src/main/bootstrap.ts',
+  'src/main/index.ts',
+  'src/main/services/diagnostics-report.ts',
+  'src/main/services/tray.ts',
+  'src/renderer/app/components/TitleBar.svelte',
+  'src/renderer/app/index.html',
+  'src/renderer/app/views/SettingsView.svelte',
+  'src/renderer/overlay/index.html',
+  'src/shared/model-progress.ts',
+];
+
+describe('Eve visible identity', () => {
+  test('keeps legacy branding out of active user-facing surfaces', () => {
+    for (const relativePath of VISIBLE_PRODUCT_FILES) {
+      const contents = readFileSync(path.join(APP_ROOT, relativePath), 'utf8');
+      const withoutAllowedInternalNames = contents.replaceAll(
+        'getMurmurTrayIcon',
+        'getCompatibilityTrayIcon'
+      );
+      expect(withoutAllowedInternalNames).not.toContain('Murmur');
+    }
+  });
+
+  test('uses an Eve-branded default export name', () => {
+    const handlers = readFileSync(
+      path.join(APP_ROOT, 'src/main/ipc/handlers.ts'),
+      'utf8'
+    );
+    expect(handlers).toContain("defaultPath: 'eve-hotwords.csv'");
+    expect(handlers).not.toContain("defaultPath: 'murmur-hotwords.csv'");
+  });
+});

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -3,9 +3,10 @@
 ## Status
 
 Accepted for staged implementation. Gate 1 compatibility scaffolding merged in PR #15 at
-`5e5b3a3c458d56279e8ece37c51827ce60cfa7a0`. Gate 2 implementation is authorized only
-for the clean Eve data boundary described here; packaging, host installation, registry
-changes, visible renaming, publication, and merge remain separately gated.
+`5e5b3a3c458d56279e8ece37c51827ce60cfa7a0`, and Gate 2 merged in PR #16 at
+`ca9eddbc8c6a40af7194fbb6a2f172109f46b84d`. Gate 3 is authorized for the visible
+Eve-name bridge described here. AppUserModelID, startup-registration changes, visual
+redesign, publication, and merge remain separately gated.
 
 The companion [cutover checklist](eve-identity-cutover-checklist.md) maps this decision to exact files, release gates, checks, and remaining work.
 
@@ -243,9 +244,10 @@ After the compatibility window, internal `MURMUR_*`, Python package, preload bri
 
 ## Explicit no-go actions
 
-Until a later implementation phase is approved:
+During the authorized Gate 3 implementation:
 
-- do not change `com.murmur.app`, `productName`, executable, installer, shortcut, package, or artifact names;
+- change only the visible `productName`, executable, installer, shortcut, and current artifact names to Eve;
+- do not change `com.murmur.app`, the explicit NSIS GUID, internal package name, or compatibility payload name;
 - do not add, edit, or remove registry entries or startup registrations;
 - do not read, copy, merge, rename, or delete Murmur History, settings, browser storage, logs, or other personal data;
 - do not move or delete `%APPDATA%\murmur`;
@@ -256,10 +258,11 @@ Until a later implementation phase is approved:
 
 ## Implementation progress
 
-Gate 1 compatibility scaffolding is complete in merged PR #15. Gate 2 is a separate
-compatibility PR that activates `%APPDATA%\Eve` before importing data consumers while
-retaining all published Murmur product and installer identities. Its automated Gate A and
-approved Gate B package/lifecycle acceptance are recorded in the companion evidence.
+Gate 1 compatibility scaffolding is complete in merged PR #15. Gate 2 is complete in
+merged PR #16 and activates `%APPDATA%\Eve` before importing data consumers while
+retaining the published installer identity. Gate 3 changes visible product surfaces to
+Eve while preserving the AppUserModelID, NSIS GUID, internal APIs, and legacy data
+boundary. Its acceptance evidence will be recorded before the Gate 3 PR is marked ready.
 Filesystem path tracing is explicitly out of scope for this gate: its absence limits the
 available evidence but is not a draft, readiness, or merge criterion.
 

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -246,7 +246,9 @@ After the compatibility window, internal `MURMUR_*`, Python package, preload bri
 
 During the authorized Gate 3 implementation:
 
-- change only the visible `productName`, executable, installer, shortcut, and current artifact names to Eve;
+- change only the visible `productName`, executable, installer, shortcut, current
+  artifact names, and active UI copy in tray strings, dialogs, diagnostics, and
+  model-progress text to Eve;
 - do not change `com.murmur.app`, the explicit NSIS GUID, internal package name, or compatibility payload name;
 - do not add, edit, or remove registry entries or startup registrations;
 - do not read, copy, merge, rename, or delete Murmur History, settings, browser storage, logs, or other personal data;

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -262,9 +262,10 @@ Gate 1 compatibility scaffolding is complete in merged PR #15. Gate 2 is complet
 merged PR #16 and activates `%APPDATA%\Eve` before importing data consumers while
 retaining the published installer identity. Gate 3 changes visible product surfaces to
 Eve while preserving the AppUserModelID, NSIS GUID, internal APIs, and legacy data
-boundary. Its acceptance evidence will be recorded before the Gate 3 PR is marked ready.
-Filesystem path tracing is explicitly out of scope for this gate: its absence limits the
-available evidence but is not a draft, readiness, or merge criterion.
+boundary. Its automated and Windows lifecycle acceptance is recorded in
+[Gate 3 evidence](eve-identity-gate-3-evidence.md). Filesystem path tracing is explicitly
+out of scope for this gate: its absence limits the available evidence but is not a
+draft, readiness, or merge criterion.
 
 ## Consequences
 

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -163,8 +163,8 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Select final Eve data-root casing | Complete: exact `%APPDATA%\Eve` | No |
 | Select final AppUserModelID | Pending; Gate 4 only | Separate approval |
 | Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
-| Fresh Eve profile implementation | Gate A passes on `codex/eve-fresh-profile-gate-2`; Gate B candidate Fast/Long smoke, repair, normal uninstall preservation, and rollback evidence captured; path tracing is an out-of-scope evidence limitation | Fresh CI and substantive review passed; merge remains separately approved |
-| Visible installed-product rename | Pending | Separate approval after data isolation passes |
+| Fresh Eve profile implementation | Complete in merged PR #16 at `ca9eddb`; Gate A/B evidence includes Fast/Long smoke, repair, normal uninstall preservation, and official rollback | No |
+| Visible installed-product rename | In progress on `codex/eve-visible-identity-gate-3`; AppUserModelID and startup registrations remain deferred | Gate 3 acceptance and merge approval |
 | AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |
 | Visual identity and homepage | Pending | Later design phase |
 | Thin-client/component packs and ASR profiles | Pending | Later technical phase |

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -164,7 +164,7 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Select final AppUserModelID | Pending; Gate 4 only | Separate approval |
 | Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
 | Fresh Eve profile implementation | Complete in merged PR #16 at `ca9eddb`; Gate A/B evidence includes Fast/Long smoke, repair, normal uninstall preservation, and official rollback | No |
-| Visible installed-product rename | In progress on `codex/eve-visible-identity-gate-3`; AppUserModelID and startup registrations remain deferred | Gate 3 acceptance and merge approval |
+| Visible installed-product rename | Complete on `codex/eve-visible-identity-gate-3`; see [Gate 3 evidence](eve-identity-gate-3-evidence.md). AppUserModelID and startup registrations remain deferred | Merge approval |
 | AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |
 | Visual identity and homepage | Pending | Later design phase |
 | Thin-client/component packs and ASR profiles | Pending | Later technical phase |

--- a/docs/architecture/eve-identity-gate-3-evidence.md
+++ b/docs/architecture/eve-identity-gate-3-evidence.md
@@ -20,15 +20,18 @@ assets, manifests, temporary helpers, dependency changes, or diagnostic artifact
 
 ## Automated verification
 
-| Check | Result |
-|---|---|
-| `python scripts/version.py check` | Passed at `0.6.3`. |
-| App suite, `bun test` | 89 passed, 0 failed. |
-| Server suite, `uv run --no-sync pytest -q` | 139 passed. |
-| Production app build, `bun run build` | Passed. |
-| PowerShell and JSON parsing | Passed for the changed installer/release scripts and package configuration. |
-| `git diff --check` | Passed. |
-| Scope audit | No lockfile, dependency, workflow, runtime, model, server-source, release, or generated-output changes. |
+Commands ran natively in Windows PowerShell 7.5.8. Copy-pasteable wrapper invocations
+from the repository root are recorded below.
+
+| Check | Windows PowerShell invocation | Result |
+|---|---|---|
+| Version consistency | `& "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -Command "python scripts/version.py check"` | Passed at `0.6.3`. |
+| App suite | `& "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -Command "Set-Location app; bun test"` | 89 passed, 0 failed. |
+| Server suite | `& "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -Command "Set-Location server; uv run --no-sync pytest -q"` | 139 passed. |
+| Production app build | `& "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -Command "Set-Location app; bun run build"` | Passed. |
+| PowerShell and JSON parsing | — | Passed for the changed installer/release scripts and package configuration. |
+| `git diff --check` | — | Passed. |
+| Scope audit | — | No lockfile, dependency, workflow, runtime, model, server-source, release, or generated-output changes. |
 
 The new regression test checks only visible identity surfaces and explicitly permits
 the frozen internal compatibility token `getMurmurTrayIcon`. Its first local run exposed

--- a/docs/architecture/eve-identity-gate-3-evidence.md
+++ b/docs/architecture/eve-identity-gate-3-evidence.md
@@ -1,0 +1,90 @@
+# Eve identity Gate 3 evidence
+
+## Scope and decision
+
+Gate 3 changes the visible Windows product identity from Murmur to Eve while preserving
+the merged Gate 2 data boundary and installer chain. Work began from exact trunk commit
+`ca9eddbc8c6a40af7194fbb6a2f172109f46b84d`. The implementation commit is
+`0cf9da847efa408845014a952e5953a4712b63ff`.
+
+The change keeps version `0.6.3`, `com.murmur.app`, NSIS GUID
+`0204d005-75b3-5b31-b1f6-ef2831e2b204`, package name `murmur`, compatibility payload
+name `murmur-0.6.3-x64.nsis.7z`, preload bridges, `MURMUR_*` variables, Python package
+names, update/release identity, and both profile roots unchanged. AppUserModelID,
+startup-registration migration, icons, visual design, homepage, signing, release
+publication, dependencies, models, and server behavior remain out of scope.
+
+The final Gate 3 diff contains 25 files: 24 implementation/test/documentation files and
+this evidence record. It contains no generated packages, logs, audio output, downloaded
+assets, manifests, temporary helpers, dependency changes, or diagnostic artifacts.
+
+## Automated verification
+
+| Check | Result |
+|---|---|
+| `python scripts/version.py check` | Passed at `0.6.3`. |
+| App suite, `bun test` | 89 passed, 0 failed. |
+| Server suite, `uv run --no-sync pytest -q` | 139 passed. |
+| Production app build, `bun run build` | Passed. |
+| PowerShell and JSON parsing | Passed for the changed installer/release scripts and package configuration. |
+| `git diff --check` | Passed. |
+| Scope audit | No lockfile, dependency, workflow, runtime, model, server-source, release, or generated-output changes. |
+
+The new regression test checks only visible identity surfaces and explicitly permits
+the frozen internal compatibility token `getMurmurTrayIcon`. Its first local run exposed
+an overbroad test assertion, not a product defect; the assertion was narrowed before
+the complete passing rerun.
+
+## Deterministic package and artifacts
+
+The candidate source worktree did not contain a complete Python runtime, so packaging
+did not begin there. Runtime assets were recovered from the preserved exact detached
+Gate 2 build tree only after confirming that dependency-defining server paths were
+identical. The recovered target contained:
+
+- `.runtime`: 1,885 files and 55,187,715 bytes;
+- `.venv`: 30,215 files and 5,023,766,618 bytes;
+- Python 3.11.15, Torch 2.6.0+cu124, working NeMo/faster-whisper imports, CUDA available.
+
+Exactly one `bun run package:win` invocation ran from the detached E:-resident worktree
+at `0cf9da847efa408845014a952e5953a4712b63ff`. It completed successfully in 831 seconds.
+No rejected, partial, or prior candidate payload was reused.
+
+| Fresh output | Bytes | SHA-256 |
+|---|---:|---|
+| `Eve.Web.Setup.0.6.3.exe` | 887,486 | `8D71E7089677625E693B97E88CB4EB151E95AF06A251765F214FDDF97EF02328` |
+| `murmur-0.6.3-x64.nsis.7z` | 2,033,992,770 | `1B2555CE7AE54EF3544DA41C806AD10EFF9CD4788B0F3576F285A4556A3B9899` |
+| `latest.yml` | 558 | `40936EF36BF294A1C2A2B4580C9055C1ED77F6A987EA5CBFA508C5B876C2A40E` |
+
+Two independent copies of all three outputs were hash-verified before lifecycle use.
+The unpacked executable was `Eve.exe`; its ProductName and FileDescription were `Eve`,
+and its ProductVersion was `0.6.3.0`.
+
+## Windows lifecycle acceptance
+
+| Boundary | Result |
+|---|---|
+| Published baseline | Official Murmur v0.6.3 was healthy with a ready model before candidate installation. |
+| Upgrade/install | Set A installed with exit `0` through the frozen GUID and reused the legacy install root. Control Panel showed `Eve 0.6.3`; `Eve.exe`, `Uninstall Eve.exe`, Start-menu shortcut, and desktop shortcut were present. No second uninstall entry was created. |
+| Runtime closure | Candidate `/health` reported `0.6.3`, healthy, engine/model ready, CUDA available, and CUDA DLLs present. |
+| Controlled smoke | Fast fixture: 10.0 seconds and a non-empty final result. Long fixture: 47.334 seconds, a non-empty final result, and both long-dictation status boundaries. No transcript or audio output was retained. |
+| Singleton | A second launch exited without increasing the packaged process count. |
+| Same-version repair | Untouched Set B repair exited `0`; the candidate `app.asar` remained SHA-256 `94CE03EAD4483CC98F3F7FDEE761D43053F04E121FE35244C5F6CF0FB5BB2153`; repaired health, model, engine, CUDA, and DLL checks passed. |
+| Normal uninstall | `Uninstall Eve.exe /S /currentuser` exited `0`; install root and frozen GUID entry were removed. Murmur remained 113 files/12,690,479 bytes and Eve remained 44 files/3,015,012 bytes. Login-entry fingerprints were unchanged and the shared model cache remained present. |
+| Official rollback | The published installer (887,561 bytes, SHA-256 `366088A4266F54EA7C39E2E7FD1FC7177CAC46BF8A4B3F43D58A6D025E15CD33`) and payload (2,034,188,308 bytes, SHA-256 `0B557FDE05853DA1F7C0AEF77CECBAD1FAF8C5FC9314457EA45119D3A69F4FBD`) restored Murmur v0.6.3. Installed `app.asar` matched `98910F5CD2C3A9426ECD7850EE352E47F9C48FB00BB5EEF526220660E69FC8FD`; fresh PID-file health was healthy with ready Whisper, cached model, CUDA and CUDA DLLs available, and zero diagnostics warnings. |
+
+An initial rollback assertion used the candidate-side field name `engine.state`; the
+published server correctly reports `engine.status`. The captured response already
+showed healthy/ready state, and the corrected schema assertion passed immediately.
+This was an acceptance-harness correction, not a product failure.
+
+An unrelated pre-existing shortcut outside the managed install locations was left
+untouched. No personal profile contents were inspected or recorded. ProcMon/WPR and
+filesystem tracing remained explicitly out of scope.
+
+## Acceptance conclusion
+
+Gate 3 meets its defined boundary: the installed product and current visible UI identify
+as Eve, while upgrade/repair/uninstall continuity, fresh Eve profile isolation, both
+profile roots, login state, shared models, frozen installer identity, and official
+rollback remain intact. Gate 4 AppUserModelID work remains separately gated.

--- a/docs/windows-local-cuda-dictation.md
+++ b/docs/windows-local-cuda-dictation.md
@@ -1,6 +1,12 @@
 # Windows local CUDA dictation setup
 
-This document captures a reproducible Windows 11 setup for running Murmur as a fully local, GPU-accelerated push-to-talk dictation assistant.
+This document is the historical, machine-specific recovery record for the published
+v0.6.3 Murmur release. Its Murmur paths are intentionally unchanged. Current source
+builds are visibly named Eve and use `%APPDATA%\Eve`; use `BUILDING.md` for current
+build instructions.
+
+It captures a reproducible Windows 11 setup for running the published Murmur release
+as a fully local, GPU-accelerated push-to-talk dictation assistant.
 
 ## Verified machine-local paths
 

--- a/scripts/installer-smoke.ps1
+++ b/scripts/installer-smoke.ps1
@@ -58,17 +58,17 @@ function Stop-ProductProcesses {
     Get-Process -Name "Eve","Murmur" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 }
 
-function Resolve-UninstallerPath {
-    param([string]$Directory)
+function Resolve-UninstallerPaths {
+    param([string[]]$Directories)
 
-    foreach ($name in @("Uninstall Eve.exe", "Uninstall Murmur.exe")) {
-        $candidate = Join-Path $Directory $name
-        if (Test-Path $candidate) {
-            return $candidate
+    foreach ($directory in ($Directories | Select-Object -Unique)) {
+        foreach ($name in @("Uninstall Eve.exe", "Uninstall Murmur.exe")) {
+            $candidate = Join-Path $directory $name
+            if (Test-Path $candidate) {
+                $candidate
+            }
         }
     }
-
-    return $null
 }
 
 function Wait-For-Health {
@@ -153,11 +153,12 @@ if (-not $SkipUninstall) {
     Write-Step "Stopping any running Eve or legacy Murmur processes"
     Stop-ProductProcesses
 
-    $uninstaller = Resolve-UninstallerPath -Directory $InstallDir
-    if ($uninstaller) {
-        Write-Step "Uninstalling existing Eve or legacy Murmur installation"
+    $legacyInstallDir = "$env:LOCALAPPDATA\Programs\murmur"
+    $uninstallers = @(Resolve-UninstallerPaths -Directories @($InstallDir, $legacyInstallDir))
+    foreach ($uninstaller in $uninstallers) {
+        Write-Step "Uninstalling existing Eve or legacy Murmur installation at $uninstaller"
         $uninstallProc = Start-Process -Wait -FilePath $uninstaller -ArgumentList "/S" -PassThru
-        Assert-ExitCode -Process $uninstallProc -Step "Uninstall"
+        Assert-ExitCode -Process $uninstallProc -Step "Uninstall $uninstaller"
     }
 }
 

--- a/scripts/installer-smoke.ps1
+++ b/scripts/installer-smoke.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [string]$InstallerPath,
-    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\Murmur",
+    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\Eve",
     [string]$Model = "",
     [int]$HealthTimeoutSec = 180,
     [int]$DownloadTimeoutSec = 1200,
@@ -45,7 +45,7 @@ function Resolve-InstallerPath {
     foreach ($root in $roots) {
         $resolved = Resolve-Path $root -ErrorAction SilentlyContinue
         if (-not $resolved) { continue }
-        $candidate = Get-ChildItem -Path $resolved -Filter "Murmur*Setup*.exe" -File |
+        $candidate = Get-ChildItem -Path $resolved -Filter "Eve*Setup*.exe" -File |
             Sort-Object LastWriteTime -Descending |
             Select-Object -First 1
         if ($candidate) { return $candidate.FullName }
@@ -54,8 +54,21 @@ function Resolve-InstallerPath {
     return $null
 }
 
-function Stop-MurmurProcesses {
-    Get-Process -Name "Murmur" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+function Stop-ProductProcesses {
+    Get-Process -Name "Eve","Murmur" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+function Resolve-UninstallerPath {
+    param([string]$Directory)
+
+    foreach ($name in @("Uninstall Eve.exe", "Uninstall Murmur.exe")) {
+        $candidate = Join-Path $Directory $name
+        if (Test-Path $candidate) {
+            return $candidate
+        }
+    }
+
+    return $null
 }
 
 function Wait-For-Health {
@@ -131,24 +144,24 @@ if ($env:OS -ne "Windows_NT") {
 
 $resolvedInstaller = Resolve-InstallerPath -ExplicitPath $InstallerPath
 if (-not $resolvedInstaller) {
-    throw "Installer not found. Pass -InstallerPath or ensure app/release has a Murmur Setup*.exe."
+    throw "Installer not found. Pass -InstallerPath or ensure app/release has an Eve Setup*.exe."
 }
 
 Write-Step "Using installer: $resolvedInstaller"
 
 if (-not $SkipUninstall) {
-    Write-Step "Stopping any running Murmur processes"
-    Stop-MurmurProcesses
+    Write-Step "Stopping any running Eve or legacy Murmur processes"
+    Stop-ProductProcesses
 
-    $uninstaller = Join-Path $InstallDir "Uninstall Murmur.exe"
-    if (Test-Path $uninstaller) {
-        Write-Step "Uninstalling existing Murmur"
+    $uninstaller = Resolve-UninstallerPath -Directory $InstallDir
+    if ($uninstaller) {
+        Write-Step "Uninstalling existing Eve or legacy Murmur installation"
         $uninstallProc = Start-Process -Wait -FilePath $uninstaller -ArgumentList "/S" -PassThru
         Assert-ExitCode -Process $uninstallProc -Step "Uninstall"
     }
 }
 
-$hfHome = Join-Path $env:LOCALAPPDATA "Murmur\hf-smoke"
+$hfHome = Join-Path $env:LOCALAPPDATA "Eve\hf-smoke"
 $env:HF_HOME = $hfHome
 $env:HF_HUB_CACHE = Join-Path $hfHome "hub"
 
@@ -170,7 +183,7 @@ if (Test-Path $PidFilePath) {
     Remove-Item -Path $PidFilePath -Force
 }
 
-Write-Step "Installing Murmur"
+Write-Step "Installing Eve"
 $installProc = Start-Process -Wait -FilePath $resolvedInstaller -ArgumentList @("/S", "/D=$InstallDir") -PassThru
 Assert-ExitCode -Process $installProc -Step "Install"
 
@@ -179,13 +192,13 @@ if ($SkipLaunch) {
     exit 0
 }
 
-$exePath = Join-Path $InstallDir "Murmur.exe"
+$exePath = Join-Path $InstallDir "Eve.exe"
 if (-not (Test-Path $exePath)) {
     throw "Installed app not found at $exePath"
 }
 
 $launchStartedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
-Write-Step "Launching Murmur"
+Write-Step "Launching Eve"
 $launchTimeUtc = (Get-Date).ToUniversalTime()
 $process = Start-Process -FilePath $exePath -WorkingDirectory $InstallDir -PassThru
 
@@ -242,7 +255,7 @@ try {
         throw "Expected a fresh download, but detail=$($state.detail)"
     }
 } finally {
-    Write-Step "Stopping Murmur"
+    Write-Step "Stopping Eve"
     if ($process -and -not $process.HasExited) {
         Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
     }

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -1,8 +1,8 @@
 [CmdletBinding()]
 param(
     [string]$ExpectedVersion = "0.6.3",
-    [string]$InstallerDir = "E:\MurmurRelease\release-prep\full-nsis-web\nsis-web",
-    [string]$InstallDir = "E:\MurmurRelease\release-prep\smoke-install\Murmur",
+    [string]$InstallerDir = "E:\EveRelease\release-prep\full-nsis-web\nsis-web",
+    [string]$InstallDir = "E:\EveRelease\release-prep\smoke-install\Eve",
     [string]$BaseBranch = "trunk",
     [int]$HealthPort = 8765,
     [int]$HealthTimeoutSec = 180
@@ -82,7 +82,7 @@ try {
     Pop-Location
 }
 
-$setupExe = Join-Path $InstallerDir "Murmur Web Setup $ExpectedVersion.exe"
+$setupExe = Join-Path $InstallerDir "Eve.Web.Setup.$ExpectedVersion.exe"
 $payload7z = Join-Path $InstallerDir "murmur-$ExpectedVersion-x64.nsis.7z"
 $latestYml = Join-Path $InstallerDir "latest.yml"
 
@@ -93,10 +93,10 @@ Assert-Path $latestYml "latest.yml"
 Assert-Contains -Value (Get-Content -LiteralPath $latestYml -Raw) -Expected $ExpectedVersion -Description "latest.yml"
 
 Write-Step "Checking installed payload contents"
-$appExe = Join-Path $InstallDir "Murmur.exe"
+$appExe = Join-Path $InstallDir "Eve.exe"
 $serverRoot = Join-Path $InstallDir "resources\server"
 $pythonExe = Join-Path $serverRoot ".venv\Scripts\python.exe"
-Assert-Path $appExe "Installed Murmur.exe"
+Assert-Path $appExe "Installed Eve.exe"
 Assert-Path $pythonExe "Bundled Python"
 Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\faster_whisper") "faster-whisper package"
 Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\torch") "torch package"

--- a/server/tests/test_installer_smoke_script.py
+++ b/server/tests/test_installer_smoke_script.py
@@ -28,5 +28,9 @@ def test_installer_smoke_script_exists_and_targets_health() -> None:
     assert '"Eve*Setup*.exe"' in contents
     assert '"Uninstall Eve.exe"' in contents
     assert '"Uninstall Murmur.exe"' in contents
+    assert "Resolve-UninstallerPaths -Directories @($InstallDir, $legacyInstallDir)" in contents
+    assert '"$env:LOCALAPPDATA\\Programs\\murmur"' in contents
+    assert "foreach ($uninstaller in $uninstallers)" in contents
+    assert "Assert-ExitCode -Process $uninstallProc" in contents
     assert '"Eve.exe"' in contents
     assert 'Get-Process -Name "Eve","Murmur"' in contents

--- a/server/tests/test_installer_smoke_script.py
+++ b/server/tests/test_installer_smoke_script.py
@@ -24,3 +24,9 @@ def test_installer_smoke_script_exists_and_targets_health() -> None:
     assert "RequireVcRedist" in contents
     assert "RequireDriverMinimum" in contents
     assert "RequireModelDownload" in contents
+    assert '"$env:LOCALAPPDATA\\Programs\\Eve"' in contents
+    assert '"Eve*Setup*.exe"' in contents
+    assert '"Uninstall Eve.exe"' in contents
+    assert '"Uninstall Murmur.exe"' in contents
+    assert '"Eve.exe"' in contents
+    assert 'Get-Process -Name "Eve","Murmur"' in contents

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -59,12 +59,17 @@ def test_nsis_web_identity_and_data_retention_are_explicit() -> None:
     build = package_json.get("build", {})
     nsis_web = build.get("nsisWeb", {})
 
+    assert package_json.get("name") == "murmur"
     assert build.get("appId") == "com.murmur.app"
-    assert build.get("productName") == "Murmur"
+    assert build.get("productName") == "Eve"
+    assert build.get("executableName") == "Eve"
     assert nsis_web == {
         "guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204",
         "oneClick": True,
         "deleteAppDataOnUninstall": False,
+        "artifactName": "Eve.Web.Setup.${version}.${ext}",
+        "shortcutName": "Eve",
+        "uninstallDisplayName": "Eve ${version}",
     }
 
 
@@ -114,6 +119,15 @@ def test_windows_packaging_never_publishes_implicitly() -> None:
     package_json = _load_package_json()
     package_script = package_json.get("scripts", {}).get("package:win", "")
     assert "--publish never" in package_script
+
+
+def test_release_verification_targets_eve_with_legacy_payload_name() -> None:
+    contents = (ROOT / "scripts" / "release-verify.ps1").read_text(
+        encoding="utf-8"
+    )
+    assert '"Eve.Web.Setup.$ExpectedVersion.exe"' in contents
+    assert '"Eve.exe"' in contents
+    assert '"murmur-$ExpectedVersion-x64.nsis.7z"' in contents
 
 
 def test_release_workflow_installs_extras_and_uploads_payloads() -> None:


### PR DESCRIPTION
## Summary
- cut over the visible Windows product, executable, installer, shortcut, diagnostics, and active UI name from Murmur to Eve
- preserve the frozen NSIS GUID, `com.murmur.app`, compatibility payload/internal names, Gate 2 fresh-profile boundary, dependencies, and release identity
- update focused regression coverage and record deterministic Windows lifecycle evidence

## Verification
- `python scripts/version.py check`
- app: 89 passed, 0 failed
- server: 139 passed
- `bun run build`
- exactly one Windows package run from the exact detached candidate tree
- upgrade, Fast/47.334s Long smoke, singleton, untouched-payload repair, normal uninstall with both profiles preserved, and published v0.6.3 rollback
- focused post-evidence checks: app 13/13; server/release 15/15
- `git diff --check`; 25 files; clean worktree

## Boundaries
No AppUserModelID/startup-registration cutover, visual redesign, homepage work, dependency/model/server changes, release publication, generated artifacts, or personal-data migration. ProcMon/WPR remains explicitly out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rebranded visible Windows product, installer, executable, shortcuts, tray, dialogs, overlays, diagnostics, and settings from Murmur to Eve.
  * Eve builds now use a separate `%APPDATA%\Eve` profile while preserving upgrade compatibility with existing Murmur installations.
  * Hotwords exports now default to `eve-hotwords.csv`.

* **Documentation**
  * Updated Windows build, release, architecture, and identity migration documentation to reflect the Eve branding and compatibility behavior.

* **Tests**
  * Added and updated automated checks for Eve branding, packaging, installer behavior, and release verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->