### PR TITLE
feat: cut over Eve Windows application identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Local dictation for Windows, built as an Electron desktop client with a packaged
 <img src="https://img.shields.io/badge/v0.6.3-orange?style=flat-square" alt="v0.6.3">
 
 > [!IMPORTANT]
-> Current source builds use the visible **Eve** product, executable, installer, and shortcut names with a separate `%APPDATA%\Eve` profile. The published v0.6.3 download remains **Murmur** and is listed below unchanged. The bridge release deliberately retains the `com.murmur.app` AppUserModelID, installer GUID, internal `murmur` package name, and `MURMUR_*` interfaces for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.
+> Current source builds use the visible **Eve** product, executable, installer, and shortcut names, the `io.github.burntcookiedough.eve` AppUserModelID, and a separate `%APPDATA%\Eve` profile. The published v0.6.3 download remains **Murmur** and is listed below unchanged. The frozen installer GUID, internal `murmur` package name, compatibility payload name, and `MURMUR_*` interfaces remain stable for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.
 
 ## What works today
 

--- a/app/package.json
+++ b/app/package.json
@@ -51,7 +51,7 @@
     "fast-uri": "3.1.3"
   },
   "build": {
-    "appId": "com.murmur.app",
+    "appId": "io.github.burntcookiedough.eve",
     "productName": "Eve",
     "executableName": "Eve",
     "directories": {

--- a/app/src/main/bootstrap-core.ts
+++ b/app/src/main/bootstrap-core.ts
@@ -1,4 +1,4 @@
-import { MURMUR_IDENTITY } from './identity.js';
+import { EVE_IDENTITY } from './identity.js';
 import { prepareUserDataRootSync } from './user-data-root.js';
 
 export interface BootstrapApp {
@@ -47,7 +47,7 @@ export async function bootstrapApplication(
   }
 
   if ((options.platform ?? process.platform) === 'win32') {
-    electronApp.setAppUserModelId(MURMUR_IDENTITY.appId);
+    electronApp.setAppUserModelId(EVE_IDENTITY.appId);
   }
 
   await loadApplication();

--- a/app/src/main/identity.ts
+++ b/app/src/main/identity.ts
@@ -17,7 +17,15 @@ export const MURMUR_IDENTITY = {
 } as const satisfies ApplicationIdentity;
 
 /**
- * Active visible product name and isolated user-data directory.
+ * Active Eve process and data identity. The installer GUID remains frozen to
+ * preserve the published Murmur upgrade and uninstall chain.
  */
-export const EVE_PRODUCT_NAME = 'Eve' as const;
-export const EVE_USER_DATA_DIRECTORY_NAME = 'Eve' as const;
+export const EVE_IDENTITY = {
+  productName: 'Eve',
+  appId: 'io.github.burntcookiedough.eve',
+  userDataDirectoryName: 'Eve',
+  nsisGuid: MURMUR_IDENTITY.nsisGuid,
+} as const satisfies ApplicationIdentity;
+
+export const EVE_PRODUCT_NAME = EVE_IDENTITY.productName;
+export const EVE_USER_DATA_DIRECTORY_NAME = EVE_IDENTITY.userDataDirectoryName;

--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -18,8 +18,13 @@ import {
 } from '../services/server-settings.js';
 import { startHotkeyCapture, cancelHotkeyCapture } from '../services/hotkey.js';
 import { formatHotkey } from '../services/keycodes.js';
-import { validateLaunchOnBootUpdate } from '../login-item-policy.js';
+import { createLogger } from '../lib/logger.js';
+import {
+  applyLaunchOnBoot,
+  reconcileLegacyLoginItems,
+} from '../login-item-policy.js';
 
+const log = createLogger('IpcHandlers');
 let historyServiceRef: HistoryService | null = null;
 let serverManagerRef: ServerManager | null = null;
 
@@ -30,6 +35,19 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
   }
   if (serverManager) {
     serverManagerRef = serverManager;
+  }
+
+  try {
+    const result = reconcileLegacyLoginItems(app, {
+      localAppData: process.env.LOCALAPPDATA,
+    });
+    if (result.ignoredLegacyCandidates > 0) {
+      log.warn('Left unrecognized launch-on-login entries unchanged', {
+        count: result.ignoredLegacyCandidates,
+      });
+    }
+  } catch {
+    log.warn('Could not reconcile exact legacy launch-on-login entries');
   }
 
   // Handle clipboard copy requests
@@ -61,7 +79,14 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
     IPC_CHANNELS.UPDATE_SETTING,
     async (_event, key: keyof Settings, value: Settings[keyof Settings]) => {
       if (key === 'launchOnBoot') {
-        validateLaunchOnBootUpdate(value);
+        const result = applyLaunchOnBoot(app, value, {
+          localAppData: process.env.LOCALAPPDATA,
+        });
+        if (result.ignoredLegacyCandidates > 0) {
+          log.warn('Left unrecognized launch-on-login entries unchanged', {
+            count: result.ignoredLegacyCandidates,
+          });
+        }
       }
 
       updateSetting(key, value);

--- a/app/src/main/login-item-policy.ts
+++ b/app/src/main/login-item-policy.ts
@@ -144,14 +144,13 @@ export function reconcileLegacyLoginItems(
     };
   }
 
-  const executablePath = app.getPath('exe');
   const legacyExecutablePath = path.win32.join(
     context.localAppData,
     'Programs',
     'murmur',
     'Murmur.exe'
   );
-  const launchItems = getLaunchItems(app, executablePath);
+  const launchItems = getLaunchItems(app, legacyExecutablePath);
   const exactLegacyItems = launchItems.filter(
     (item) =>
       LEGACY_LOGIN_ITEM_NAMES.includes(
@@ -177,7 +176,7 @@ export function reconcileLegacyLoginItems(
     setExactLoginItem(app, item.name, legacyExecutablePath, false);
   }
 
-  const remainingItems = getLaunchItems(app, executablePath);
+  const remainingItems = getLaunchItems(app, legacyExecutablePath);
   const legacyEntryRemains = remainingItems.some((item) =>
     exactLegacyItems.some((legacyItem) =>
       isExactUserLoginItem(item, legacyItem.name, legacyExecutablePath)

--- a/app/src/main/login-item-policy.ts
+++ b/app/src/main/login-item-policy.ts
@@ -1,10 +1,233 @@
-export const LOGIN_ITEM_CUTOVER_DEFERRED = 'LOGIN_ITEM_CUTOVER_DEFERRED';
+import path from 'node:path';
+import { EVE_IDENTITY, MURMUR_IDENTITY } from './identity.js';
 
-export function validateLaunchOnBootUpdate(enabled: unknown): asserts enabled is boolean {
+export const LOGIN_ITEM_UNAVAILABLE = 'LOGIN_ITEM_UNAVAILABLE';
+export const LOGIN_ITEM_UPDATE_FAILED = 'LOGIN_ITEM_UPDATE_FAILED';
+
+export const LEGACY_LOGIN_ITEM_NAMES = [
+  'Murmur',
+  'electron.app.Murmur',
+  MURMUR_IDENTITY.appId,
+] as const;
+
+interface LoginItem {
+  readonly name: string;
+  readonly path: string;
+  readonly args: string[];
+  readonly scope: 'user' | 'machine';
+  readonly enabled: boolean;
+}
+
+interface LoginItemState {
+  readonly openAtLogin: boolean;
+  readonly executableWillLaunchAtLogin?: boolean;
+  readonly launchItems?: LoginItem[];
+}
+
+interface LoginItemOptions {
+  readonly path?: string;
+  readonly args?: string[];
+}
+
+interface LoginItemUpdate {
+  readonly openAtLogin: boolean;
+  readonly path: string;
+  readonly args: string[];
+  readonly name: string;
+  readonly enabled?: boolean;
+}
+
+export interface LoginItemApp {
+  readonly isPackaged: boolean;
+  getPath(name: 'exe'): string;
+  getLoginItemSettings(options?: LoginItemOptions): LoginItemState;
+  setLoginItemSettings(settings: LoginItemUpdate): void;
+}
+
+export interface LaunchOnBootContext {
+  readonly platform?: NodeJS.Platform;
+  readonly localAppData?: string;
+}
+
+export interface LaunchOnBootResult {
+  readonly removedLegacyEntries: number;
+  readonly ignoredLegacyCandidates: number;
+}
+
+function normalizeWindowsPath(value: string): string {
+  const trimmed = value.trim();
+  const unquoted =
+    trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
+      ? trimmed.slice(1, -1)
+      : trimmed;
+  return path.win32.normalize(unquoted).replace(/[\\/]+$/, '').toLowerCase();
+}
+
+function hasNoArguments(item: LoginItem): boolean {
+  return item.args.length === 0;
+}
+
+function isExactUserLoginItem(
+  item: LoginItem,
+  name: string,
+  executablePath: string
+): boolean {
+  return (
+    item.scope === 'user' &&
+    item.name === name &&
+    normalizeWindowsPath(item.path) === normalizeWindowsPath(executablePath) &&
+    hasNoArguments(item)
+  );
+}
+
+function getLaunchItems(app: LoginItemApp, executablePath: string): LoginItem[] {
+  return app.getLoginItemSettings({
+    path: executablePath,
+    args: [],
+  }).launchItems ?? [];
+}
+
+function setExactLoginItem(
+  app: LoginItemApp,
+  name: string,
+  executablePath: string,
+  enabled: boolean
+): void {
+  app.setLoginItemSettings({
+    openAtLogin: enabled,
+    ...(enabled ? { enabled: true } : {}),
+    name,
+    path: executablePath,
+    args: [],
+  });
+}
+
+function verifyEveLoginItem(
+  app: LoginItemApp,
+  executablePath: string,
+  enabled: boolean
+): boolean {
+  const state = app.getLoginItemSettings({
+    path: executablePath,
+    args: [],
+  });
+  const exactItem = (state.launchItems ?? []).find((item) =>
+    isExactUserLoginItem(item, EVE_IDENTITY.appId, executablePath)
+  );
+
+  if (!enabled) {
+    return exactItem === undefined;
+  }
+  return exactItem?.enabled === true;
+}
+
+export function validateLaunchOnBootUpdate(
+  enabled: unknown
+): asserts enabled is boolean {
   if (typeof enabled !== 'boolean') {
     throw new TypeError('launchOnBoot must be a boolean');
   }
-  if (enabled) {
-    throw new Error(LOGIN_ITEM_CUTOVER_DEFERRED);
+}
+
+export function reconcileLegacyLoginItems(
+  app: LoginItemApp,
+  context: LaunchOnBootContext = {}
+): LaunchOnBootResult {
+  if (
+    (context.platform ?? process.platform) !== 'win32' ||
+    !app.isPackaged ||
+    !context.localAppData
+  ) {
+    return {
+      removedLegacyEntries: 0,
+      ignoredLegacyCandidates: 0,
+    };
+  }
+
+  const executablePath = app.getPath('exe');
+  const legacyExecutablePath = path.win32.join(
+    context.localAppData,
+    'Programs',
+    'murmur',
+    'Murmur.exe'
+  );
+  const launchItems = getLaunchItems(app, executablePath);
+  const exactLegacyItems = launchItems.filter(
+    (item) =>
+      LEGACY_LOGIN_ITEM_NAMES.includes(
+        item.name as (typeof LEGACY_LOGIN_ITEM_NAMES)[number]
+      ) &&
+      isExactUserLoginItem(item, item.name, legacyExecutablePath)
+  );
+  const ignoredLegacyCandidates = launchItems.filter((item) => {
+    const hasKnownName = LEGACY_LOGIN_ITEM_NAMES.includes(
+      item.name as (typeof LEGACY_LOGIN_ITEM_NAMES)[number]
+    );
+    const hasKnownPath =
+      normalizeWindowsPath(item.path) ===
+      normalizeWindowsPath(legacyExecutablePath);
+    const hasSimilarName = item.name.toLowerCase().includes('murmur');
+    return (
+      (hasKnownName || hasKnownPath || hasSimilarName) &&
+      !exactLegacyItems.includes(item)
+    );
+  }).length;
+
+  for (const item of exactLegacyItems) {
+    setExactLoginItem(app, item.name, legacyExecutablePath, false);
+  }
+
+  const remainingItems = getLaunchItems(app, executablePath);
+  const legacyEntryRemains = remainingItems.some((item) =>
+    exactLegacyItems.some((legacyItem) =>
+      isExactUserLoginItem(item, legacyItem.name, legacyExecutablePath)
+    )
+  );
+  if (legacyEntryRemains) {
+    throw new Error(LOGIN_ITEM_UPDATE_FAILED);
+  }
+
+  return {
+    removedLegacyEntries: exactLegacyItems.length,
+    ignoredLegacyCandidates,
+  };
+}
+
+export function applyLaunchOnBoot(
+  app: LoginItemApp,
+  enabled: unknown,
+  context: LaunchOnBootContext = {}
+): LaunchOnBootResult {
+  validateLaunchOnBootUpdate(enabled);
+
+  if ((context.platform ?? process.platform) !== 'win32' || !app.isPackaged) {
+    throw new Error(LOGIN_ITEM_UNAVAILABLE);
+  }
+  if (enabled && !context.localAppData) {
+    throw new Error(LOGIN_ITEM_UNAVAILABLE);
+  }
+
+  const executablePath = app.getPath('exe');
+  setExactLoginItem(app, EVE_IDENTITY.appId, executablePath, enabled);
+
+  if (!verifyEveLoginItem(app, executablePath, enabled)) {
+    if (enabled) {
+      setExactLoginItem(app, EVE_IDENTITY.appId, executablePath, false);
+    }
+    throw new Error(LOGIN_ITEM_UPDATE_FAILED);
+  }
+
+  if (!enabled) {
+    return {
+      removedLegacyEntries: 0,
+      ignoredLegacyCandidates: 0,
+    };
+  }
+
+  try {
+    return reconcileLegacyLoginItems(app, context);
+  } catch {
+    setExactLoginItem(app, EVE_IDENTITY.appId, executablePath, false);
+    throw new Error(LOGIN_ITEM_UPDATE_FAILED);
   }
 }

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -299,7 +299,7 @@
       await window.murmurMain.updateSetting('launchOnBoot', enabled);
     } catch {
       settings.launchOnBoot = previous;
-      toast('Launch on boot is unavailable in this compatibility build', 'error');
+      toast('Eve could not update launch on boot', 'error');
     }
   }
 

--- a/app/tests/bootstrap.test.ts
+++ b/app/tests/bootstrap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
 import { bootstrapApplication, type BootstrapApp } from '../src/main/bootstrap-core';
 import {
+  EVE_IDENTITY,
   EVE_PRODUCT_NAME,
   EVE_USER_DATA_DIRECTORY_NAME,
   MURMUR_IDENTITY,
@@ -37,11 +38,17 @@ class FakeApp implements BootstrapApp {
 }
 
 describe('application identity bootstrap', () => {
-  test('keeps the published Murmur compatibility identity while Eve is visible', () => {
+  test('uses the approved Eve application ID with the frozen installer GUID', () => {
     expect(MURMUR_IDENTITY).toEqual({
       productName: 'Murmur',
       appId: 'com.murmur.app',
       userDataDirectoryName: 'murmur',
+      nsisGuid: '0204d005-75b3-5b31-b1f6-ef2831e2b204',
+    });
+    expect(EVE_IDENTITY).toEqual({
+      productName: 'Eve',
+      appId: 'io.github.burntcookiedough.eve',
+      userDataDirectoryName: 'Eve',
       nsisGuid: '0204d005-75b3-5b31-b1f6-ef2831e2b204',
     });
     expect(EVE_PRODUCT_NAME).toBe('Eve');
@@ -73,7 +80,7 @@ describe('application identity bootstrap', () => {
       `set:userData:${path.join(APP_DATA_PATH, 'Eve')}`,
       `set:sessionData:${path.join(APP_DATA_PATH, 'Eve')}`,
       'lock',
-      'app-id:com.murmur.app',
+      'app-id:io.github.burntcookiedough.eve',
       'load',
     ]);
   });

--- a/app/tests/eve-profile-boundary.test.ts
+++ b/app/tests/eve-profile-boundary.test.ts
@@ -194,7 +194,7 @@ const electronApp = {
         `set:userData:${eveRoot}`,
         `set:sessionData:${eveRoot}`,
         `lock:userData:${eveRoot}:sessionData:${eveRoot}`,
-        'app-id:com.murmur.app',
+        'app-id:io.github.burntcookiedough.eve',
         'load',
       ],
       userData: eveRoot,

--- a/app/tests/login-item-boundary.test.ts
+++ b/app/tests/login-item-boundary.test.ts
@@ -62,15 +62,19 @@ class FakeLoginItemApp implements LoginItemApp {
     const args = options.args ?? [];
     const matchingItems = this.items.filter(
       (item) =>
-        item.scope === 'user' &&
         path.win32.normalize(item.path).toLowerCase() ===
           path.win32.normalize(executablePath).toLowerCase() &&
         item.args.join('\0') === args.join('\0')
     );
     return {
-      openAtLogin: matchingItems.length > 0,
-      executableWillLaunchAtLogin: matchingItems.some((item) => item.enabled),
-      launchItems: this.items.map((item) => ({ ...item, args: [...item.args] })),
+      openAtLogin: matchingItems.some((item) => item.scope === 'user'),
+      executableWillLaunchAtLogin: matchingItems.some(
+        (item) => item.scope === 'user' && item.enabled
+      ),
+      launchItems: matchingItems.map((item) => ({
+        ...item,
+        args: [...item.args],
+      })),
     };
   }
 
@@ -175,7 +179,7 @@ describe('Gate 4 launch-on-login policy', () => {
         ...LEGACY_LOGIN_ITEM_NAMES.map((name) => item(name, LEGACY_EXE)),
         item('Murmur', unpackedPath),
         item('murmur', LEGACY_EXE),
-        item('Murmur Candidate', unpackedPath),
+        item('Murmur Candidate', LEGACY_EXE),
         item('Murmur', LEGACY_EXE, { args: ['--hidden'] }),
         item('Murmur', LEGACY_EXE, { scope: 'machine' }),
         item('Unrelated', String.raw`C:\Elsewhere\Other.exe`),
@@ -189,12 +193,12 @@ describe('Gate 4 launch-on-login policy', () => {
 
     expect(result).toEqual({
       removedLegacyEntries: 3,
-      ignoredLegacyCandidates: 5,
+      ignoredLegacyCandidates: 3,
     });
     expect(app.items).toEqual([
       item('Murmur', unpackedPath),
       item('murmur', LEGACY_EXE),
-      item('Murmur Candidate', unpackedPath),
+      item('Murmur Candidate', LEGACY_EXE),
       item('Murmur', LEGACY_EXE, { args: ['--hidden'] }),
       item('Murmur', LEGACY_EXE, { scope: 'machine' }),
       item('Unrelated', String.raw`C:\Elsewhere\Other.exe`),

--- a/app/tests/login-item-boundary.test.ts
+++ b/app/tests/login-item-boundary.test.ts
@@ -1,21 +1,340 @@
 import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
 import {
-  LOGIN_ITEM_CUTOVER_DEFERRED,
-  validateLaunchOnBootUpdate,
+  applyLaunchOnBoot,
+  LEGACY_LOGIN_ITEM_NAMES,
+  LOGIN_ITEM_UNAVAILABLE,
+  LOGIN_ITEM_UPDATE_FAILED,
+  reconcileLegacyLoginItems,
+  type LoginItemApp,
 } from '../src/main/login-item-policy';
+import { EVE_IDENTITY } from '../src/main/identity';
 
-describe('launch-on-login Gate 2 boundary', () => {
-  test('rejects enabling launch-on-login before settings persistence', () => {
-    expect(() => validateLaunchOnBootUpdate(true)).toThrow(LOGIN_ITEM_CUTOVER_DEFERRED);
-  });
+const EVE_APP_ID = EVE_IDENTITY.appId;
+const EVE_EXE = String.raw`C:\Users\fixture\AppData\Local\Programs\murmur\Eve.exe`;
+const LOCAL_APP_DATA = String.raw`C:\Users\fixture\AppData\Local`;
+const LEGACY_EXE = path.win32.join(
+  LOCAL_APP_DATA,
+  'Programs',
+  'murmur',
+  'Murmur.exe'
+);
 
-  test('allows the fresh-profile disabled value without an OS write', () => {
-    expect(() => validateLaunchOnBootUpdate(false)).not.toThrow();
-  });
+interface FakeLoginItem {
+  name: string;
+  path: string;
+  args: string[];
+  scope: 'user' | 'machine';
+  enabled: boolean;
+}
 
-  test('rejects non-boolean IPC values before settings persistence', () => {
-    for (const value of [undefined, null, 0, 1, '', 'false', {}, []]) {
-      expect(() => validateLaunchOnBootUpdate(value)).toThrow(TypeError);
+class FakeLoginItemApp implements LoginItemApp {
+  readonly writes: Array<{
+    openAtLogin: boolean;
+    path: string;
+    args: string[];
+    name: string;
+    enabled?: boolean;
+  }> = [];
+  readonly isPackaged: boolean;
+  readonly executablePath: string;
+  readonly items: FakeLoginItem[];
+  rejectEveEnable = false;
+  rejectLegacyRemoval = false;
+
+  constructor(options: {
+    isPackaged?: boolean;
+    executablePath?: string;
+    items?: FakeLoginItem[];
+  } = {}) {
+    this.isPackaged = options.isPackaged ?? true;
+    this.executablePath = options.executablePath ?? EVE_EXE;
+    this.items = options.items ?? [];
+  }
+
+  getPath(name: 'exe'): string {
+    expect(name).toBe('exe');
+    return this.executablePath;
+  }
+
+  getLoginItemSettings(options: { path?: string; args?: string[] } = {}) {
+    const executablePath = options.path ?? this.executablePath;
+    const args = options.args ?? [];
+    const matchingItems = this.items.filter(
+      (item) =>
+        item.scope === 'user' &&
+        path.win32.normalize(item.path).toLowerCase() ===
+          path.win32.normalize(executablePath).toLowerCase() &&
+        item.args.join('\0') === args.join('\0')
+    );
+    return {
+      openAtLogin: matchingItems.length > 0,
+      executableWillLaunchAtLogin: matchingItems.some((item) => item.enabled),
+      launchItems: this.items.map((item) => ({ ...item, args: [...item.args] })),
+    };
+  }
+
+  setLoginItemSettings(settings: {
+    openAtLogin: boolean;
+    path: string;
+    args: string[];
+    name: string;
+    enabled?: boolean;
+  }): void {
+    this.writes.push({
+      ...settings,
+      args: [...settings.args],
+    });
+    const existingIndex = this.items.findIndex(
+      (item) =>
+        item.scope === 'user' &&
+        item.name === settings.name &&
+        path.win32.normalize(item.path).toLowerCase() ===
+          path.win32.normalize(settings.path).toLowerCase() &&
+        item.args.join('\0') === settings.args.join('\0')
+    );
+
+    if (!settings.openAtLogin) {
+      if (
+        this.rejectLegacyRemoval &&
+        LEGACY_LOGIN_ITEM_NAMES.includes(
+          settings.name as (typeof LEGACY_LOGIN_ITEM_NAMES)[number]
+        )
+      ) {
+        return;
+      }
+      if (existingIndex >= 0) {
+        this.items.splice(existingIndex, 1);
+      }
+      return;
     }
+    if (this.rejectEveEnable && settings.name === EVE_APP_ID) {
+      return;
+    }
+
+    const item: FakeLoginItem = {
+      name: settings.name,
+      path: settings.path,
+      args: [...settings.args],
+      scope: 'user',
+      enabled: settings.enabled ?? true,
+    };
+    if (existingIndex >= 0) {
+      this.items[existingIndex] = item;
+    } else {
+      this.items.push(item);
+    }
+  }
+}
+
+function item(
+  name: string,
+  executablePath: string,
+  options: Partial<Pick<FakeLoginItem, 'args' | 'scope' | 'enabled'>> = {}
+): FakeLoginItem {
+  return {
+    name,
+    path: executablePath,
+    args: options.args ?? [],
+    scope: options.scope ?? 'user',
+    enabled: options.enabled ?? true,
+  };
+}
+
+describe('Gate 4 launch-on-login policy', () => {
+  test('creates only the approved Eve entry after explicit packaged-Windows opt-in', () => {
+    const app = new FakeLoginItemApp();
+
+    const result = applyLaunchOnBoot(app, true, {
+      platform: 'win32',
+      localAppData: LOCAL_APP_DATA,
+    });
+
+    expect(result).toEqual({
+      removedLegacyEntries: 0,
+      ignoredLegacyCandidates: 0,
+    });
+    expect(app.items).toEqual([
+      item(EVE_APP_ID, EVE_EXE),
+    ]);
+    expect(app.writes).toEqual([
+      {
+        openAtLogin: true,
+        enabled: true,
+        name: EVE_APP_ID,
+        path: EVE_EXE,
+        args: [],
+      },
+    ]);
+  });
+
+  test('ordinary launch removes only exact allowlisted entries without creating Eve', () => {
+    const unpackedPath = String.raw`C:\dev\murmur\Murmur.exe`;
+    const app = new FakeLoginItemApp({
+      items: [
+        ...LEGACY_LOGIN_ITEM_NAMES.map((name) => item(name, LEGACY_EXE)),
+        item('Murmur', unpackedPath),
+        item('murmur', LEGACY_EXE),
+        item('Murmur Candidate', unpackedPath),
+        item('Murmur', LEGACY_EXE, { args: ['--hidden'] }),
+        item('Murmur', LEGACY_EXE, { scope: 'machine' }),
+        item('Unrelated', String.raw`C:\Elsewhere\Other.exe`),
+      ],
+    });
+
+    const result = reconcileLegacyLoginItems(app, {
+      platform: 'win32',
+      localAppData: LOCAL_APP_DATA,
+    });
+
+    expect(result).toEqual({
+      removedLegacyEntries: 3,
+      ignoredLegacyCandidates: 5,
+    });
+    expect(app.items).toEqual([
+      item('Murmur', unpackedPath),
+      item('murmur', LEGACY_EXE),
+      item('Murmur Candidate', unpackedPath),
+      item('Murmur', LEGACY_EXE, { args: ['--hidden'] }),
+      item('Murmur', LEGACY_EXE, { scope: 'machine' }),
+      item('Unrelated', String.raw`C:\Elsewhere\Other.exe`),
+    ]);
+    expect(app.writes.map((write) => write.name)).toEqual([
+      ...LEGACY_LOGIN_ITEM_NAMES,
+    ]);
+  });
+
+  test('disabling removes only the exact Eve registration', () => {
+    const app = new FakeLoginItemApp({
+      items: [
+        item(EVE_APP_ID, EVE_EXE),
+        item(EVE_APP_ID, String.raw`C:\dev\Eve.exe`),
+        item('Murmur', LEGACY_EXE),
+      ],
+    });
+
+    const result = applyLaunchOnBoot(app, false, {
+      platform: 'win32',
+      localAppData: LOCAL_APP_DATA,
+    });
+
+    expect(result).toEqual({
+      removedLegacyEntries: 0,
+      ignoredLegacyCandidates: 0,
+    });
+    expect(app.items).toEqual([
+      item(EVE_APP_ID, String.raw`C:\dev\Eve.exe`),
+      item('Murmur', LEGACY_EXE),
+    ]);
+    expect(app.writes).toEqual([
+      {
+        openAtLogin: false,
+        name: EVE_APP_ID,
+        path: EVE_EXE,
+        args: [],
+      },
+    ]);
+  });
+
+  test('rejects non-Windows and unpackaged callers without an OS write', () => {
+    for (const testCase of [
+      { app: new FakeLoginItemApp(), platform: 'linux' as const },
+      {
+        app: new FakeLoginItemApp({ isPackaged: false }),
+        platform: 'win32' as const,
+      },
+    ]) {
+      expect(() =>
+        applyLaunchOnBoot(testCase.app, true, {
+          platform: testCase.platform,
+          localAppData: LOCAL_APP_DATA,
+        })
+      ).toThrow(LOGIN_ITEM_UNAVAILABLE);
+      expect(testCase.app.writes).toEqual([]);
+    }
+  });
+
+  test('does not leave an Eve entry when the exact legacy path is unavailable', () => {
+    const app = new FakeLoginItemApp();
+
+    expect(() =>
+      applyLaunchOnBoot(app, true, {
+        platform: 'win32',
+      })
+    ).toThrow(LOGIN_ITEM_UNAVAILABLE);
+    expect(app.items).toEqual([]);
+  });
+
+  test('rejects invalid IPC values before an OS write', () => {
+    for (const value of [undefined, null, 0, 1, '', 'false', {}, []]) {
+      const app = new FakeLoginItemApp();
+      expect(() =>
+        applyLaunchOnBoot(app, value, {
+          platform: 'win32',
+          localAppData: LOCAL_APP_DATA,
+        })
+      ).toThrow(TypeError);
+      expect(app.writes).toEqual([]);
+    }
+  });
+
+  test('rolls back an Eve entry that cannot be verified before legacy cleanup', () => {
+    const app = new FakeLoginItemApp({
+      items: [
+        item('Murmur', LEGACY_EXE),
+      ],
+    });
+    app.rejectEveEnable = true;
+
+    expect(() =>
+      applyLaunchOnBoot(app, true, {
+        platform: 'win32',
+        localAppData: LOCAL_APP_DATA,
+      })
+    ).toThrow(LOGIN_ITEM_UPDATE_FAILED);
+
+    expect(app.items).toEqual([
+      item('Murmur', LEGACY_EXE),
+    ]);
+    expect(app.writes.map((write) => write.name)).toEqual([
+      EVE_APP_ID,
+      EVE_APP_ID,
+    ]);
+  });
+
+  test('rolls back Eve when an exact legacy entry cannot be removed', () => {
+    const app = new FakeLoginItemApp({
+      items: [
+        item('Murmur', LEGACY_EXE),
+      ],
+    });
+    app.rejectLegacyRemoval = true;
+
+    expect(() =>
+      applyLaunchOnBoot(app, true, {
+        platform: 'win32',
+        localAppData: LOCAL_APP_DATA,
+      })
+    ).toThrow(LOGIN_ITEM_UPDATE_FAILED);
+
+    expect(app.items).toEqual([
+      item('Murmur', LEGACY_EXE),
+    ]);
+    expect(app.writes.map((write) => write.name)).toEqual([
+      EVE_APP_ID,
+      'Murmur',
+      EVE_APP_ID,
+    ]);
+  });
+
+  test('updates the operating-system registration before settings persistence', async () => {
+    const source = await Bun.file(
+      new URL('../src/main/ipc/handlers.ts', import.meta.url)
+    ).text();
+    const applyIndex = source.indexOf('applyLaunchOnBoot(app, value');
+    const persistIndex = source.indexOf('updateSetting(key, value)');
+
+    expect(applyIndex).toBeGreaterThan(-1);
+    expect(persistIndex).toBeGreaterThan(applyIndex);
   });
 });

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -2,11 +2,10 @@
 
 ## Status
 
-Accepted for staged implementation. Gate 1 compatibility scaffolding merged in PR #15 at
-`5e5b3a3c458d56279e8ece37c51827ce60cfa7a0`, and Gate 2 merged in PR #16 at
-`ca9eddbc8c6a40af7194fbb6a2f172109f46b84d`. Gate 3 is authorized for the visible
-Eve-name bridge described here. AppUserModelID, startup-registration changes, visual
-redesign, publication, and merge remain separately gated.
+Accepted for staged implementation. Gates 1–3 are merged through PR #17 at
+`822a353d9e232a1b365b61c972db4195ac23ba48`. Gate 4 is authorized with the exact
+AppUserModelID `io.github.burntcookiedough.eve`. Visual redesign, publication, and
+merge remain separately gated.
 
 The companion [cutover checklist](eve-identity-cutover-checklist.md) maps this decision to exact files, release gates, checks, and remaining work.
 
@@ -40,17 +39,24 @@ notation and contain no user-specific directory.
 | Surface | Current value or behavior | Consequence |
 |---|---|---|
 | Electron package name | `murmur` | Build-tool identifier; change separately from installer continuity work. |
-| Product name | `Murmur` | Controls executable and installer-facing names. |
-| Application ID | `com.murmur.app` | Used as the Windows Application User Model ID and as input to the default NSIS GUID. |
-| Runtime AppUserModelID | `com.murmur.app` | Set explicitly in `app/src/main/index.ts`. |
-| Observed NSIS uninstall key | `0204d005-75b3-5b31-b1f6-ef2831e2b204` | Treat as the installed upgrade identity. Confirm on a clean v0.6.3 installation, then freeze it explicitly before changing `appId`. |
-| Executable | `Murmur.exe` | Renaming affects startup paths, shortcuts, firewall prompts, and user expectations. |
-| Uninstaller | `Uninstall Murmur.exe` | Must remain discoverable across an in-place upgrade. |
+| Product name | `Eve` | Controls current executable and installer-facing names. |
+| Application ID | `io.github.burntcookiedough.eve` | Active Electron Builder application identity after Gate 4. |
+| Runtime AppUserModelID | `io.github.burntcookiedough.eve` | Set explicitly during bootstrap before application import. |
+| Frozen NSIS uninstall key | `0204d005-75b3-5b31-b1f6-ef2831e2b204` | Preserves the published `com.murmur.app` upgrade and uninstall chain independently of the new app ID. |
+| Executable | `Eve.exe` | Activated in Gate 3 and retained by Gate 4. |
+| Uninstaller | `Uninstall Eve.exe` | Remains discoverable through the frozen installer identity. |
 | Existing install directory | `%LOCALAPPDATA%\Programs\murmur` | An upgrade should continue to recognize this installation. New clean Eve installs may use an Eve directory after testing. |
 | Historical artifacts | `Murmur.Web.Setup.*.exe`, `murmur-*-x64.nsis.7z` | Immutable. Future Eve artifact names do not rename old releases. |
 | Publish repository | `burntcookiedough/eve-windows-dictation` | Already migrated and not part of the app cutover. |
 
-Electron Builder documents that NSIS derives a deterministic GUID from `appId` when a target-specific GUID is absent and warns that changing `appId` can break silent upgrades. It also documents product-name changes as supported when installer identity remains stable. This repository targets `nsis-web`, so its options belong under `build.nsisWeb`, not `build.nsis`. See the official [NSIS configuration](https://www.electron.build/docs/nsis/), [NSIS web options](https://www.electron.build/docs/api/electron-builder.interface.nsisweboptions/), and [application configuration](https://www.electron.build/docs/configuration/).
+Electron Builder documents that NSIS derives a deterministic GUID from `appId` when a
+target-specific GUID is absent and warns that changing `appId` can break silent
+upgrades. Gate 1 therefore froze the published derived GUID explicitly before Gate 4
+changed `appId`. This repository targets `nsis-web`, so its options belong under
+`build.nsisWeb`, not `build.nsis`. See the official
+[NSIS configuration](https://www.electron.build/docs/nsis/),
+[NSIS web options](https://www.electron.build/docs/api/electron-builder.interface.nsisweboptions/),
+and [application configuration](https://www.electron.build/docs/configuration/).
 
 ### Legacy Murmur data
 
@@ -152,12 +158,20 @@ This is the smallest safe implementation PR. It changes no visible product or da
 
 ### Stage D: AppUserModelID cutover
 
-- Change to a distinctive identifier such as `io.github.burntcookiedough.eve` only after Stage C upgrade tests pass.
+- Change to the approved identifier `io.github.burntcookiedough.eve`.
 - Preserve the explicit NSIS GUID.
 - Update `app.setAppUserModelId()` and launch-on-login handling together.
+- Keep version `0.6.3`; versioning remains release-phase work.
+- Ordinary packaged launch may remove exact stale project-owned legacy registrations,
+  but it never creates an Eve registration. Only explicit user interaction may create
+  or remove the exact Eve registration.
+- On opt-in, enumerate through Electron, remove only the exact known legacy names at
+  `%LOCALAPPDATA%\Programs\murmur\Murmur.exe`, and leave development, machine-scope,
+  argument-bearing, differently cased, and otherwise unknown entries untouched.
 - Validate notifications, taskbar grouping, shortcuts, Control Panel metadata, install-over-existing behavior, and uninstall/reinstall behavior.
 
-The exact future AppUserModelID remains separately approved. The example value is not authorized by this ADR.
+The exact AppUserModelID was approved on 2026-07-27. The explicit NSIS GUID remains the
+installer continuity boundary and does not derive from the new `appId`.
 
 ### Stage E: optional internal cleanup
 
@@ -260,14 +274,12 @@ During the authorized Gate 3 implementation:
 
 ## Implementation progress
 
-Gate 1 compatibility scaffolding is complete in merged PR #15. Gate 2 is complete in
-merged PR #16 and activates `%APPDATA%\Eve` before importing data consumers while
-retaining the published installer identity. Gate 3 changes visible product surfaces to
-Eve while preserving the AppUserModelID, NSIS GUID, internal APIs, and legacy data
-boundary. Its automated and Windows lifecycle acceptance is recorded in
-[Gate 3 evidence](eve-identity-gate-3-evidence.md). Filesystem path tracing is explicitly
-out of scope for this gate: its absence limits the available evidence but is not a
-draft, readiness, or merge criterion.
+Gate 1 compatibility scaffolding, Gate 2's `%APPDATA%\Eve` boundary, and Gate 3's
+visible Eve identity are complete in merged PRs #15–#17. Gate 4 activates
+`io.github.burntcookiedough.eve` in Electron Builder and the running process while
+retaining the frozen NSIS GUID, internal APIs, release identity, and legacy data
+boundary. Its implementation and acceptance are recorded in
+[Gate 4 evidence](eve-identity-gate-4-evidence.md).
 
 ## Consequences
 

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -2,7 +2,15 @@
 
 ## One-minute brief
 
-Eve will be a new Windows application identity, but it must remain in Murmur's existing NSIS upgrade chain. It will start with an empty History and default settings in a separate Eve directory. It will not import or delete Murmur History, settings, hotwords, external-server configuration, browser storage, credentials, logs, or startup preference. The old Murmur data directory stays inactive and untouched. Generic Hugging Face model weights may be reused because they are downloaded runtime assets outside Murmur userData. Implementation is split into compatibility scaffolding, the fresh Eve data boundary, the visible product rename, and the later AppUserModelID cutover. Each step gets its own PR and Windows acceptance gate.
+Eve uses the approved Windows AppUserModelID `io.github.burntcookiedough.eve` while
+remaining in Murmur's existing frozen NSIS upgrade chain. It starts with an empty
+History and default settings in a separate Eve directory. It does not import or delete
+Murmur History, settings, hotwords, external-server configuration, browser storage,
+credentials, logs, or startup preference. The old Murmur data directory stays inactive
+and untouched. Generic Hugging Face model weights may be reused because they are
+downloaded runtime assets outside Murmur userData. Compatibility scaffolding, the fresh
+Eve data boundary, and the visible product rename are merged; Gate 4 is the focused
+AppUserModelID and startup-registration cutover.
 
 The controlling architecture decision is [ADR-001](adr-001-eve-application-identity-migration.md).
 
@@ -94,11 +102,16 @@ Exit condition: an upgrade from published Murmur succeeds, Eve starts with a fre
 | File or system | Required work |
 |---|---|
 | `app/package.json` | Change `appId` only after the exact future ID is approved; retain explicit NSIS GUID. |
-| `app/src/main/index.ts` | Change `app.setAppUserModelId()` with the packaged ID. |
+| `app/src/main/identity.ts`, `bootstrap-core.ts` | Activate the approved ID in the typed identity and in `app.setAppUserModelId()` before application import. |
 | `app/src/main/ipc/handlers.ts` | Register only Eve launch-on-login after user opt-in; reconcile exact known legacy registrations. |
 | Windows installation | Verify taskbar grouping, notifications, shortcuts, uninstall key, install location, repair, and upgrade. |
 
-Exit condition: no duplicate installer entry, no stale enabled startup entry, and no loss of the existing uninstall/upgrade path.
+Approved Gate 4 identity: `io.github.burntcookiedough.eve`. Version remains `0.6.3`;
+the explicit NSIS GUID remains `0204d005-75b3-5b31-b1f6-ef2831e2b204`.
+
+Exit condition: package/runtime IDs match, no duplicate installer entry, opt-in creates
+one exact Eve startup entry, exact known legacy installed-path entries are removed,
+unknown entries remain untouched, and the existing uninstall/upgrade path is intact.
 
 ### Keep stable during the cutover
 
@@ -161,11 +174,11 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Derive and cross-check the published v0.6.3 NSIS key | Complete; see Gate 1 evidence | No |
 | Confirm NSIS key from published v0.6.3 installation | Complete in Gate 1 host acceptance | No |
 | Select final Eve data-root casing | Complete: exact `%APPDATA%\Eve` | No |
-| Select final AppUserModelID | Pending; Gate 4 only | Separate approval |
+| Select final AppUserModelID | Complete: `io.github.burntcookiedough.eve` approved 2026-07-27 | No |
 | Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
 | Fresh Eve profile implementation | Complete in merged PR #16 at `ca9eddb`; Gate A/B evidence includes Fast/Long smoke, repair, normal uninstall preservation, and official rollback | No |
 | Visible installed-product rename | Complete on `codex/eve-visible-identity-gate-3`; see [Gate 3 evidence](eve-identity-gate-3-evidence.md). AppUserModelID and startup registrations remain deferred | Merge approval |
-| AppUserModelID cutover | Pending | Separate approval after upgrade acceptance |
+| AppUserModelID cutover | In progress on Gate 4 | Merge remains separately approved |
 | Visual identity and homepage | Pending | Later design phase |
 | Thin-client/component packs and ASR profiles | Pending | Later technical phase |
 

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -178,7 +178,7 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
 | Fresh Eve profile implementation | Complete in merged PR #16 at `ca9eddb`; Gate A/B evidence includes Fast/Long smoke, repair, normal uninstall preservation, and official rollback | No |
 | Visible installed-product rename | Complete on `codex/eve-visible-identity-gate-3`; see [Gate 3 evidence](eve-identity-gate-3-evidence.md). AppUserModelID and startup registrations remain deferred | Merge approval |
-| AppUserModelID cutover | In progress on Gate 4 | Merge remains separately approved |
+| AppUserModelID cutover | Complete on Gate 4 draft PR #18; Gate A and the full Windows lifecycle passed from fixed head `c6d9d3a` | Merge approval |
 | Visual identity and homepage | Pending | Later design phase |
 | Thin-client/component packs and ASR profiles | Pending | Later technical phase |
 

--- a/docs/architecture/eve-identity-gate-4-evidence.md
+++ b/docs/architecture/eve-identity-gate-4-evidence.md
@@ -1,0 +1,96 @@
+# Eve identity Gate 4 evidence
+
+## Scope and decision
+
+Gate 4 starts from exact merged Gate 3 trunk commit
+`822a353d9e232a1b365b61c972db4195ac23ba48`. The approved Eve application ID and
+Windows AppUserModelID is:
+
+```text
+io.github.burntcookiedough.eve
+```
+
+The version remains `0.6.3`. The NSIS GUID remains
+`0204d005-75b3-5b31-b1f6-ef2831e2b204`, preserving the published Murmur upgrade and
+uninstall chain. Product, executable, wrapper, shortcut, internal package, compatibility
+payload, preload, environment, Python, update/release, profile, model, and visual
+identities remain unchanged from Gate 3.
+
+The Gate 4 file ceiling is 14 tracked files:
+
+- six production/configuration files for package identity, process identity, startup
+  policy, IPC ordering, and accurate failure copy;
+- four direct regression files;
+- `README.md`, ADR-001, the cutover checklist, and this evidence record.
+
+No dependency, lockfile, workflow, server-source, runtime, model, homepage, release,
+generated, downloaded, profile, registry-export, log, audio, or package output belongs
+in the diff.
+
+## Startup policy
+
+- Ordinary packaged launch creates no Eve login item. It enumerates through Electron
+  and writes only when an exact stale project-owned legacy registration is present.
+- Unpackaged and non-Windows callers cannot create a registration.
+- A boolean user toggle is validated before any operating-system or settings write.
+- Enabling creates the exact Eve user registration for the current packaged executable
+  with no arguments and verifies its exact path and enabled state before persistence.
+- Both ordinary packaged launch and opt-in enumerate Electron's `launchItems` and
+  remove allowlisted names `Murmur`, `electron.app.Murmur`, and `com.murmur.app` only
+  when they are user-scope, argument-free, and resolve exactly to
+  `%LOCALAPPDATA%\Programs\murmur\Murmur.exe`.
+- Development paths, machine-scope entries, argument-bearing entries, different casing,
+  unknown names, and unrelated entries remain untouched. Only a count of possible
+  legacy candidates is logged; names and paths are not logged.
+- Disabling removes only the exact Eve name/path registration.
+- A failed verification does not persist the setting and makes a best-effort exact Eve
+  registration rollback. It never performs substring-based deletion or direct registry
+  access.
+
+## Gate A automated verification
+
+Results on 2026-07-27:
+
+| Check | Result |
+|---|---|
+| `python scripts/version.py check` | Passed at `0.6.3`. |
+| Focused identity/startup/profile tests | 19 passed, 0 failed, including a real Electron controlled-root singleton check. |
+| Full `bun test` | 95 passed, 0 failed. |
+| `bun run test:history` | Passed. |
+| `bunx tsc -p tsconfig.main.json --noEmit` | Passed. |
+| `bun run build` | Main, preload, and renderer production builds passed. |
+| `uv run --no-sync pytest -q` | 139 passed. |
+| Frozen dependency preparation | `bun install --frozen-lockfile` and `uv sync --extra whisper --group dev --frozen` passed with tracked manifests and locks unchanged. |
+| PowerShell/JSON parsing and `git diff --check` | Passed. |
+| Changed-file and privacy/release audit | Exactly 14 tracked files; no dependency, lock, workflow, server-source, runtime, model, homepage, release, or generated-output diff. |
+
+The first fresh server environment intentionally installed only the base and development
+groups. That run passed 136 tests and failed three imports because the optional
+faster-whisper/Hugging Face packages were absent. Adding the locked `whisper` extra—the
+documented Gate A environment—changed no tracked file, and the complete 139-test rerun
+passed. This was environment preparation, not a product defect.
+
+## Gate B Windows lifecycle acceptance
+
+The separately authorized lifecycle will use exactly one package invocation from an
+exact detached candidate head after validating the complete runtime/engine/CUDA
+closure. Independent hash-verified copies will be made before repair consumes a
+payload. Acceptance must cover:
+
+- published Murmur v0.6.3 baseline and same-GUID Eve upgrade;
+- one Control Panel identity and the legacy install chain;
+- package/runtime AppUserModelID, taskbar grouping, notifications, permissions,
+  shortcuts, executable, uninstaller, and install location;
+- default launch-on-login disabled with no startup write;
+- exact user opt-in creating only the Eve entry;
+- exact known legacy installed-path entries removed and unknown controlled fixtures
+  untouched;
+- current PID-file health, controlled Fast/Long smoke, and singleton;
+- independent same-version repair;
+- normal uninstall preserving both profile manifests, shared model-cache presence, and
+  controlled unknown login state;
+- checksum-verified official rollback and fresh current PID-file health.
+
+No personal profile contents, transcript text, audio output, unknown startup value
+contents, or shared model files may be recorded or deleted. No tag, release, asset,
+update manifest, merge, or publication is authorized.

--- a/docs/architecture/eve-identity-gate-4-evidence.md
+++ b/docs/architecture/eve-identity-gate-4-evidence.md
@@ -94,3 +94,25 @@ payload. Acceptance must cover:
 No personal profile contents, transcript text, audio output, unknown startup value
 contents, or shared model files may be recorded or deleted. No tag, release, asset,
 update manifest, merge, or publication is authorized.
+
+### Rejected first candidate
+
+The first exact-head package run at commit
+`ee36b07fc20ee131fd2f2d6a755cf02f1c8fb4c5` was rejected during the ordinary-launch
+startup boundary. Electron filters `launchItems` by the `path` supplied to
+`getLoginItemSettings`; querying with `Eve.exe` therefore did not enumerate exact
+legacy registrations whose path was `Murmur.exe`. The controlled host check found the
+legacy entry still present, while the unknown fixture remained untouched and no Eve
+entry was created.
+
+Lifecycle testing stopped at that boundary. The candidate was normally uninstalled,
+the checksum-verified official v0.6.3 rollback was restored and became healthy with a
+ready Whisper engine, CUDA active, required CUDA DLLs present, and zero diagnostics
+warnings. All ten explicitly captured startup values were restored exactly; no broad
+registry cleanup was performed.
+
+The correction queries and verifies `launchItems` using the exact allowlisted legacy
+executable path. The fake Electron boundary now applies the same path-and-arguments
+filter, so the regression fails if reconciliation queries the current Eve executable.
+The rejected artifacts are not eligible for further acceptance evidence. A fresh
+exact-head package is required before Gate B can resume.

--- a/docs/architecture/eve-identity-gate-4-evidence.md
+++ b/docs/architecture/eve-identity-gate-4-evidence.md
@@ -72,24 +72,39 @@ passed. This was environment preparation, not a product defect.
 
 ## Gate B Windows lifecycle acceptance
 
-The separately authorized lifecycle will use exactly one package invocation from an
-exact detached candidate head after validating the complete runtime/engine/CUDA
-closure. Independent hash-verified copies will be made before repair consumes a
-payload. Acceptance must cover:
+The replacement lifecycle ran from exact fixed head
+`c6d9d3a45354d6cd9f5be914843fa928558df9fc`. The detached build tree was clean and
+its split Python runtime passed imports for Torch 2.6.0+cu124, CTranslate2 4.6.3,
+Faster-Whisper 1.2.1, and NeMo 2.6.2 with CUDA active and the required native DLLs
+present.
 
-- published Murmur v0.6.3 baseline and same-GUID Eve upgrade;
-- one Control Panel identity and the legacy install chain;
-- package/runtime AppUserModelID, taskbar grouping, notifications, permissions,
-  shortcuts, executable, uninstaller, and install location;
-- default launch-on-login disabled with no startup write;
-- exact user opt-in creating only the Eve entry;
-- exact known legacy installed-path entries removed and unknown controlled fixtures
-  untouched;
-- current PID-file health, controlled Fast/Long smoke, and singleton;
-- independent same-version repair;
-- normal uninstall preserving both profile manifests, shared model-cache presence, and
-  controlled unknown login state;
-- checksum-verified official rollback and fresh current PID-file health.
+Exactly one replacement `bun run package:win` invocation ran and exited `0` in
+846.6 seconds. The rejected first-cycle outputs were not reused. Two fresh independent
+artifact sets were copied and verified against the exact build outputs before Set A
+installation and Set B repair.
+
+| Output | Bytes | SHA-256 |
+|---|---:|---|
+| `Eve.Web.Setup.0.6.3.exe` | 887,518 | `6AA2016A46B93C7F9298ACC134628A79E2D49CFEC20734D782587EE26176DAA6` |
+| `murmur-0.6.3-x64.nsis.7z` | 2,034,073,193 | `54963E55DE6CCA3FD26BA0755B59AC99C05878D7D01AD939B3B82D09E6B94547` |
+| `latest.yml` | 558 | `BEE065C9A98FFC04914E3354F6E6BAE2997F80FEB06EC24931056B1D17FCC603` |
+
+The manifest wrapper and payload sizes and SHA-512 values matched the generated files.
+The packaged and installed candidate `app.asar` SHA-256 was
+`D7B188732B504705F3A8277B7A4488714F6B744F76E15EE9F377C77DAD5E4B62`.
+
+| Boundary | Result |
+|---|---|
+| Same-GUID in-place install | Set A exited `0` in 285.319 seconds. The published install root was reused, exactly one frozen-GUID uninstall entry existed, and it displayed `Eve 0.6.3`. The install did not alter either stopped profile aggregate or any scoped startup value. |
+| Installed identity | Only `Eve.exe` was installed. Its product and file metadata were Eve/0.6.3. `Get-StartApps` and both installed shortcuts exposed exact AppUserModelID `io.github.burntcookiedough.eve`. |
+| Ordinary launch policy | All three exact user-scope, argument-free legacy names at the installed Murmur path were removed. The controlled unknown entry remained exact, and ordinary launch created no Eve entry. |
+| Explicit opt-in and opt-out | The live packaged Settings toggle changed from disabled to enabled and created only the exact Eve name/path registration. The unknown fixture remained and no legacy entry returned. Toggling off removed the exact Eve registration and left the unknown fixture unchanged. |
+| Runtime and singleton | Current PID-file ownership matched the packaged Python runtime. Health reported 0.6.3, engine/model ready, CUDA and CUDA DLLs available, and zero warnings. A second Eve invocation exited without changing the five Electron process IDs or server PID/port. |
+| Controlled dictation | The repository WAV fixture was converted in memory to 16 kHz mono. Fast Dictation produced a non-empty final result for 10.0 seconds. Long Dictation produced a non-empty final result for 47.334 seconds and emitted both `long_dictation_started` and `long_dictation_processing`. No transcript or audio output was retained. |
+| Independent repair | Untouched, hash-verified Set B exited `0` in 269.345 seconds. Candidate `app.asar`, both stopped profile aggregates, and all scoped startup values remained exact. Relaunch used a fresh owned PID-file port and returned ready CUDA health with zero warnings. |
+| Normal uninstall | The candidate stopped before the comparison. Uninstall exited `0` in 0.953 seconds and removed the install root and frozen-GUID uninstall key. Both stopped profile aggregates remained exact (Murmur: 113 files/13,353,837 bytes; Eve: 45 files/3,031,628 bytes), all scoped startup values remained exact, and the shared model-cache root remained present. |
+| Published rollback | Official wrapper SHA-256 `366088A4266F54EA7C39E2E7FD1FC7177CAC46BF8A4B3F43D58A6D025E15CD33` and payload SHA-256 `0B557FDE05853DA1F7C0AEF77CECBAD1FAF8C5FC9314457EA45119D3A69F4FBD` matched the immutable v0.6.3 release set. Install exited `0` in 208.814 seconds; installed `app.asar` matched `98910F5CD2C3A9426ECD7850EE352E47F9C48FB00BB5EEF526220660E69FC8FD`. Fresh owned PID-file health returned Murmur 0.6.3, ready engine/model, CUDA and DLLs available, and zero warnings. |
+| Final host restoration | All ten explicitly captured pre-test startup values were restored and remained exact after the official launch. No broad registry cleanup ran. |
 
 No personal profile contents, transcript text, audio output, unknown startup value
 contents, or shared model files may be recorded or deleted. No tag, release, asset,
@@ -114,5 +129,12 @@ registry cleanup was performed.
 The correction queries and verifies `launchItems` using the exact allowlisted legacy
 executable path. The fake Electron boundary now applies the same path-and-arguments
 filter, so the regression fails if reconciliation queries the current Eve executable.
-The rejected artifacts are not eligible for further acceptance evidence. A fresh
-exact-head package is required before Gate B can resume.
+The rejected artifacts were not used for acceptance evidence.
+
+### Smoke-harness correction
+
+The first replacement-cycle smoke harness used `/ws`, which the repository does not
+route, and received HTTP 403 before sending audio. Repository routing identifies
+`/transcribe` as the protocol endpoint. The corrected in-memory invocation passed
+immediately. This was a local acceptance-harness error and did not require a product
+change or another package run.

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -60,7 +60,7 @@ def test_nsis_web_identity_and_data_retention_are_explicit() -> None:
     nsis_web = build.get("nsisWeb", {})
 
     assert package_json.get("name") == "murmur"
-    assert build.get("appId") == "com.murmur.app"
+    assert build.get("appId") == "io.github.burntcookiedough.eve"
     assert build.get("productName") == "Eve"
     assert build.get("executableName") == "Eve"
     assert nsis_web == {


### PR DESCRIPTION
## Summary

- activate approved AppUserModelID \io.github.burntcookiedough.eve\ while retaining the frozen NSIS GUID
- reconcile only exact project-owned legacy login entries and create Eve startup only after explicit opt-in
- preserve version, installer chain, profiles, shared cache, internal compatibility names, and release identity

## Gate A

- \python scripts/version.py check\`n- focused identity/startup/profile tests: 19 passed
- full app suite: 95 passed
- history aggregate check
- TypeScript check and production build
- server suite: 139 passed
- \git diff --check\ and 14-file scope/privacy audit

## Boundaries

Draft only. No merge, tag, release, publication, profile inspection, shared-cache deletion, or broad registry cleanup is authorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Eve now uses its approved Windows identity and separate user-data location.
  - Launch on boot can be enabled or disabled reliably on supported Windows installations.
  - Enabling launch on boot removes recognized legacy entries and verifies the updated setting.

- **Bug Fixes**
  - Failed launch-on-boot updates now roll back safely and provide a clear error message.
  - Existing installer upgrade and uninstall compatibility is preserved.

- **Documentation**
  - Windows identity, upgrade compatibility, and data-handling details are now documented more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->