### PR TITLE
Prepare Eve v0.7.0 release metadata

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -4,6 +4,19 @@ Eve contains software derived from the MIT-licensed Murmur project created by Ra
 
 Subsequent contributors retain authorship of their changes. Repository documentation distinguishes later implementation and release-hardening work from the inherited codebase; it does not claim that those contributors created the original project.
 
-The v0.6.3 Windows artifacts retain the Murmur application and installer identity during the compatibility-preserving transition to Eve.
+The public v0.6.3 Windows artifacts retain the historical Murmur application and
+installer identity. The source prepared for Eve v0.7.0 retains the frozen installer
+continuity boundary while using the Eve product identity; it is not yet a published
+release.
 
-Third-party libraries, models, and tools remain subject to their respective licenses and notices. This file does not replace those terms or claim that a complete binary-distribution notice audit has been finished. That audit is a release gate for a future Eve-branded distribution.
+Gate 6A verified from the tracked manifests and release configuration that the Windows
+distribution includes an Electron application, a managed Python runtime, and packaged
+production Python dependencies; models download separately on first use. Third-party
+libraries, runtimes, models, and tools remain subject to their respective licenses and
+notices.
+
+This file is not a complete binary-distribution notice inventory. The release workflow
+packages the full runtime closure, whose embedded notices and redistribution terms still
+require a complete, evidence-backed audit. That inventory, together with the separately
+deferred Eve name/mark review, is a Gate 6C publication blocker. Nothing in this notice
+claims legal or trademark clearance.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local dictation for Windows, built as an Electron desktop client with a packaged Python transcription service.
 
-<img src="https://img.shields.io/badge/v0.6.3-orange?style=flat-square" alt="v0.6.3">
+<img src="https://img.shields.io/badge/v0.7.0-orange?style=flat-square" alt="v0.7.0">
 
 > [!IMPORTANT]
 > Current source builds use the visible **Eve** product, executable, installer, and shortcut names, the `io.github.burntcookiedough.eve` AppUserModelID, and a separate `%APPDATA%\Eve` profile. The published v0.6.3 download remains **Murmur** and is listed below unchanged. The frozen installer GUID, internal `murmur` package name, compatibility payload name, and `MURMUR_*` interfaces remain stable for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,26 +4,42 @@ This roadmap separates shipped behavior from design and research. It is not a re
 
 ## Current baseline
 
-v0.6.3 is the production baseline. It retains the Murmur application identity and ships a packaged Python runtime with faster-whisper/CTranslate2 and NeMo/PyTorch/CUDA dependency stacks. Models download separately on first use.
+Eve v0.7.0 is the prepared source baseline; it is not yet a public release. The latest
+public download remains the historical Murmur v0.6.3 release. The prepared Eve source
+retains the frozen Murmur installer chain while using the Eve product identity, an
+isolated Eve profile, the approved visual/accessibility system, and packaged cactus
+resources. Its portable Python runtime and separately downloaded models remain subject to
+their existing release gates.
 
-The repository is now standalone under `burntcookiedough/eve-windows-dictation`, and its release configuration targets that repository. Existing app IDs, installer identity, update behavior, and user-data paths remain unchanged.
+The repository is standalone under `burntcookiedough/eve-windows-dictation`, and its
+release configuration targets that repository. Existing app IDs, installer identity,
+update behavior, and user-data paths remain unchanged.
 
-## Next: application-identity migration design
+## Completed: application identity and visual system
 
-The proposed technical contract is documented in [ADR-001](docs/architecture/adr-001-eve-application-identity-migration.md). Trademark work is currently deferred; it remains separate from the compatibility design.
+The technical contract is documented in [ADR-001](docs/architecture/adr-001-eve-application-identity-migration.md).
+Gates 1–4 completed the compatibility, fresh-profile, visible-identity, and
+AppUserModelID cutover. Gates 5A and 5B completed the approved renderer/accessibility
+system and cactus Windows resources. Trademark work remains separate and incomplete.
 
-Before an Eve-branded binary is produced:
+Before Eve v0.7.0 is published:
 
-- complete manual trademark checks in relevant software classes and markets;
-- inventory every app ID, executable, installer, protocol, package, update, and data-path identifier;
-- establish a fresh Eve profile that never imports Murmur History, settings, hotwords, browser storage, credentials, or external-server configuration;
-- preserve the inactive Murmur data directory without reading, moving, or deleting personal files; permit only a bounded `server.pid` ownership check when required to prevent process conflicts;
-- test clean install, upgrade, downgrade/rollback, repair, startup registration, and uninstall without deleting either data profile or shared model caches;
-- complete the binary-distribution third-party notice audit.
+- complete the binary-distribution third-party notice audit;
+- resolve or explicitly accept the Eve name/mark publication risk; and
+- run a fresh exact-head release-candidate lifecycle, then follow a separately approved
+  tag/publication procedure.
 
-## Later: visual system
+The completed gates established a fresh Eve profile that does not automatically import
+Murmur History, settings, hotwords, browser storage, credentials, or external-server
+configuration. They also proved the compatibility lifecycle for the accepted candidates;
+the public release still requires fresh Gate 6 evidence.
 
-Design Eve's icon, typography, color, windows, overlay, onboarding, and public screenshots after identity and migration constraints are fixed. Do not reskin the existing product and treat that as an identity migration.
+## Next: release readiness
+
+Gate 6 prepares version metadata, release notes, factual status records, NOTICE readiness,
+and publication controls. It does not publish merely because the source is prepared. The
+final package, lifecycle, merge, tag, release, and public-download checks remain separate
+approval gates.
 
 ## Later: component-based distribution
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,8 +12,10 @@ resources. Its portable Python runtime and separately downloaded models remain s
 their existing release gates.
 
 The repository is standalone under `burntcookiedough/eve-windows-dictation`, and its
-release configuration targets that repository. Existing app IDs, installer identity,
-update behavior, and user-data paths remain unchanged.
+release configuration targets that repository. The approved cutovers use the Eve
+product identity, AppUserModelID `io.github.burntcookiedough.eve`, and isolated
+`%APPDATA%\Eve` profile. The frozen Murmur installer chain and GUID, update
+compatibility, and internal compatibility interfaces remain unchanged.
 
 ## Completed: application identity and visual system
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",

--- a/docs/architecture/eve-gate-5-master-plan.md
+++ b/docs/architecture/eve-gate-5-master-plan.md
@@ -1,6 +1,7 @@
 # Eve Gate 5 master plan
 
-- Status: Gate 5A authorized; Gate 5B planned and separately gated
+- Status: Gate 5A and Gate 5B passed and merged through PRs #19 and #20; Gate 6 owns
+  release preparation and publication.
 - Canonical base: `20a781f78d638bc5884a8e85511cf3c8507eca4b`
 - Gate 4 accepted head contained by the base: `e2086fd8f36020ced09483311dde0530d6b8fe77`
 - Repository: `burntcookiedough/eve-windows-dictation`
@@ -331,7 +332,9 @@ commits or close the unmerged PR. Never use a destructive reset against user wor
 
 ## Gate 5B — cactus resources and Windows icon lifecycle
 
-Status: planned; not authorized for implementation, branch creation, packaging, or PR.
+Status: passed and merged in PR #20. The planning-time scope and lifecycle contract below
+are preserved as historical evidence; no Gate 5B artifact may be reused as a Gate 6
+release artifact.
 
 ### Dependency and order
 
@@ -452,12 +455,12 @@ rollback cannot be proven, or publication would be required.
 | Gate 5A design QA | Passed | `design-qa.md`; local synthetic screenshots | None | Preserve the passed target comparison. |
 | Gate 5A accessibility/Windows | Passed | `docs/architecture/eve-gate-5a-evidence.md` | None | Preserve accessibility and native-window behavior. |
 | Gate 5A Gate A | Passed | `docs/architecture/eve-gate-5a-evidence.md`; exact-head command results | None | Open the draft PR and run hosted review. |
-| Gate 5A PR/CI/CodeRabbit | Planned | Hosted checks and review threads | None for creation/review | Leave Ready but unmerged. |
-| Gate 5A merge | Deferred | PR merge commit | Explicit user approval | Merge only if separately authorized. |
-| Gate 5B branch/implementation | Deferred | Future 5B branch and evidence | Explicit user authorization after 5A review | Branch from accepted 5A state. |
-| Gate 5B one-package lifecycle | Deferred | Future 5B evidence | Included only in explicit 5B authorization | Package exactly once from final 5B head. |
-| Gate 5B merge | Deferred | Future PR merge commit | Explicit user approval | Merge only if separately authorized. |
-| Release/publication | Deferred | Future release plan | Separate explicit approval | Never infer from Gate 5 acceptance. |
+| Gate 5A PR/CI/CodeRabbit | Passed | PR #19 hosted checks and resolved CodeRabbit review | Complete | Gate 5A merged after explicit approval. |
+| Gate 5A merge | Passed | Merge commit `c7a5e8b596337396b6754cf64e7b535fcb1a0a31` | Complete | Gate 5B branched from the accepted state. |
+| Gate 5B branch/implementation | Passed | PR #20 and `eve-gate-5b-icon-evidence.md` | Complete | Preserve resource provenance and evidence. |
+| Gate 5B one-package lifecycle | Passed | Exact-head package/lifecycle in `eve-gate-5b-icon-evidence.md` | Complete | Do not reuse its candidate artifacts for a release. |
+| Gate 5B merge | Passed | Merge commit `0d6605d07aa783036d61fc93af7ce043a808f1a6` | Complete | Gate 6 release preparation follows. |
+| Release/publication | Deferred | Gate 6 release plan | Separate explicit approval | Never infer publication from Gate 5 acceptance. |
 
 ## Continuation instructions
 

--- a/docs/architecture/eve-gate-6-release-plan.md
+++ b/docs/architecture/eve-gate-6-release-plan.md
@@ -1,6 +1,6 @@
 # Eve Gate 6 release plan
 
-- Status: Gate 6A planning contract committed; mechanical 6A work pending review
+- Status: Gate 6A contract parent-reviewed and passed; mechanical implementation in progress
 - Repository: `burntcookiedough/eve-windows-dictation`
 - Canonical base: `0d6605d07aa783036d61fc93af7ce043a808f1a6`
 - Tracking issue: [#21](https://github.com/burntcookiedough/eve-windows-dictation/issues/21)
@@ -479,9 +479,9 @@ explicit authorization.
 |---|---|---|---|---|
 | Canonical Gate 6 base | Passed | Fresh clone; exact `0d6605d…`; clean `trunk` | Complete | Preserve base ancestry. |
 | Gate 6 tracking issue | Passed | Issue #21, `ready`, execution allowed | Complete | Keep issue state authoritative. |
-| Permanent Gate 6 contract | In progress | This file and its first commit | Parent review | Review allowlist, blockers, and next commands. |
-| Gate 6A mechanical edits | Planned | Future scoped commit(s) | Continue only after contract review | Apply factual/version/release-note/notice work. |
-| Gate 6A local Gate A | Planned | `eve-gate-6a-evidence.md` | None beyond authorized 6A | Run full validation without dependency mutation. |
+| Permanent Gate 6 contract | Passed | Commit `e33c9304f6c133867c6a9f0948a943a75fedaca5`; independent parent review | Complete | Preserve the allowlist and stage boundaries. |
+| Gate 6A mechanical edits | Passed | Scoped 13-file diff and `eve-gate-6a-evidence.md` | Complete | Commit the reviewed release-preparation head. |
+| Gate 6A local Gate A | Passed | `eve-gate-6a-evidence.md`; exact scope/privacy/frozen-boundary audit | Complete | Push and open the draft PR. |
 | Gate 6A PR/CI/CodeRabbit | Planned | Future PR and hosted checks | None for draft/review | Leave Ready but unmerged. |
 | Gate 6A merge | Deferred | Future merge commit | Explicit authorization | Do not infer from Ready status. |
 | Gate 6B exact candidate | Deferred | External artifact/lifecycle evidence | Separate explicit authorization | One package and full lifecycle only. |

--- a/docs/architecture/eve-gate-6-release-plan.md
+++ b/docs/architecture/eve-gate-6-release-plan.md
@@ -1,0 +1,547 @@
+# Eve Gate 6 release plan
+
+- Status: Gate 6A planning contract committed; mechanical 6A work pending review
+- Repository: `burntcookiedough/eve-windows-dictation`
+- Canonical base: `0d6605d07aa783036d61fc93af7ce043a808f1a6`
+- Tracking issue: [#21](https://github.com/burntcookiedough/eve-windows-dictation/issues/21)
+- Proposed release: Eve `v0.7.0`
+- Last updated: 2026-07-28 (Asia/Calcutta)
+
+## Purpose and outcome
+
+Gate 6 prepares and, through separately approved stages, publishes the first Eve-branded
+Windows release after the compatibility, identity, privacy, visual, accessibility, and
+resource work completed in Gates 1–5.
+
+The intended outcome is a release whose source version, release notes, package identity,
+artifact set, Windows lifecycle evidence, and public GitHub record all describe the same
+accepted code. Release preparation must not weaken the established compatibility or
+privacy boundaries merely to make publication easier.
+
+Gate 6 is deliberately split:
+
+- **Gate 6A — release preparation:** documentation, factual status cleanup, synchronized
+  version metadata, release notes, release-readiness audits, tests, CI, CodeRabbit, and a
+  Ready-but-unmerged pull request.
+- **Gate 6B — exact release candidate:** one fresh package from the final accepted release
+  head and the complete privacy-safe Windows lifecycle. It requires separate explicit
+  authorization.
+- **Gate 6C — publication:** final merge/tag/release procedure and public-download
+  validation. It requires separate explicit authorization after Gate 6B passes and all
+  publication blockers are resolved.
+
+Authorization for one stage never implies authorization for a later stage.
+
+## Release-version decision
+
+The proposed version is `0.7.0`.
+
+- `0.6.4` would understate the coordinated, backward-compatible product milestone:
+  Gates 1–5 established a separate Eve profile, visible Eve identity, the approved
+  AppUserModelID, a new application shell and accessibility system, and original packaged
+  cactus resources.
+- `1.0.0` would overstate current release maturity. Signing, the large installer/runtime
+  distribution strategy, formal name/mark clearance, and other pre-1.0 work remain open.
+- `0.7.0` communicates a substantial but still pre-1.0, backward-compatible milestone.
+
+The version decision changes no protocol, data format, runtime, engine, dependency, or
+installer identity.
+
+## Decision ledger
+
+| Decision | Status | Evidence or consequence |
+|---|---|---|
+| Prepare Eve `v0.7.0` | Approved for Gate 6A | User-authorized release-preparation decision; no publication implied. |
+| Keep Gates 6A, 6B, and 6C separate | Frozen | Packaging/lifecycle and publication remain consequential independent gates. |
+| Preserve the Gates 1–5 compatibility and privacy architecture | Frozen | No release convenience may alter identity, profiles, startup, cache, runtime, or protocol behavior. |
+| Use the existing version tool for all synchronized metadata | Approved | `scripts/version.py bump 0.7.0` owns exactly six files. |
+| Add human-reviewed release notes | Approved | The repository has no tracked changelog/release-note convention; the tag workflow currently generates notes automatically. |
+| Do not claim automatic Murmur History import | Frozen | Eve ships a fresh profile. A one-time user-requested local migration was not product behavior. |
+| Do not package in Gate 6A | Frozen | Gate 6B owns the single final exact-head candidate package. |
+| Do not tag while the current publication procedure is unresolved | Frozen | A `v*` tag immediately invokes a workflow that builds and publishes. |
+| Treat unresolved notice or name/mark risk as a Gate 6C blocker | Frozen | Record limitations; do not invent legal conclusions or speculative code changes. |
+
+## Canonical program state
+
+Canonical `trunk` at the start of Gate 6 is merge commit
+`0d6605d07aa783036d61fc93af7ce043a808f1a6`, which merged Gate 5B PR #20. Gates 1–5
+are complete:
+
+| Gate | Accepted result |
+|---|---|
+| Gate 1 / PR #15 | Frozen NSIS installer continuity and compatibility scaffolding. |
+| Gate 2 / PR #16 | Isolated `%APPDATA%\Eve` profile with no automatic legacy-profile access. |
+| Gate 3 / PR #17 | Visible Eve product, executable, installer, and shortcut identity. |
+| Gate 4 / PR #18 | AppUserModelID `io.github.burntcookiedough.eve` with frozen NSIS GUID. |
+| Gate 5A / PR #19 | Approved monochrome renderer, overlay, IA, and accessibility system. |
+| Gate 5B / PR #20 | Original cactus resources, deterministic derivatives, and passed Windows lifecycle. |
+
+Gate 5 evidence remains durable historical evidence. Gate 6A may correct stale status
+ledgers but must not rewrite Gate 1–5 acceptance results.
+
+## Frozen boundaries
+
+All Gate 6 stages preserve these values and behaviors unless a future, separately
+approved architecture decision explicitly changes them:
+
+- AppUserModelID and Electron Builder app ID:
+  `io.github.burntcookiedough.eve`;
+- NSIS GUID: `0204d005-75b3-5b31-b1f6-ef2831e2b204`;
+- the published Murmur install/upgrade/uninstall chain and the retained internal install
+  path needed for that chain;
+- product name `Eve`, executable `Eve.exe`, and existing artifact compatibility names;
+- `%APPDATA%\Eve` as Eve's profile and `%APPDATA%\murmur` as a preserved legacy profile;
+- no automatic import, merge, fallback, prompt, or deletion involving the Murmur profile;
+- exact startup/login policy and allowlisted legacy-entry handling;
+- shared Hugging Face/model-cache behavior and locations;
+- IPC, WebSocket protocol, `window.murmurMain`, `window.murmur`, `MURMUR_*`, Python
+  package/CLI names, and other internal compatibility surfaces;
+- packaged Python, Faster-Whisper, NeMo, PyTorch, CUDA, CTranslate2, ONNX Runtime, model
+  selection, and engine behavior;
+- repository/publish target `burntcookiedough/eve-windows-dictation`;
+- updater and release behavior unless a later stage explicitly authorizes a focused
+  publication-procedure change; and
+- current homepage, signing, and release infrastructure outside this plan's approved
+  stage.
+
+No Gate 6 work may inspect personal transcript text, audio, settings, hotwords,
+credentials, browser data, clipboard data, logs, or unknown startup values. It may not
+move, delete, enumerate internally, or alter either profile, installed application,
+registry/login state, shared model cache, or the preserved migration backup.
+
+The user-requested one-time local import of 541 Murmur transcription records is machine
+maintenance history only. It is not shipped automatic migration behavior and must never
+appear as such in release notes, support copy, or acceptance claims.
+
+## Gate 6A — release preparation
+
+### Authorized scope
+
+1. Preserve this permanent Gate 6 contract.
+2. Correct only present-tense stale status in `ROADMAP.md`, the Gate 5 master ledger, and
+   the Eve identity checklist.
+3. Run the existing version tool to set its six owned files to `0.7.0`.
+4. Add concise human-reviewed `v0.7.0` release notes based on merged Gates 1–5.
+5. Audit repository/publish/updater configuration without changing behavior.
+6. Audit third-party binary-distribution NOTICE readiness and record facts, limitations,
+   and blockers.
+7. Record preliminary Eve name/mark readiness without claiming formal legal clearance.
+8. Run focused checks, full Gate A, exact scope/privacy/frozen-boundary audit, hosted CI,
+   and a real CodeRabbit review.
+9. Leave the Gate 6A PR Ready but unmerged.
+
+### Non-goals and prohibited actions
+
+Gate 6A must not:
+
+- change production application or server behavior;
+- change dependencies, dependency constraints, dependency resolution, or lockfile
+  content other than the single root-package version field owned by
+  `scripts/version.py`;
+- change workflows, runtime, engines, models, protocols, IPC, profiles, startup/login,
+  cache, updater behavior, homepage, signing, AppUserModelID, NSIS GUID, install chain,
+  or internal compatibility names;
+- build a Windows package, create installer artifacts, install, repair, uninstall,
+  rollback, launch a lifecycle candidate, or mutate application/registry/profile state;
+- merge a PR, create or push a tag, create a GitHub release or draft, upload an asset, or
+  publish anything;
+- rewrite historical Gate 1–5 evidence;
+- claim formal trademark clearance or a completed NOTICE inventory without evidence; or
+- claim automatic Murmur History migration.
+
+### Exact Gate 6A allowlist and ceiling
+
+Gate 6A may change at most these **13 tracked files**. This is an allowlist, not a
+requirement to modify every file. A fourteenth file requires explicit scope review
+before it is changed.
+
+| # | File | Why it is allowed |
+|---:|---|---|
+| 1 | `docs/architecture/eve-gate-6-release-plan.md` | Permanent 6A/6B/6C contract, audit findings, approvals, and continuation instructions. |
+| 2 | `docs/architecture/eve-gate-6a-evidence.md` | Exact-head local/hosted validation, audit limitations, review disposition, and Ready handoff. |
+| 3 | `docs/releases/eve-v0.7.0-release-notes.md` | Concise human-reviewed release notes; no automatic-import claim. |
+| 4 | `ROADMAP.md` | Factual current-baseline and completed identity/visual-stage correction only. |
+| 5 | `docs/architecture/eve-gate-5-master-plan.md` | Factual Gate 5A/5B final ledger correction only; historical body remains intact. |
+| 6 | `docs/architecture/eve-identity-cutover-checklist.md` | Factual merged Gate 3/4/5 and remaining-release status correction only. |
+| 7 | `NOTICE.md` | User-facing third-party notice-readiness facts and unresolved limitations only. |
+| 8 | `app/package.json` | Version field only, through the existing version tool. |
+| 9 | `server/pyproject.toml` | Root project version field only, through the existing version tool. |
+| 10 | `server/src/version.py` | Server version constant only, through the existing version tool. |
+| 11 | `server/uv.lock` | Editable root `murmur` package version only, through the existing version tool. |
+| 12 | `README.md` | Version badge/alt text only, through the existing version tool; published v0.6.3 download table remains historical until Gate 6C. |
+| 13 | `scripts/release-verify.ps1` | Default expected version only, through the existing version tool. |
+
+`scripts/version.py` is authoritative but is not itself modified. `app/bun.lock` is not
+version-owned by the script and must remain byte-identical. No workflow or release
+configuration file is allowed.
+
+### Implementation sequence
+
+1. Verify issue #21 remains open with `Status: ready` and `Execution Gate: allowed`.
+2. Verify branch ancestry, exact base, and clean worktree.
+3. Run `python scripts/version.py check` and
+   `python scripts/version.py bump 0.7.0 --dry-run`.
+4. Make the three factual status corrections without altering historical evidence.
+5. Run `python scripts/version.py bump 0.7.0`; inspect every changed hunk and prove the
+   root `server/uv.lock` version is the only lockfile change.
+6. Add concise release notes and the factual Gate 6A evidence record.
+7. Complete repository/updater, NOTICE, and preliminary name/mark audits; record
+   unresolved blockers rather than guessing.
+8. Run focused version/release assertions and full Gate A.
+9. Audit the full diff against this 13-file allowlist and every frozen boundary.
+10. Commit minimal changes, push the branch, and open a draft PR linked to issue #21.
+11. Wait for hosted CI at completion boundaries.
+12. Mark Ready only after local and hosted acceptance, then obtain a real CodeRabbit
+    review.
+13. Disposition every thread, revalidate justified fixes, and leave the PR Ready but
+    unmerged.
+
+### Release-note content contract
+
+The `v0.7.0` notes may describe:
+
+- the visible Eve identity and approved AppUserModelID;
+- the separate fresh Eve profile and preservation of the Murmur profile;
+- History, Insights, Settings, Advanced Server placement, and the accepted monochrome
+  accessibility system;
+- the noninteractive waveform/transcript overlay behavior;
+- the original cactus application and Windows resource family;
+- existing local Faster-Whisper/Nemotron, CUDA, diagnostics, singleton, and installer
+  continuity where supported by merged evidence; and
+- the unsigned-release warning and known large download/model-download behavior.
+
+They must state that Eve does not automatically import Murmur personal data. They must
+not convert the user's one-time local import into a feature claim, invent settings or
+analytics, promise signing, call the product 1.0-ready, or claim publication before it
+occurs.
+
+### Repository, updater, and publication audit
+
+The planning audit found:
+
+- `app/package.json` points both repository and Electron Builder GitHub publishing to
+  `burntcookiedough/eve-windows-dictation`;
+- the local Windows packaging command includes `--publish never`;
+- no `electron-updater` or in-app auto-updater implementation is present in the
+  production source found by the audit;
+- the NSIS-web distribution uses GitHub release metadata and `latest.yml` for payload
+  discovery;
+- `.github/workflows/release.yml` runs on every `v*` tag, builds a fresh Windows package,
+  and publishes a GitHub release with generated notes and matching artifacts; and
+- the latest public download remains the historical Murmur `v0.6.3` release.
+
+Therefore Gate 6A changes no updater or workflow behavior. Before Gate 6C, the user must
+approve a publication procedure that reconciles Gate 6B's verified candidate with the
+tag-triggered workflow. Pushing a `v0.7.0` tag without that decision would immediately
+build and publish and is prohibited.
+
+### NOTICE and name/mark audit
+
+`NOTICE.md` currently preserves the original Murmur MIT attribution and explicitly says
+that the binary-distribution third-party notice audit is unfinished. The packaged
+closure includes a managed Python distribution, Electron/Node dependencies, Python
+dependencies, ASR/runtime libraries, CUDA-adjacent binaries, and separately downloaded
+models with their own terms.
+
+Gate 6A must inventory the distributed closure using manifests, lockfiles, package
+metadata, embedded license/notice files, and authoritative upstream terms. The audit
+must distinguish:
+
+- code and binaries actually shipped in the installer;
+- build-only and test-only tools not shipped;
+- models downloaded separately on first use; and
+- platform/vendor components whose redistribution terms need separate confirmation.
+
+`NOTICE.md` may be updated only with verified attribution and limitations. If a complete
+binary-distribution notice set cannot be proven, Gate 6A may still reach Ready with the
+limitation recorded, but Gate 6C remains blocked.
+
+The cactus provenance record is an originality record, not a trademark opinion.
+Repository documents defer formal review of the word mark **Eve**. Gate 6A may record a
+preliminary conflict/search log, but no agent may claim legal clearance. Any unresolved
+name/mark risk blocks Gate 6C until the user explicitly accepts a documented risk or
+obtains appropriate review.
+
+### Gate 6A acceptance matrix
+
+| Requirement | Evidence |
+|---|---|
+| Exact base and ancestry | `git rev-parse HEAD`, `git rev-parse origin/trunk`, merge-base, remote URL, clean status. |
+| Version synchronization | Dry-run list, `bump 0.7.0`, `check --tag v0.7.0`, exact six-file version diff. |
+| Factual status cleanup | Line-by-line diff proving only current status changed in the three allowed historical documents. |
+| Release notes | Manual claim-to-merged-evidence review; explicit no-automatic-import statement. |
+| Repository/updater readiness | Static audit of package metadata, release workflow, tests, and absence/presence of updater implementation. |
+| NOTICE readiness | Dependency/distribution inventory with sources, verified notices, limitations, and Gate 6C blocker decision. |
+| Frozen identities | Exact assertions for app ID, AppUserModelID, GUID, product/executable names, profile roots, startup constants, publish target, and package command. |
+| Dependency integrity | Manifests and lockfiles unchanged except allowed version-owned fields; frozen install commands. |
+| Privacy | No access to user profiles/application/registry/cache; no sensitive/generated artifact in the diff or untracked tree. |
+| Full Gate A | Version check, app tests, History/Insights check, TypeScript, production build, server tests, lock check, diff check, scope/privacy audit. |
+| Hosted acceptance | Draft PR CI, Ready transition, real CodeRabbit review, all threads dispositioned, clean final head. |
+| Handoff | PR open, Ready, mergeable, unmerged; exact head/scope/worktree recorded. |
+
+### Gate 6A validation commands
+
+All runtime, dependency, test, and build commands execute in Windows PowerShell, as
+required by `AGENT.md`. Gate 6A does not install or update dependencies.
+
+```powershell
+# Repository and issue gate
+git remote get-url origin
+git rev-parse HEAD
+git rev-parse origin/trunk
+git merge-base HEAD origin/trunk
+git status --short --branch
+
+# Version-owned metadata
+python scripts/version.py check
+python scripts/version.py bump 0.7.0 --dry-run
+python scripts/version.py bump 0.7.0
+python scripts/version.py check --tag v0.7.0
+
+# Application (existing dependencies only)
+Set-Location app
+bun test
+bun run test:history
+bunx tsc -p tsconfig.main.json --noEmit
+bunx tsc -p tsconfig.json --noEmit
+bun run build
+
+# Server (existing Windows environment only; no sync/install)
+Set-Location ..\server
+uv lock --check
+uv run --no-sync pytest
+
+# Final repository audit
+Set-Location ..
+git diff --check origin/trunk...HEAD
+git diff --name-only origin/trunk...HEAD
+git status --short --branch
+```
+
+If the fresh clone lacks already-valid Windows dependencies, Gate 6A must not install or
+mutate them silently. Use hosted CI for the authoritative dependency-materialized run or
+request explicit authorization for a bounded environment-preparation step.
+
+### Gate 6A stop conditions
+
+Stop immediately if:
+
+- the canonical base or issue gate differs;
+- a fourteenth tracked file is required;
+- version tooling changes anything beyond its six declared fields;
+- a dependency, workflow, production behavior, identity, installer, profile, startup,
+  cache, protocol, runtime, updater, homepage, or release setting drifts;
+- personal or installed-machine state would need inspection or mutation;
+- release notes require an unsupported claim;
+- NOTICE or name/mark evidence is represented as stronger than it is;
+- validation reveals a production regression;
+- a package, install, tag, release, or publication action would be needed; or
+- CI/review cannot be reconciled within two focused correction rounds.
+
+### Gate 6A rollback
+
+Before a PR exists, rollback is removal of the disposable Gate 6A branch/clone after
+preserving this contract commit for review. After a PR exists, use additive corrective
+commits or close the unmerged PR. Never rewrite shared history or reset user work.
+
+Gate 6A changes repository files only. It has no application/profile/registry rollback
+because those systems must remain untouched.
+
+## Gate 6B — exact release candidate
+
+### Authorization boundary
+
+Gate 6B is not authorized by Gate 6A. It begins only after the user reviews the complete
+Gate 6A PR/head and explicitly authorizes the exact package/lifecycle plan.
+
+### Required inputs
+
+- the final accepted Gate 6A release head and tree;
+- clean exact-head package workspace with the full locked Windows runtime;
+- resolved Gate 6A scope and validation findings;
+- explicit user authorization for package and application-state lifecycle changes;
+- bounded preflight for disk space, artifact staging, current installation, exact scoped
+  startup state, profile aggregate metadata, and shared-cache root presence without
+  reading personal contents; and
+- checksum-verified official `v0.6.3` rollback artifacts.
+
+Gate 5B candidate packages are acceptance history and must not be reused as `v0.7.0`
+release artifacts.
+
+### Package rule
+
+Run exactly one accepted deterministic Windows package from the final frozen Gate 6
+release head. If that attempt fails or its identity/runtime closure is ambiguous, stop;
+any replacement attempt requires new explicit authorization.
+
+Hash and preserve independent artifact sets when repair consumes a payload. Record exact
+bytes and SHA-256/SHA-512 for the wrapper, payload, manifest, blockmaps where present,
+unpacked application, and relevant identity resources. No generated artifact belongs in
+Git.
+
+### Lifecycle matrix
+
+Gate 6B must prove, at minimum:
+
+1. packaged version, product/file metadata, AppUserModelID, frozen GUID, artifact names,
+   repository metadata, and runtime closure;
+2. upgrade over the accepted installed Eve/Murmur-chain state;
+3. a bounded clean-install scenario without inspecting personal profiles;
+4. title-bar/taskbar/tray/Start/shortcut/uninstaller/notification cactus identity;
+5. owned PID-file health, singleton behavior, CUDA/runtime availability, and controlled
+   Fast and Long Dictation using repository fixtures with no retained transcript/audio;
+6. same-version repair using an untouched hash-verified payload;
+7. normal uninstall preserving both profiles, scoped login state, unknown entries, and
+   shared caches;
+8. checksum-verified official `v0.6.3` rollback and fresh owned health; and
+9. exact restoration of pre-test scoped startup state.
+
+Only aggregate counts/bytes/timestamps for the two profile roots may be recorded.
+Unknown startup values and cache contents remain uninspected.
+
+### Gate 6B output and stop conditions
+
+Gate 6B produces an immutable artifact/evidence handoff outside Git unless a separately
+approved evidence-only repository change is proven compatible with the exact-head
+release rule. It does not merge, tag, create a release, upload, or publish.
+
+Stop on identity/version/GUID drift, incomplete runtime closure, artifact mismatch,
+profile/startup/cache mutation beyond owned behavior, dictation or singleton failure,
+repair/uninstall failure, rollback failure, notice/name blocker, or any need to inspect
+personal data. Do not guess or automatically retry.
+
+## Gate 6C — merge, tag, and publication
+
+### Authorization boundary
+
+Gate 6C requires a new explicit user authorization after:
+
+- Gate 6A is Ready and accepted;
+- Gate 6B passes from the exact accepted release head;
+- artifact hashes and lifecycle evidence are independently reviewed;
+- NOTICE readiness is complete or explicitly resolved;
+- Eve name/mark risk is explicitly resolved or accepted; and
+- the publication procedure below is unambiguous.
+
+### Publication-procedure blocker
+
+The current `.github/workflows/release.yml` runs on a `v*` tag and immediately builds
+and publishes. This creates a consequential choice:
+
+1. authorize the tag-triggered workflow as the publication build, treating Gate 6B as a
+   release-candidate rehearsal and independently comparing the published closure; or
+2. separately authorize a focused workflow/manual-upload procedure that publishes the
+   exact Gate 6B artifacts without an uncontrolled second build.
+
+Gate 6A does not choose or implement either option. No `v0.7.0` tag may be pushed until
+the user approves one exact method and its rollback.
+
+### Gate 6C acceptance
+
+Before publication:
+
+- re-audit PR/head/tree, mergeability, CI, CodeRabbit, allowlist, version, and clean
+  worktree;
+- merge only the accepted release change using the repository's approved merge method;
+- prove canonical `trunk` contains the accepted tree;
+- prove tag `v0.7.0` points at the explicitly approved release commit;
+- publish only the approved, hash-verified artifact set with human-reviewed notes; and
+- ensure the unsigned-release warning remains accurate.
+
+After publication:
+
+- independently verify the GitHub release, tag, asset names, bytes, hashes, manifest,
+  repository URLs, and clean public download;
+- test the NSIS-web wrapper's public payload resolution;
+- verify the public installer against the approved lifecycle identity/runtime closure;
+- record any release workflow divergence or artifact mismatch as a release failure; and
+- never delete or replace historical `v0.6.3` assets.
+
+If publication fails, stop asset promotion, preserve evidence, and follow the exact
+approved rollback. Do not move tags, overwrite assets, or publish replacements without
+explicit authorization.
+
+## Cleanup policy
+
+- The obsolete parent checkout and its untracked `eve-gate5b-base.zip` are never touched.
+- Gate 6 uses only the fresh nested clone named in this plan.
+- No package, installer, copied runtime, dependency tree, log, audio, screenshot, profile
+  backup, manifest, diagnostic helper, or downloaded reference is committed.
+- Disposable Gate 6B workspaces/artifacts are removed only after resolving and verifying
+  exact absolute paths and only after the user confirms retention is no longer required.
+- Historical release assets and Gate 1–5 evidence are immutable.
+- Normal source/build cleanup must never target a repository root, profile root,
+  installed application, registry, shared cache, or migration backup.
+
+## Stage-gate ledger
+
+| Stage | Status | Evidence | Required approval | What happens next |
+|---|---|---|---|---|
+| Canonical Gate 6 base | Passed | Fresh clone; exact `0d6605d…`; clean `trunk` | Complete | Preserve base ancestry. |
+| Gate 6 tracking issue | Passed | Issue #21, `ready`, execution allowed | Complete | Keep issue state authoritative. |
+| Permanent Gate 6 contract | In progress | This file and its first commit | Parent review | Review allowlist, blockers, and next commands. |
+| Gate 6A mechanical edits | Planned | Future scoped commit(s) | Continue only after contract review | Apply factual/version/release-note/notice work. |
+| Gate 6A local Gate A | Planned | `eve-gate-6a-evidence.md` | None beyond authorized 6A | Run full validation without dependency mutation. |
+| Gate 6A PR/CI/CodeRabbit | Planned | Future PR and hosted checks | None for draft/review | Leave Ready but unmerged. |
+| Gate 6A merge | Deferred | Future merge commit | Explicit authorization | Do not infer from Ready status. |
+| Gate 6B exact candidate | Deferred | External artifact/lifecycle evidence | Separate explicit authorization | One package and full lifecycle only. |
+| Gate 6C publication method | Blocked | Current tag workflow audit | Explicit method/risk decision | Resolve exact-artifact versus tag-build procedure. |
+| Gate 6C merge/tag/release | Deferred | Future canonical/tag/release evidence | Separate explicit authorization | Publish only after all blockers pass. |
+
+## First-turn audit findings
+
+The planning turn verified:
+
+- the fresh nested clone remote is
+  `https://github.com/burntcookiedough/eve-windows-dictation.git`;
+- local `trunk` and `origin/trunk` were both exactly
+  `0d6605d07aa783036d61fc93af7ce043a808f1a6`;
+- the tracked worktree was clean before the Gate 6A branch was created;
+- `AGENT.md`, ADR-001, the Gate 5 master/evidence, the identity checklist, roadmap,
+  version tool, release verification script, manifests, NOTICE/LICENSE, release case
+  study, and all GitHub workflows were read;
+- `python scripts/version.py check` passed at `0.6.3`;
+- the version-tool dry run named exactly six owned files;
+- no tracked changelog or release-note file/convention exists; v0.6.3 uses README
+  history, an engineering case study, and generated GitHub notes;
+- repository/publish metadata targets the standalone Eve repository and local packaging
+  explicitly disables publication;
+- the tag workflow is publication-active and therefore a Gate 6C control boundary;
+- `NOTICE.md` explicitly records an unfinished binary-distribution notice audit;
+- formal trademark review remains deferred in the controlling architecture records; and
+- stale present-tense Gate 5/identity/roadmap statuses are documentation debt, not
+  evidence that merged work is incomplete.
+
+No version, production, package, workflow, profile, registry, application, release, or
+personal-data mutation occurred during the planning audit.
+
+## Continuation instructions
+
+A future task resumes without chat history by:
+
+1. reading this file completely;
+2. reading issue #21 and confirming `Status: ready` / `Execution Gate: allowed`;
+3. verifying canonical base/branch ancestry and a clean worktree;
+4. checking the stage-gate ledger for the first incomplete authorized stage;
+5. confirming the 13-file Gate 6A allowlist and frozen boundaries;
+6. performing only that stage's listed commands and recording fresh evidence; and
+7. stopping before any separately gated action.
+
+Use gpt-5.6-sol medium for architecture, release judgment, notice/name risk, review
+disposition, and final audit. Use gpt-5.6-terra medium only at safe turn boundaries for
+already-decided mechanical version edits, tests, CI, or lifecycle execution. Use
+completion-boundary waits for long jobs and avoid unchanged polling. Do not use
+subagents unless the user explicitly requests them.
+
+## Failure protocol
+
+On any failed gate:
+
+1. stop the affected stage;
+2. preserve only privacy-safe evidence;
+3. do not broaden scope or mutate protected machine state;
+4. restore the last known safe state using the stage's documented rollback;
+5. record what passed, what failed, the exact command/evidence, and the smallest needed
+   decision;
+6. keep later stages blocked; and
+7. never guess past a failed acceptance condition.

--- a/docs/architecture/eve-gate-6a-evidence.md
+++ b/docs/architecture/eve-gate-6a-evidence.md
@@ -1,0 +1,84 @@
+# Eve Gate 6A release-preparation evidence
+
+Status: in progress. This record is factual evidence for Gate 6A only; it is not a
+package, lifecycle, merge, tag, release, or publication claim.
+
+## Starting state and authorization
+
+- Repository: `burntcookiedough/eve-windows-dictation`.
+- Canonical base: `0d6605d07aa783036d61fc93af7ce043a808f1a6`.
+- Gate 6A contract: `e33c9304f6c133867c6a9f0948a943a75fedaca5`.
+- Tracking issue: [#21](https://github.com/burntcookiedough/eve-windows-dictation/issues/21),
+  `Status: ready`, `Execution Gate: allowed`.
+- Parent review verified the contract's clean branch, one-file scope, baseline version
+  check, and six-file version-tool dry run before authorizing mechanical Gate 6A work.
+
+## Version preparation
+
+The existing `scripts/version.py` tool was used. Its `0.7.0` dry run named exactly these
+six files, and the implementation diff was reviewed before further documentation edits:
+
+1. `app/package.json`
+2. `server/pyproject.toml`
+3. `server/src/version.py`
+4. `server/uv.lock`
+5. `README.md`
+6. `scripts/release-verify.ps1`
+
+The `server/uv.lock` change is limited to the editable root `murmur` package version.
+No dependency version, resolution, or `app/bun.lock` content is part of Gate 6A.
+
+## Factual documentation cleanup
+
+- `ROADMAP.md` now distinguishes prepared Eve v0.7.0 source from the still-public Murmur
+  v0.6.3 download and records Gates 1–5 as complete.
+- The Gate 5 master ledger records PRs #19 and #20 and their merge commits while retaining
+  its historical planning contract and evidence.
+- The identity checklist records merged Gates 3–5 and keeps homepage work separate.
+- The release notes explicitly state that Eve does not automatically import Murmur data.
+
+## Repository and NOTICE readiness audit
+
+The tracked package metadata points to `burntcookiedough/eve-windows-dictation`. Local
+Windows packaging uses `--publish never`. The release workflow runs on `v*` tags and
+builds/publishes a release; Gate 6A changes none of this behavior.
+
+Tracked manifests and release configuration prove that a Windows distribution contains an
+Electron application, a managed Python runtime, and packaged production Python
+dependencies, while models download separately on first use. They do not prove a complete
+binary-distribution notice inventory or formal Eve name/mark clearance. Both remain Gate
+6C publication blockers.
+
+## Frozen-boundary statement
+
+Gate 6A does not change AppUserModelID, the frozen NSIS GUID, installer chain, profile
+roots, startup policy, shared cache behavior, protocols, runtime/engine behavior, updater
+behavior, workflows, homepage, dependencies, or internal compatibility names. It does not
+inspect or alter personal profiles, installed application state, registry, startup values,
+or model-cache contents.
+
+## Validation and hosted review
+
+Completed local checks:
+
+| Check | Result |
+|---|---|
+| `python scripts/version.py check --tag v0.7.0` | Passed. |
+| `uv lock --check --offline` | Passed with a new isolated cache outside the repository; 228 packages resolved without shared-cache access. |
+| Server suite | Passed: 139/139 on Python 3.11.15 from the pre-provisioned environment, with Gate 6A `server/src` and test UI source first on `PYTHONPATH`, bytecode disabled, and pytest cache disabled. |
+| App suite | Passed: 111/111 tests across 20 files with 640 `expect` assertions, run by the parent in the unrestricted environment against this exact Gate 6A worktree and the hash-matched pre-provisioned dependency tree. |
+| History/Insights guard | Passed: `history insights aggregate check passed`. |
+| TypeScript | Main and renderer no-emit checks passed. |
+| Production build | Main process, both preloads, and Vite renderer passed; the renderer built 140 modules. |
+| Tracked diff check | Passed. |
+| Final scope/privacy/frozen-boundary audit | Passed: exactly 13 allowlisted files; no generated residue; `app/package.json` and `server/uv.lock` each have only the planned one-line version replacement; AppUserModelID, NSIS GUID, and local `--publish never` packaging command remain exact. |
+
+The fresh clone has no local `app/node_modules` or `server/.venv`. The parent completed
+the Bun-blocked checks in an unrestricted environment using the required Bun executable
+and a verified temporary junction to the approved dependency tree. That junction and the
+generated ignored `app/dist` directory were removed after exact-path verification. No
+substitute runtime, dependency installation, sync, download, shared-cache mutation, or
+repository artifact was used.
+
+Hosted CI and CodeRabbit review remain pending. This file must be updated only with fresh
+hosted-review facts before the Gate 6A PR is marked Ready.

--- a/docs/architecture/eve-identity-cutover-checklist.md
+++ b/docs/architecture/eve-identity-cutover-checklist.md
@@ -9,8 +9,9 @@ Murmur History, settings, hotwords, external-server configuration, browser stora
 credentials, logs, or startup preference. The old Murmur data directory stays inactive
 and untouched. Generic Hugging Face model weights may be reused because they are
 downloaded runtime assets outside Murmur userData. Compatibility scaffolding, the fresh
-Eve data boundary, and the visible product rename are merged; Gate 4 is the focused
-AppUserModelID and startup-registration cutover.
+Eve data boundary, the visible product rename, and the AppUserModelID/startup-registration
+cutover are merged. Gates 5A and 5B subsequently completed the approved
+visual/accessibility system and cactus Windows resources.
 
 The controlling architecture decision is [ADR-001](adr-001-eve-application-identity-migration.md).
 
@@ -23,7 +24,7 @@ The controlling architecture decision is [ADR-001](adr-001-eve-application-ident
 - Eve data: a distinct fresh profile.
 - Shared model cache: may be reused without reading Murmur userData.
 - Existing installer chain: preserve through an explicit NSIS GUID.
-- Visual redesign: later phase.
+- Visual redesign and cactus resource lifecycle: complete in merged Gates 5A and 5B.
 - Thin-client and new ASR profiles: later phase.
 
 ## Audit coverage
@@ -177,9 +178,10 @@ These names are internal or compatibility surfaces. They are not evidence that p
 | Select final AppUserModelID | Complete: `io.github.burntcookiedough.eve` approved 2026-07-27 | No |
 | Compatibility-scaffolding implementation | Complete in merged PR #15 at `5e5b3a3` | No |
 | Fresh Eve profile implementation | Complete in merged PR #16 at `ca9eddb`; Gate A/B evidence includes Fast/Long smoke, repair, normal uninstall preservation, and official rollback | No |
-| Visible installed-product rename | Complete on `codex/eve-visible-identity-gate-3`; see [Gate 3 evidence](eve-identity-gate-3-evidence.md). AppUserModelID and startup registrations remain deferred | Merge approval |
-| AppUserModelID cutover | Complete on Gate 4 draft PR #18; Gate A and the full Windows lifecycle passed from fixed head `c6d9d3a` | Merge approval |
-| Visual identity and homepage | Pending | Later design phase |
+| Visible installed-product rename | Complete in merged PR #17; see [Gate 3 evidence](eve-identity-gate-3-evidence.md) | No |
+| AppUserModelID cutover | Complete in merged PR #18; Gate A and the full Windows lifecycle passed from fixed head `c6d9d3a` | No |
+| Visual identity | Complete in merged PRs #19 and #20; see Gate 5 evidence | No |
+| Homepage | Pending | Later public-presence phase |
 | Thin-client/component packs and ASR profiles | Pending | Later technical phase |
 
 ## Stop conditions

--- a/docs/releases/eve-v0.7.0-release-notes.md
+++ b/docs/releases/eve-v0.7.0-release-notes.md
@@ -1,0 +1,35 @@
+# Eve v0.7.0 release notes
+
+Status: prepared release notes; Eve v0.7.0 has not been published.
+
+## Highlights
+
+- Eve is the visible Windows product name, executable, installer, shortcut, and
+  AppUserModelID (`io.github.burntcookiedough.eve`).
+- Eve uses its own fresh `%APPDATA%\Eve` profile. It does **not** automatically import,
+  merge, prompt for, or delete Murmur History, settings, hotwords, browser storage,
+  credentials, external-server configuration, or other personal state.
+- The desktop app now uses the approved compact monochrome History, Insights, and
+  Settings experience, with existing Server controls grouped under Settings > Advanced.
+- The waveform overlay remains click-through and non-focusable, with a fixed two-line
+  transcript viewport and programmatic newest-text follow rather than interactive
+  controls or manual scrolling.
+- Eve includes the original monochrome cactus Windows resource family for the application,
+  title bar, taskbar, tray variants, Start menu, shortcuts, installer, and uninstaller.
+
+## Compatibility and privacy
+
+- The established NSIS upgrade/uninstall chain remains frozen through GUID
+  `0204d005-75b3-5b31-b1f6-ef2831e2b204`.
+- Existing `%APPDATA%\murmur` data remains untouched. Shared model caches remain outside
+  the profile migration boundary.
+- The internal `murmur` package name, payload compatibility name, `MURMUR_*` interfaces,
+  preload bridges, and local protocol remain unchanged for compatibility.
+
+## Before publication
+
+These notes describe the accepted source preparation, not an available download. A fresh
+exact-head package and Windows lifecycle, complete third-party notice readiness, an
+explicit Eve name/mark publication decision, and an approved tag/publication procedure
+are still required. The Windows release remains unsigned unless a separately approved
+signing decision changes that status.

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$ExpectedVersion = "0.6.3",
+    [string]$ExpectedVersion = "0.7.0",
     [string]$InstallerDir = "E:\EveRelease\release-prep\full-nsis-web\nsis-web",
     [string]$InstallDir = "E:\EveRelease\release-prep\smoke-install\Eve",
     [string]$BaseBranch = "trunk",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.6.3"
+version = "0.7.0"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.6.3"
+SERVER_VERSION = "0.7.0"

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "murmur"
-version = "0.6.3"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Closes #21

## Scope
- prepare synchronized Eve v0.7.0 metadata
- add release notes and Gate 6A evidence
- correct factual Gate 1-5 status ledgers
- record NOTICE and name/mark publication blockers

## Boundaries
No packaging, installation, workflow, dependency, runtime, profile, registry, merge, tag, release, or publication changes.

## Validation
- app: 111/111 tests, 640 assertions
- server: 139/139 tests
- History/Insights, TypeScript, production build, version, lock, diff, scope, privacy, and frozen-identity checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Preparation**
  * Updated product, server, and Windows release verification to **v0.7.0**.
  * Added/updated verification expectations for the **v0.7.0** prepared-but-not-yet-published release state.

* **Documentation**
  * Added **Eve v0.7.0** release notes (highlights, compatibility/privacy, and pre-publication checklist).
  * Updated roadmap, Gate 5/6 governance materials, and Gate 6 evidence to reflect release readiness and publication blockers.
  * Expanded the Windows distribution **NOTICE** with clearer gate-based provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->