### PR TITLE
Prepare controlled Gate 6C release promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,25 +42,41 @@ jobs:
         with:
           ref: ${{ inputs.expected_commit }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Require default-branch dispatch and explicit risk gates
         shell: pwsh
+        env:
+          TAG: ${{ inputs.tag }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
+          ACCEPTED_NAME_RISK: ${{ inputs.accepted_name_risk }}
         run: |
-          if ('${{ github.ref }}' -ne 'refs/heads/trunk') { throw 'Dispatch only from trunk.' }
-          if (-not ${{ inputs.allow_unsigned }}) { throw 'Unsigned publication requires allow_unsigned=true.' }
-          if (-not ${{ inputs.accepted_name_risk }}) { throw 'Name-risk acceptance must be explicit.' }
+          $ErrorActionPreference = 'Stop'
+          if ($env:GITHUB_REF -ne 'refs/heads/trunk') { throw 'Dispatch only from trunk.' }
+          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$') { throw 'Malformed release inputs.' }
+          if ($env:ACCEPTED_NAME_RISK -ne 'true') { throw 'Name-risk acceptance must be explicit.' }
       - name: Download existing draft assets only
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
         run: |
-          gh release view '${{ inputs.tag }}' --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
+          gh release view $env:TAG --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
           $release = Get-Content release.json -Raw | ConvertFrom-Json
-          if (-not $release.isDraft -or $release.isPrerelease) { throw 'An existing non-prerelease draft release is required.' }
-          gh release download '${{ inputs.tag }}' --repo '${{ github.repository }}' --dir release-assets
+          if (-not $release.isDraft -or $release.isPrerelease -or $release.targetCommitish -ne $env:EXPECTED_COMMIT) { throw 'An exact-target non-prerelease draft release is required.' }
+          gh release download $env:TAG --repo '${{ github.repository }}' --dir release-assets
       - name: Verify draft manifest and artifacts
         shell: pwsh
+        env:
+          TAG: ${{ inputs.tag }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_MANIFEST_SHA256: ${{ inputs.expected_manifest_sha256 }}
+          ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
         run: |
-          & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag '${{ inputs.tag }}' -ExpectedCommit '${{ inputs.expected_commit }}' -ExpectedManifestSha256 '${{ inputs.expected_manifest_sha256 }}' -AllowUnsigned:$${{ inputs.allow_unsigned }}
+          $ErrorActionPreference = 'Stop'
+          & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag $env:TAG -ExpectedCommit $env:EXPECTED_COMMIT -ExpectedManifestSha256 $env:EXPECTED_MANIFEST_SHA256 -AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')
+          if ($LASTEXITCODE -ne 0) { throw 'Artifact verification failed.' }
 
   promote:
     name: Reverify and publish the verified draft
@@ -74,18 +90,27 @@ jobs:
         with:
           ref: ${{ inputs.expected_commit }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Re-download and reverify after approval
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_MANIFEST_SHA256: ${{ inputs.expected_manifest_sha256 }}
+          ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
         run: |
-          gh release view '${{ inputs.tag }}' --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
+          $ErrorActionPreference = 'Stop'
+          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_MANIFEST_SHA256 -notmatch '^[0-9a-fA-F]{64}$' -or $env:ALLOW_UNSIGNED -notin @('true', 'false')) { throw 'Malformed release inputs.' }
+          gh release view $env:TAG --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
           $release = Get-Content release.json -Raw | ConvertFrom-Json
-          if (-not $release.isDraft -or $release.isPrerelease) { throw 'Draft state changed after verification.' }
-          gh release download '${{ inputs.tag }}' --repo '${{ github.repository }}' --dir release-assets
-          & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag '${{ inputs.tag }}' -ExpectedCommit '${{ inputs.expected_commit }}' -ExpectedManifestSha256 '${{ inputs.expected_manifest_sha256 }}' -AllowUnsigned:$${{ inputs.allow_unsigned }}
+          if (-not $release.isDraft -or $release.isPrerelease -or $release.targetCommitish -ne $env:EXPECTED_COMMIT) { throw 'Draft target or state changed after verification.' }
+          gh release download $env:TAG --repo '${{ github.repository }}' --dir release-assets
+          & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag $env:TAG -ExpectedCommit $env:EXPECTED_COMMIT -ExpectedManifestSha256 $env:EXPECTED_MANIFEST_SHA256 -AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')
+          if ($LASTEXITCODE -ne 0) { throw 'Artifact re-verification failed.' }
       - name: Publish the existing verified draft only
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit '${{ inputs.tag }}' --repo '${{ github.repository }}' --draft=false --prerelease=false --latest
+          TAG: ${{ inputs.tag }}
+        run: gh release edit $env:TAG --repo '${{ github.repository }}' --draft=false --prerelease=false --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,158 +1,91 @@
-name: Release Windows
+name: Verify And Promote Windows Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Exact existing release tag
+        required: true
+        type: string
+      expected_commit:
+        description: Exact 40-character release commit
+        required: true
+        type: string
+      expected_manifest_sha256:
+        description: SHA-256 of the uploaded manifest
+        required: true
+        type: string
+      allow_unsigned:
+        description: Permit an intentionally unsigned Windows wrapper
+        required: true
+        default: false
+        type: boolean
+      accepted_name_risk:
+        description: Confirm the documented Eve name/mark risk acceptance
+        required: true
+        default: false
+        type: boolean
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: eve-release-${{ inputs.tag }}
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Build And Publish Release
+  verify-draft:
+    name: Verify existing draft assets (no build or upload)
     runs-on: windows-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          python-version: "3.11"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Validate tag version matches repository version
-        run: python scripts/version.py check --tag "${{ github.ref_name }}"
-
-      - name: Prepare managed Python and server dependencies
-        working-directory: server
+          ref: ${{ inputs.expected_commit }}
+          fetch-depth: 0
+      - name: Require default-branch dispatch and explicit risk gates
         shell: pwsh
         run: |
-          & "..\scripts\prepare-python-runtime.ps1" -ServerDir "." -PythonVersion "3.11"
-          $python = (Resolve-Path ".runtime\python.exe").Path
-          uv sync --python $python --extra all --group dev --frozen
-
-      - name: Run server tests
-        working-directory: server
-        run: uv run --no-sync pytest
-
-      - name: Remove development-only server packages
-        working-directory: server
+          if ('${{ github.ref }}' -ne 'refs/heads/trunk') { throw 'Dispatch only from trunk.' }
+          if (-not ${{ inputs.allow_unsigned }}) { throw 'Unsigned publication requires allow_unsigned=true.' }
+          if (-not ${{ inputs.accepted_name_risk }}) { throw 'Name-risk acceptance must be explicit.' }
+      - name: Download existing draft assets only
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view '${{ inputs.tag }}' --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
+          $release = Get-Content release.json -Raw | ConvertFrom-Json
+          if (-not $release.isDraft -or $release.isPrerelease) { throw 'An existing non-prerelease draft release is required.' }
+          gh release download '${{ inputs.tag }}' --repo '${{ github.repository }}' --dir release-assets
+      - name: Verify draft manifest and artifacts
         shell: pwsh
         run: |
-          $python = (Resolve-Path ".runtime\python.exe").Path
-          uv sync --python $python --extra all --no-dev --frozen
+          & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag '${{ inputs.tag }}' -ExpectedCommit '${{ inputs.expected_commit }}' -ExpectedManifestSha256 '${{ inputs.expected_manifest_sha256 }}' -AllowUnsigned:$${{ inputs.allow_unsigned }}
 
-      - name: Verify portable Python imports
-        working-directory: server
-        shell: pwsh
-        run: |
-          $env:PYTHONNOUSERSITE = "1"
-          $env:PYTHONPATH = (Resolve-Path ".venv\Lib\site-packages").Path
-          & ".runtime\python.exe" -c "import fastapi, uvicorn, faster_whisper, torch, nemo.collections.asr; print('portable runtime imports passed')"
-          if ($LASTEXITCODE -ne 0) { throw "Portable Python import smoke test failed." }
-
-      - name: Smoke-start server with portable Python
-        working-directory: server
-        shell: pwsh
-        run: |
-          $env:PYTHONNOUSERSITE = "1"
-          $env:PYTHONPATH = (Resolve-Path ".venv\Lib\site-packages").Path
-          $env:MURMUR_PID_FILE = Join-Path $env:RUNNER_TEMP "murmur-release-smoke.pid"
-          $env:MURMUR_SETTINGS_FILE = Join-Path $env:RUNNER_TEMP "murmur-release-smoke-settings.json"
-          $env:MURMUR_PORT = "51819"
-          $env:MURMUR_ENGINE = "whisper"
-          $env:MURMUR_WHISPER_MODEL = "tiny"
-          $env:MURMUR_WHISPER_DEVICE = "cpu"
-          $env:MURMUR_WHISPER_COMPUTE_TYPE = "int8"
-          $process = Start-Process -FilePath ".runtime\python.exe" -ArgumentList "src\main.py" -WorkingDirectory $PWD -WindowStyle Hidden -PassThru
-          try {
-            $deadline = (Get-Date).AddMinutes(10)
-            $ready = $false
-            $lastState = $null
-            while ((Get-Date) -lt $deadline -and -not $process.HasExited) {
-              try {
-                $health = Invoke-RestMethod -Uri "http://127.0.0.1:51819/health" -TimeoutSec 5
-                $lastState = $health
-                if (
-                  $health.status -eq "healthy" -and
-                  $health.engine.status -eq "ready" -and
-                  $health.model_download.status -eq "ready"
-                ) {
-                  $ready = $true
-                  break
-                }
-              } catch {}
-              Start-Sleep -Seconds 2
-            }
-            if (-not $ready) {
-              $lastJson = $lastState | ConvertTo-Json -Depth 8 -Compress
-              throw "Portable server did not reach transcription readiness before timeout. Last state: $lastJson"
-            }
-          } finally {
-            if (-not $process.HasExited) { Stop-Process -Id $process.Id -Force }
-          }
-
-      - name: Install app dependencies
-        working-directory: app
-        run: bun install --frozen-lockfile
-
-      - name: Run app tests
-        working-directory: app
-        run: bun test
-
-      - name: Build Windows installer
-        working-directory: app
-        run: bun run package:win
-
-      - name: Verify packaged Python imports
-        working-directory: app
-        shell: pwsh
-        run: |
-          $server = (Resolve-Path "release\win-unpacked\resources\server").Path
-          $env:PYTHONNOUSERSITE = "1"
-          $env:PYTHONPATH = (Resolve-Path "$server\.venv\Lib\site-packages").Path
-          & "$server\.runtime\python.exe" -c "import fastapi, uvicorn, faster_whisper, torch, nemo.collections.asr; print('packaged runtime imports passed')"
-          if ($LASTEXITCODE -ne 0) { throw "Packaged Python import smoke test failed." }
-
-      - name: Verify release artifacts fit GitHub
-        shell: pwsh
-        run: |
-          $releaseDir = "app\release\nsis-web"
-          $artifacts = Get-ChildItem $releaseDir -File | Where-Object {
-            $_.Extension -in ".exe", ".7z", ".blockmap", ".yml"
-          }
-          if (-not $artifacts) { throw "No release artifacts were produced." }
-          if (-not ($artifacts | Where-Object Extension -eq ".exe")) {
-            throw "No web installer executable was produced."
-          }
-          if (-not ($artifacts | Where-Object Extension -eq ".7z")) {
-            throw "No offline installer payload was produced."
-          }
-          if (-not ($artifacts | Where-Object Name -eq "latest.yml")) {
-            throw "No update manifest was produced."
-          }
-          # Keep margin below GitHub's 2 GiB per-file release limit.
-          $maxAssetBytes = 2100000000
-          $oversized = $artifacts | Where-Object Length -ge $maxAssetBytes
-          if ($oversized) {
-            $names = ($oversized | ForEach-Object { "$($_.Name) ($([math]::Round($_.Length / 1GB, 2)) GiB)" }) -join ", "
-            throw "Release asset exceeds the 2.10 GB safety budget: $names"
-          }
-
-      - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+  promote:
+    name: Reverify and publish the verified draft
+    needs: verify-draft
+    runs-on: windows-latest
+    environment: production-release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          files: |
-            app/release/nsis-web/*.exe
-            app/release/nsis-web/*.7z
-            app/release/nsis-web/*.blockmap
-            app/release/nsis-web/*.yml
+          ref: ${{ inputs.expected_commit }}
+          fetch-depth: 0
+      - name: Re-download and reverify after approval
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view '${{ inputs.tag }}' --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
+          $release = Get-Content release.json -Raw | ConvertFrom-Json
+          if (-not $release.isDraft -or $release.isPrerelease) { throw 'Draft state changed after verification.' }
+          gh release download '${{ inputs.tag }}' --repo '${{ github.repository }}' --dir release-assets
+          & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag '${{ inputs.tag }}' -ExpectedCommit '${{ inputs.expected_commit }}' -ExpectedManifestSha256 '${{ inputs.expected_manifest_sha256 }}' -AllowUnsigned:$${{ inputs.allow_unsigned }}
+      - name: Publish the existing verified draft only
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit '${{ inputs.tag }}' --repo '${{ github.repository }}' --draft=false --prerelease=false --latest

--- a/.gitignore
+++ b/.gitignore
@@ -103,8 +103,8 @@ server_err.log
 app/resources/generated/
 release-assets/
 eve-v*-artifact-manifest.json
-SHA256SUMS.txt
-SHA512SUMS.txt
+/SHA256SUMS.txt
+/SHA512SUMS.txt
 
 # Claude/AI tooling
 .claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,11 @@ dmypy.json
 # Project-specific
 server_out.log
 server_err.log
+app/resources/generated/
+release-assets/
+eve-v*-artifact-manifest.json
+SHA256SUMS.txt
+SHA512SUMS.txt
 
 # Claude/AI tooling
 .claude/settings.local.json

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -15,8 +15,8 @@ production Python dependencies; models download separately on first use. Third-p
 libraries, runtimes, models, and tools remain subject to their respective licenses and
 notices.
 
-This file is not a complete binary-distribution notice inventory. The release workflow
-packages the full runtime closure, whose embedded notices and redistribution terms still
-require a complete, evidence-backed audit. That inventory, together with the separately
-deferred Eve name/mark review, is a Gate 6C publication blocker. Nothing in this notice
-claims legal or trademark clearance.
+The Windows package also ships a closure-derived readable notice inventory, project
+LICENSE/NOTICE material, and the existing Electron/Chromium and managed-Python notices.
+`THIRD_PARTY_NOTICES.md` records the enforcement method and its limits. NVIDIA/CUDA and
+downloaded-model terms require authoritative final-candidate review; nothing here claims
+legal or trademark clearance. The user has accepted the Eve name/mark publication risk.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,21 @@
+# Third-party distribution notice record
+
+This tracked record describes the notice process for Eve Windows binaries. The generated
+`legal/THIRD_PARTY_NOTICES.txt` inside a release candidate is the closure-derived notice
+file for that exact candidate; it is not a legal opinion or trademark clearance.
+
+The generator inventories the production Node closure, Electron/Chromium notices,
+managed Python, packaged Python distributions, and native ASR/CUDA/CTranslate2/ONNX
+components. It fails when a shipped component has neither embedded license material nor
+a reviewed entry in `config/third-party-license-overrides.json`.
+
+`LICENSE`, `NOTICE.md`, this record, Electron's `LICENSE.electron.txt`, Chromium's
+`LICENSES.chromium.html`, and the managed Python license material are shipped as readable
+distribution resources. CUDA redistribution eligibility is reviewed against the applicable
+NVIDIA Attachment A for the final DLL inventory; an SPDX-like metadata label alone is not
+treated as authority.
+
+Models are downloaded separately and are not installer payloads. Final validation records
+the exact model revision and governing terms for `nvidia/nemotron-speech-streaming-en-0.6b`
+and `mobiuslabsgmbh/faster-whisper-large-v3-turbo`. Those terms may change upstream and
+must be authoritatively rechecked before publication.

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,8 @@
     "test:history": "node tests/run-history-insights-check.mjs",
     "preview": "vite preview",
     "package": "bun run build && electron-builder",
-    "package:win": "bun run build && electron-builder --win --publish never",
+    "notices:generate": "powershell -NoProfile -ExecutionPolicy Bypass -File ../scripts/generate-third-party-notices.ps1",
+    "package:win": "bun run notices:generate && bun run build && electron-builder --win --publish never",
     "clear-data": "node scripts/clear-data.js"
   },
   "devDependencies": {
@@ -63,6 +64,13 @@
       "resources/**/*"
     ],
     "extraResources": [
+      {
+        "from": "resources/generated/legal",
+        "to": "legal",
+        "filter": [
+          "**/*"
+        ]
+      },
       {
         "from": "../server",
         "to": "server",

--- a/app/package.json
+++ b/app/package.json
@@ -21,8 +21,8 @@
     "build:renderer": "vite build",
     "test:history": "node tests/run-history-insights-check.mjs",
     "preview": "vite preview",
-    "package": "bun run build && electron-builder",
-    "notices:generate": "powershell -NoProfile -ExecutionPolicy Bypass -File ../scripts/generate-third-party-notices.ps1",
+    "package": "bun run notices:generate && bun run build && electron-builder",
+    "notices:generate": "pwsh -NoProfile -File ../scripts/generate-third-party-notices.ps1",
     "package:win": "bun run notices:generate && bun run build && electron-builder --win --publish never",
     "clear-data": "node scripts/clear-data.js"
   },

--- a/config/third-party-license-overrides.json
+++ b/config/third-party-license-overrides.json
@@ -7,7 +7,7 @@
     "tokenizers": { "license": "Apache-2.0", "source": "https://github.com/huggingface/tokenizers/blob/main/LICENSE" },
     "colorama": { "license": "BSD-3-Clause", "source": "https://github.com/tartley/colorama/blob/0.4.6/LICENSE.txt", "sha256": "cac35c02686e5d04a5a7140bfb3b36e73aed496656e891102e428886d7930318" },
     "Jinja2": { "license": "BSD-3-Clause", "source": "https://github.com/pallets/jinja/blob/3.1.6/LICENSE.txt", "sha256": "3b49dcee4105eb37bac10faf1be260408fe85d252b8e9df2e0979fc1e094437b" },
-    "llvmlite": { "license": "BSD-3-Clause", "source": "https://github.com/numba/llvmlite/blob/v0.46.0/LICENSE", "sha256": "5d0772f4dc4cb16e6bee2419bfa57c0a129808400e341b87fd9f87cbe6a5963d" }
+    "llvmlite": { "license": "BSD-3-Clause", "source": "https://github.com/numba/llvmlite/blob/v0.46.0/LICENSE", "sha256": "7d6aa93e52a7ae9a995ff6a40c0ea5628311cdf1bd8dcd29c8ce9181f4af3a81" }
   },
   "native": {
     "ctranslate2": { "license": "MIT", "source": "https://github.com/OpenNMT/CTranslate2/blob/master/LICENSE" },

--- a/config/third-party-license-overrides.json
+++ b/config/third-party-license-overrides.json
@@ -1,0 +1,18 @@
+{
+  "schema": 1,
+  "overrides": {
+    "is-reference": { "license": "MIT", "source": "https://github.com/rich-harris/estree-walker/blob/master/LICENSE" },
+    "locate-character": { "license": "MIT", "source": "https://github.com/Rich-Harris/locate-character/blob/master/LICENSE" },
+    "sentencepiece": { "license": "Apache-2.0", "source": "https://github.com/google/sentencepiece/blob/master/LICENSE" },
+    "tokenizers": { "license": "Apache-2.0", "source": "https://github.com/huggingface/tokenizers/blob/main/LICENSE" },
+    "colorama": { "license": "BSD-3-Clause", "source": "https://github.com/tartley/colorama/blob/0.4.6/LICENSE.txt", "sha256": "cac35c02686e5d04a5a7140bfb3b36e73aed496656e891102e428886d7930318" },
+    "Jinja2": { "license": "BSD-3-Clause", "source": "https://github.com/pallets/jinja/blob/3.1.6/LICENSE.txt", "sha256": "3b49dcee4105eb37bac10faf1be260408fe85d252b8e9df2e0979fc1e094437b" },
+    "llvmlite": { "license": "BSD-3-Clause", "source": "https://github.com/numba/llvmlite/blob/v0.46.0/LICENSE", "sha256": "5d0772f4dc4cb16e6bee2419bfa57c0a129808400e341b87fd9f87cbe6a5963d" }
+  },
+  "native": {
+    "ctranslate2": { "license": "MIT", "source": "https://github.com/OpenNMT/CTranslate2/blob/master/LICENSE" },
+    "onnx": { "license": "Apache-2.0", "source": "https://github.com/onnx/onnx/blob/main/LICENSE" },
+    "onnxruntime": { "license": "MIT", "source": "https://github.com/microsoft/onnxruntime/blob/main/LICENSE" },
+    "cuda": { "license": "NVIDIA CUDA EULA", "source": "https://docs.nvidia.com/cuda/eula/index.html" }
+  }
+}

--- a/docs/architecture/eve-gate-6-release-plan.md
+++ b/docs/architecture/eve-gate-6-release-plan.md
@@ -1,8 +1,8 @@
 # Eve Gate 6 release plan
 
-- Status: Gate 6A contract parent-reviewed and passed; mechanical implementation in progress
+- Status: Gate 6B accepted; Gate 6C preparation PR authorized
 - Repository: `burntcookiedough/eve-windows-dictation`
-- Canonical base: `0d6605d07aa783036d61fc93af7ce043a808f1a6`
+- Canonical release-candidate base: `f88067ff7bb31ec7f0b5a124fefbeaff0d7829ca`
 - Tracking issue: [#21](https://github.com/burntcookiedough/eve-windows-dictation/issues/21)
 - Proposed release: Eve `v0.7.0`
 - Last updated: 2026-07-28 (Asia/Calcutta)
@@ -59,7 +59,10 @@ installer identity.
 | Do not claim automatic Murmur History import | Frozen | Eve ships a fresh profile. A one-time user-requested local migration was not product behavior. |
 | Do not package in Gate 6A | Frozen | Gate 6B owns the single final exact-head candidate package. |
 | Do not tag while the current publication procedure is unresolved | Frozen | A `v*` tag immediately invokes a workflow that builds and publishes. |
-| Treat unresolved notice or name/mark risk as a Gate 6C blocker | Frozen | Record limitations; do not invent legal conclusions or speculative code changes. |
+| Gate 6B candidate | Passed | Exact candidate hashes and lifecycle evidence outside Git; final machine state Eve v0.7.0 healthy. |
+| Eve name/mark publication risk | Accepted by user | Risk acceptance is not legal clearance and remains explicit in release controls. |
+| Unsigned Windows publication | Accepted by user | Promotion defaults false and requires explicit `allow_unsigned=true`; notes retain SmartScreen warning. |
+| Gate 6C exact-artifact publication | Approved design | Manual draft upload, dispatch verification, protected approval, and no rebuild. |
 
 ## Canonical program state
 

--- a/docs/architecture/eve-gate-6c-prep-evidence.md
+++ b/docs/architecture/eve-gate-6c-prep-evidence.md
@@ -1,0 +1,6 @@
+# Gate 6C preparation evidence
+
+This document is completed by the preparation PR and final-head validation. It records
+the exact commit, notice-inventory digest, test results, draft asset hashes, required
+unsigned and name-risk inputs, environment approval, and post-public download comparison.
+No profile, transcript, audio, settings, cache contents, or application logs belong here.

--- a/docs/architecture/eve-gate-6c-prep-evidence.md
+++ b/docs/architecture/eve-gate-6c-prep-evidence.md
@@ -4,3 +4,13 @@ This document is completed by the preparation PR and final-head validation. It r
 the exact commit, notice-inventory digest, test results, draft asset hashes, required
 unsigned and name-risk inputs, environment approval, and post-public download comparison.
 No profile, transcript, audio, settings, cache contents, or application logs belong here.
+
+| Evidence field | Value |
+|---|---|
+| Final commit/tag | |
+| Notice inventory SHA-256 | |
+| Local/hosted test results | |
+| Draft asset names, bytes, SHA-256, SHA-512 | |
+| Unsigned/name-risk inputs | |
+| Environment approval | |
+| Post-public download comparison | |

--- a/docs/architecture/eve-gate-6c-publication-runbook.md
+++ b/docs/architecture/eve-gate-6c-publication-runbook.md
@@ -1,0 +1,14 @@
+# Gate 6C publication runbook
+
+1. Merge the reviewed preparation PR and freeze its exact commit.
+2. Run the single authorized final-head package and full lifecycle validation; stop on failure.
+3. Generate the seven-asset manifest/checksum set and rehash it independently.
+4. Create the exact annotated tag only after acceptance; tag pushes do not trigger a workflow.
+5. Manually create a draft release and upload exactly the manifest, SHA256/SHA512 sums,
+   third-party notice, wrapper, payload, and `latest.yml`.
+6. Dispatch the verifier with exact tag, commit, manifest hash, `allow_unsigned=true`, and
+   `accepted_name_risk=true`. It downloads and verifies only; it never builds or uploads.
+7. A configured `production-release` environment reviewer approves the promotion job.
+   The job re-downloads and re-verifies, then changes only `draft=false`.
+8. Download public assets and compare hashes. On any mismatch stop: never move the tag or
+   replace assets. Preserve evidence and follow the incident withdrawal procedure.

--- a/docs/architecture/eve-gate-6c-publication-runbook.md
+++ b/docs/architecture/eve-gate-6c-publication-runbook.md
@@ -9,6 +9,7 @@
 6. Dispatch the verifier with exact tag, commit, manifest hash, `allow_unsigned=true`, and
    `accepted_name_risk=true`. It downloads and verifies only; it never builds or uploads.
 7. A configured `production-release` environment reviewer approves the promotion job.
-   The job re-downloads and re-verifies, then changes only `draft=false`.
+   The job re-downloads and re-verifies, then changes `draft=false`, `prerelease=false`,
+   and marks the verified release latest.
 8. Download public assets and compare hashes. On any mismatch stop: never move the tag or
    replace assets. Preserve evidence and follow the incident withdrawal procedure.

--- a/docs/releases/eve-v0.7.0-release-notes.md
+++ b/docs/releases/eve-v0.7.0-release-notes.md
@@ -29,7 +29,8 @@ Status: prepared release notes; Eve v0.7.0 has not been published.
 ## Before publication
 
 These notes describe the accepted source preparation, not an available download. A fresh
-exact-head package and Windows lifecycle, complete third-party notice readiness, an
-explicit Eve name/mark publication decision, and an approved tag/publication procedure
-are still required. The Windows release remains unsigned unless a separately approved
-signing decision changes that status.
+exact-head package and Windows lifecycle, complete third-party notice readiness, and the
+approved draft-release procedure are still required. The user accepted the Eve name/mark
+publication risk; this is not legal clearance. The planned Windows release is unsigned:
+Windows may show an Unknown Publisher warning and Microsoft Defender SmartScreen may
+require an explicit user decision before installation.

--- a/scripts/generate-third-party-notices.ps1
+++ b/scripts/generate-third-party-notices.ps1
@@ -59,7 +59,9 @@ while($pending.Count -gt 0) {
   Add-Component $data.name ([string]$data.version) 'node' ($pkgPath.Substring($RepositoryRoot.Length+1)) $license $source
   foreach($groupName in @('dependencies','optionalDependencies')){$groupProperty=$data.PSObject.Properties[$groupName];if($null -ne $groupProperty){foreach($property in $groupProperty.Value.PSObject.Properties){$pending.Enqueue($property.Name)}}}
 }
-foreach($dist in Get-ChildItem (Join-Path $server '.venv\Lib\site-packages') -Directory -Filter '*.dist-info' -ErrorAction SilentlyContinue) {
+$sitePackages=Join-Path $server '.venv\Lib\site-packages'
+if(!(Test-Path -LiteralPath $sitePackages)){throw "Managed Python site-packages is missing: $sitePackages"}
+foreach($dist in Get-ChildItem -LiteralPath $sitePackages -Directory -Filter '*.dist-info') {
   $meta=Join-Path $dist.FullName 'METADATA'; $name=$dist.Name; $version='unknown'; $license=''; if(Test-Path $meta){$m=Get-Content $meta -Raw; if($m -match '(?m)^Name: (.+)$'){$name=$Matches[1].Trim()}; if($m -match '(?m)^Version: (.+)$'){$version=$Matches[1].Trim()}; if($m -match '(?m)^License-Expression: (.+)$'){$license=$Matches[1].Trim()}elseif($m -match '(?m)^License: (.+)$'){$license=$Matches[1].Trim()}}
   if($name -eq 'murmur-testui'){continue} # validation-only test fixture; not copied by the packaged server filter
   $license=Normalize-License $license; $licenseFile=Get-ChildItem $dist.FullName -Recurse -File | Where-Object {$_.Name -like 'LICENSE*' -or $_.Name -like 'COPYING*' -or $_.Name -like 'NOTICE*'} | Select-Object -First 1; $override=$overrideLookup[[string]$name.Trim().ToLowerInvariant()]

--- a/scripts/generate-third-party-notices.ps1
+++ b/scripts/generate-third-party-notices.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+    [string]$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$app = Join-Path $RepositoryRoot 'app'
+$server = Join-Path $RepositoryRoot 'server'
+$output = Join-Path $app 'resources\generated\legal'
+$overrides = Get-Content (Join-Path $RepositoryRoot 'config\third-party-license-overrides.json') -Raw | ConvertFrom-Json
+$overrideLookup=@{}
+foreach($property in $overrides.overrides.PSObject.Properties){$overrideLookup[$property.Name.Trim().ToLowerInvariant()]=$property.Value}
+New-Item -ItemType Directory -Force -Path $output | Out-Null
+$items = [System.Collections.Generic.List[object]]::new()
+function Add-Component([string]$Name,[string]$Version,[string]$Kind,[string]$Path,[string]$License,[string]$Source) {
+  if ([string]::IsNullOrWhiteSpace($License) -or [string]::IsNullOrWhiteSpace($Source)) { throw "Unclassified shipped component: $Name" }
+  $items.Add([ordered]@{name=$Name;version=$Version;kind=$Kind;path=$Path;license=$License;source=$Source})
+}
+function Normalize-License([string]$Value) { if($null -eq $Value){return ''};$normalized=$Value.Trim();if($normalized -match '^(?i:unknown|none|n/?a)$'){return ''};return $normalized }
+foreach($required in @('LICENSE','NOTICE.md','THIRD_PARTY_NOTICES.md')) { if(!(Test-Path (Join-Path $RepositoryRoot $required))){ throw "Missing project notice input: $required" } }
+function Resolve-NodePackage([string]$Name,[string]$FromDirectory) {
+  $cursor=$FromDirectory
+  while($true) {
+    $candidate=Join-Path $cursor (Join-Path 'node_modules' (Join-Path $Name 'package.json'))
+    if(Test-Path -LiteralPath $candidate){return (Resolve-Path $candidate).Path}
+    $parent=Split-Path $cursor -Parent
+    if($parent -eq $cursor){return $null}; $cursor=$parent
+  }
+}
+$rootPackage=Get-Content (Join-Path $app 'package.json') -Raw | ConvertFrom-Json
+$pending=[System.Collections.Generic.Queue[string]]::new()
+foreach($property in $rootPackage.dependencies.PSObject.Properties){$pending.Enqueue($property.Name)}
+$visited=[System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+while($pending.Count -gt 0) {
+  $requested=$pending.Dequeue(); $pkgPath=Resolve-NodePackage $requested $app
+  if($null -eq $pkgPath){throw "Production Node dependency could not be resolved: $requested"}
+  if(-not $visited.Add($pkgPath)){continue}
+  $data=Get-Content $pkgPath -Raw|ConvertFrom-Json; if(!$data.name){throw "Node package lacks a name: $pkgPath"}
+  $dir=Split-Path $pkgPath -Parent; $licenseFile=Get-ChildItem $dir -File|Where-Object {$_.Name -like 'LICENSE*' -or $_.Name -like 'COPYING*' -or $_.Name -like 'NOTICE*'}|Select-Object -First 1
+  $override=$overrideLookup[[string]$data.name.Trim().ToLowerInvariant()]
+  $license=Normalize-License ([string]$data.license); if(!$license -and $override){$license=Normalize-License ([string]$override.license)}; $source=if($licenseFile){$licenseFile.FullName}elseif($override){[string]$override.source}elseif($license){"package metadata: $pkgPath"}else{''}
+  Add-Component $data.name ([string]$data.version) 'node' ($pkgPath.Substring($RepositoryRoot.Length+1)) $license $source
+  foreach($groupName in @('dependencies','optionalDependencies')){$groupProperty=$data.PSObject.Properties[$groupName];if($null -ne $groupProperty){foreach($property in $groupProperty.Value.PSObject.Properties){$pending.Enqueue($property.Name)}}}
+}
+foreach($dist in Get-ChildItem (Join-Path $server '.venv\Lib\site-packages') -Directory -Filter '*.dist-info' -ErrorAction SilentlyContinue) {
+  $meta=Join-Path $dist.FullName 'METADATA'; $name=$dist.Name; $version='unknown'; $license=''; if(Test-Path $meta){$m=Get-Content $meta -Raw; if($m -match '(?m)^Name: (.+)$'){$name=$Matches[1].Trim()}; if($m -match '(?m)^Version: (.+)$'){$version=$Matches[1].Trim()}; if($m -match '(?m)^License-Expression: (.+)$'){$license=$Matches[1].Trim()}elseif($m -match '(?m)^License: (.+)$'){$license=$Matches[1].Trim()}}
+  $license=Normalize-License $license; $licenseFile=Get-ChildItem $dist.FullName -Recurse -File | Where-Object {$_.Name -like 'LICENSE*' -or $_.Name -like 'COPYING*' -or $_.Name -like 'NOTICE*'} | Select-Object -First 1; $override=$overrideLookup[[string]$name.Trim().ToLowerInvariant()]
+  if(!$license -and $licenseFile){$licenseText=Get-Content $licenseFile.FullName -Raw;$isBsd3=($licenseText -match '(?is)redistributions of source code.*retain') -and ($licenseText -match '(?is)redistributions in binary form.*reproduce') -and ($licenseText -match '(?is)neither the name.*endorse or promote') -and ($licenseText -match '(?is)this software is provided.*as is');if($licenseText -match '(?i)the mit license|permission is hereby granted, free of charge'){ $license='MIT' }elseif($licenseText -match '(?i)apache license.{0,40}2\.0'){ $license='Apache-2.0' }elseif($licenseText -match '(?i)bsd' -or $isBsd3){ $license='BSD-3-Clause' }}
+  if($name -eq 'murmur'){$license='MIT';$source=(Join-Path $RepositoryRoot 'LICENSE')} elseif(!$license -and $override){$license=[string]$override.license}; $source=if($source){$source}elseif($licenseFile){$licenseFile.FullName}elseif($override){[string]$override.source}elseif($license){"METADATA: $meta"}else{''}
+  Add-Component $name $version 'python' ($dist.FullName.Substring($RepositoryRoot.Length+1)) $license $source
+}
+foreach($name in @('LICENSE.electron.txt','LICENSES.chromium.html')) { Add-Component $name '' 'electron' $name 'embedded' $name }
+foreach($native in $overrides.native.psobject.Properties){ Add-Component $native.Name '' 'native' 'packaged runtime (verified post-package)' ([string]$native.Value.license) ([string]$native.Value.source) }
+$items = @($items | Sort-Object kind,name,version)
+$items | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $output 'THIRD_PARTY_INVENTORY.json') -Encoding utf8
+$text = "Eve third-party notices`r`nGenerated from the exact pre-package closure; verify post-package before release.`r`n`r`n" + (($items | ForEach-Object { "$($_.kind): $($_.name) $($_.version) | $($_.license) | $($_.source)" }) -join "`r`n")
+$text | Set-Content (Join-Path $output 'THIRD_PARTY_NOTICES.txt') -Encoding utf8
+Copy-Item (Join-Path $RepositoryRoot 'LICENSE') (Join-Path $output 'LICENSE.txt') -Force
+Copy-Item (Join-Path $RepositoryRoot 'NOTICE.md') (Join-Path $output 'NOTICE.txt') -Force
+Copy-Item (Join-Path $RepositoryRoot 'THIRD_PARTY_NOTICES.md') (Join-Path $output 'THIRD_PARTY_NOTICES_SOURCE.md') -Force

--- a/scripts/generate-third-party-notices.ps1
+++ b/scripts/generate-third-party-notices.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    [string]$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path,
+    [string]$PackagedServerRoot
 )
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -17,6 +18,21 @@ function Add-Component([string]$Name,[string]$Version,[string]$Kind,[string]$Pat
   $items.Add([ordered]@{name=$Name;version=$Version;kind=$Kind;path=$Path;license=$License;source=$Source})
 }
 function Normalize-License([string]$Value) { if($null -eq $Value){return ''};$normalized=$Value.Trim();if($normalized -match '^(?i:unknown|none|n/?a)$'){return ''};return $normalized }
+function Get-StableSource([string]$Path) {
+  if([string]::IsNullOrWhiteSpace($Path)){return ''}
+  $full=[IO.Path]::GetFullPath($Path)
+  $root=[IO.Path]::GetFullPath($RepositoryRoot).TrimEnd([IO.Path]::DirectorySeparatorChar)+[IO.Path]::DirectorySeparatorChar
+  if(!$full.StartsWith($root,[StringComparison]::OrdinalIgnoreCase)){throw "Notice source is outside the repository closure: $full"}
+  return $full.Substring($root.Length).Replace('\\','/')
+}
+function Assert-OverrideHash($Override,$LicenseFile,[string]$Name) {
+  if($null -eq $Override -or !$Override.PSObject.Properties['sha256']){return}
+  $expected=([string]$Override.sha256).Trim().ToLowerInvariant()
+  if($expected -notmatch '^[0-9a-f]{64}$'){throw "Reviewed override has malformed SHA-256: $Name"}
+  if($null -eq $LicenseFile){return}
+  $actual=(Get-FileHash -LiteralPath $LicenseFile.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+  if($actual -ne $expected){throw "Reviewed override SHA-256 mismatch: $Name"}
+}
 foreach($required in @('LICENSE','NOTICE.md','THIRD_PARTY_NOTICES.md')) { if(!(Test-Path (Join-Path $RepositoryRoot $required))){ throw "Missing project notice input: $required" } }
 function Resolve-NodePackage([string]$Name,[string]$FromDirectory) {
   $cursor=$FromDirectory
@@ -38,18 +54,28 @@ while($pending.Count -gt 0) {
   $data=Get-Content $pkgPath -Raw|ConvertFrom-Json; if(!$data.name){throw "Node package lacks a name: $pkgPath"}
   $dir=Split-Path $pkgPath -Parent; $licenseFile=Get-ChildItem $dir -File|Where-Object {$_.Name -like 'LICENSE*' -or $_.Name -like 'COPYING*' -or $_.Name -like 'NOTICE*'}|Select-Object -First 1
   $override=$overrideLookup[[string]$data.name.Trim().ToLowerInvariant()]
-  $license=Normalize-License ([string]$data.license); if(!$license -and $override){$license=Normalize-License ([string]$override.license)}; $source=if($licenseFile){$licenseFile.FullName}elseif($override){[string]$override.source}elseif($license){"package metadata: $pkgPath"}else{''}
+  Assert-OverrideHash $override $licenseFile ([string]$data.name)
+  $license=Normalize-License ([string]$data.license); if(!$license -and $override){$license=Normalize-License ([string]$override.license)}; $source=if($licenseFile){Get-StableSource $licenseFile.FullName}elseif($override){[string]$override.source}elseif($license){"package metadata: $(Get-StableSource $pkgPath)"}else{''}
   Add-Component $data.name ([string]$data.version) 'node' ($pkgPath.Substring($RepositoryRoot.Length+1)) $license $source
   foreach($groupName in @('dependencies','optionalDependencies')){$groupProperty=$data.PSObject.Properties[$groupName];if($null -ne $groupProperty){foreach($property in $groupProperty.Value.PSObject.Properties){$pending.Enqueue($property.Name)}}}
 }
 foreach($dist in Get-ChildItem (Join-Path $server '.venv\Lib\site-packages') -Directory -Filter '*.dist-info' -ErrorAction SilentlyContinue) {
   $meta=Join-Path $dist.FullName 'METADATA'; $name=$dist.Name; $version='unknown'; $license=''; if(Test-Path $meta){$m=Get-Content $meta -Raw; if($m -match '(?m)^Name: (.+)$'){$name=$Matches[1].Trim()}; if($m -match '(?m)^Version: (.+)$'){$version=$Matches[1].Trim()}; if($m -match '(?m)^License-Expression: (.+)$'){$license=$Matches[1].Trim()}elseif($m -match '(?m)^License: (.+)$'){$license=$Matches[1].Trim()}}
+  if($name -eq 'murmur-testui'){continue} # validation-only test fixture; not copied by the packaged server filter
   $license=Normalize-License $license; $licenseFile=Get-ChildItem $dist.FullName -Recurse -File | Where-Object {$_.Name -like 'LICENSE*' -or $_.Name -like 'COPYING*' -or $_.Name -like 'NOTICE*'} | Select-Object -First 1; $override=$overrideLookup[[string]$name.Trim().ToLowerInvariant()]
   if(!$license -and $licenseFile){$licenseText=Get-Content $licenseFile.FullName -Raw;$isBsd3=($licenseText -match '(?is)redistributions of source code.*retain') -and ($licenseText -match '(?is)redistributions in binary form.*reproduce') -and ($licenseText -match '(?is)neither the name.*endorse or promote') -and ($licenseText -match '(?is)this software is provided.*as is');if($licenseText -match '(?i)the mit license|permission is hereby granted, free of charge'){ $license='MIT' }elseif($licenseText -match '(?i)apache license.{0,40}2\.0'){ $license='Apache-2.0' }elseif($licenseText -match '(?i)bsd' -or $isBsd3){ $license='BSD-3-Clause' }}
-  if($name -eq 'murmur'){$license='MIT';$source=(Join-Path $RepositoryRoot 'LICENSE')} elseif(!$license -and $override){$license=[string]$override.license}; $source=if($source){$source}elseif($licenseFile){$licenseFile.FullName}elseif($override){[string]$override.source}elseif($license){"METADATA: $meta"}else{''}
+  Assert-OverrideHash $override $licenseFile $name
+  if($name -eq 'murmur'){$license='MIT';$source='LICENSE'} elseif(!$license -and $override){$license=[string]$override.license}; $source=if($source){$source}elseif($licenseFile){Get-StableSource $licenseFile.FullName}elseif($override){[string]$override.source}elseif($license){"METADATA: $(Get-StableSource $meta)"}else{''}
   Add-Component $name $version 'python' ($dist.FullName.Substring($RepositoryRoot.Length+1)) $license $source
 }
 foreach($name in @('LICENSE.electron.txt','LICENSES.chromium.html')) { Add-Component $name '' 'electron' $name 'embedded' $name }
+if($PackagedServerRoot){
+  $packed=(Resolve-Path -LiteralPath $PackagedServerRoot).Path
+  $dlls=@(Get-ChildItem -LiteralPath $packed -Recurse -File -Filter '*.dll' | ForEach-Object Name)
+  if(!$dlls.Count){throw 'Packaged native DLL inventory is empty.'}
+  $nativePatterns=@{ctranslate2='(?i)ctranslate2';onnxruntime='(?i)onnxruntime';cuda='(?i)(cuda|cudart|cublas|cudnn)'}
+  foreach($nativeName in $overrides.native.psobject.Properties.Name){if(!$nativePatterns.ContainsKey($nativeName)){throw "Native notice has no DLL inventory rule: $nativeName"};if(-not ($dlls -match $nativePatterns[$nativeName])){throw "Configured native notice absent from packaged DLL inventory: $nativeName"}}
+}
 foreach($native in $overrides.native.psobject.Properties){ Add-Component $native.Name '' 'native' 'packaged runtime (verified post-package)' ([string]$native.Value.license) ([string]$native.Value.source) }
 $items = @($items | Sort-Object kind,name,version)
 $items | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $output 'THIRD_PARTY_INVENTORY.json') -Encoding utf8

--- a/scripts/release-artifacts.ps1
+++ b/scripts/release-artifacts.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param(
+  [ValidateSet('Create','Verify')][string]$Mode = 'Verify',
+  [Parameter(Mandatory=$true)][string]$ArtifactDir,
+  [string]$ExpectedTag,
+  [string]$ExpectedCommit,
+  [string]$ExpectedManifestSha256,
+  [switch]$AllowUnsigned
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$dir=(Resolve-Path $ArtifactDir).Path
+$version=if($ExpectedTag){$ExpectedTag.TrimStart('v')}else{throw 'ExpectedTag is required.'}
+$names=@("Eve.Web.Setup.$version.exe","murmur-$version-x64.nsis.7z",'latest.yml',"eve-v$version-artifact-manifest.json",'SHA256SUMS.txt','SHA512SUMS.txt','THIRD_PARTY_NOTICES.txt')
+$files=Get-ChildItem $dir -File
+$actual=@($files.Name | Sort-Object); $expected=@($names | Sort-Object)
+if((Compare-Object $actual $expected)){throw "Release asset allowlist mismatch. Expected exactly: $($names -join ', ')"}
+foreach($file in $files){if($file.Length -ge 2100000000){throw "Asset exceeds 2.10 GB safety ceiling: $($file.Name)"}}
+$manifest=Join-Path $dir "eve-v$version-artifact-manifest.json"
+if($Mode -eq 'Create'){
+  $entries=@(); foreach($name in $names | Where-Object {$_ -ne (Split-Path $manifest -Leaf)}){$f=Get-Item (Join-Path $dir $name);$entries += [ordered]@{name=$f.Name;bytes=$f.Length;sha256=(Get-FileHash $f -Algorithm SHA256).Hash.ToLowerInvariant();sha512=(Get-FileHash $f -Algorithm SHA512).Hash.ToLowerInvariant()}}
+  [ordered]@{schema=1;tag=$ExpectedTag;commit=$ExpectedCommit;version=$version;assets=$entries}|ConvertTo-Json -Depth 5|Set-Content $manifest -Encoding utf8
+  return
+}
+if(!(Test-Path $manifest)){throw 'Manifest is missing.'}
+if((Get-FileHash $manifest -Algorithm SHA256).Hash -ne $ExpectedManifestSha256.ToUpperInvariant()){throw 'Manifest SHA-256 mismatch.'}
+$data=Get-Content $manifest -Raw|ConvertFrom-Json
+if($data.tag -ne $ExpectedTag -or $data.commit -ne $ExpectedCommit -or $data.version -ne $version){throw 'Manifest tag, commit, or version mismatch.'}
+foreach($entry in $data.assets){$f=Get-Item (Join-Path $dir $entry.name);if($f.Length -ne $entry.bytes -or (Get-FileHash $f -Algorithm SHA256).Hash.ToLowerInvariant() -ne $entry.sha256 -or (Get-FileHash $f -Algorithm SHA512).Hash.ToLowerInvariant() -ne $entry.sha512){throw "Hash or byte mismatch: $($entry.name)"}}
+$wrapper=Join-Path $dir "Eve.Web.Setup.$version.exe"; $signature=Get-AuthenticodeSignature $wrapper
+if($AllowUnsigned){if($signature.Status -ne 'NotSigned'){throw "Expected intentionally unsigned wrapper, got $($signature.Status)."}}elseif($signature.Status -ne 'Valid'){throw "Authenticode must be Valid when allow_unsigned=false; got $($signature.Status)."}
+$latest=Get-Content (Join-Path $dir 'latest.yml') -Raw
+if($latest -notmatch [regex]::Escape("Eve.Web.Setup.$version.exe") -or $latest -notmatch [regex]::Escape("murmur-$version-x64.nsis.7z")){throw 'latest.yml does not bind the expected updater assets.'}
+if(!(Select-String -LiteralPath (Join-Path $dir 'THIRD_PARTY_NOTICES.txt') -Pattern 'Generated from the exact pre-package closure' -Quiet)){throw 'Third-party notice asset is not the generated notice.'}

--- a/scripts/release-artifacts.ps1
+++ b/scripts/release-artifacts.ps1
@@ -10,7 +10,10 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $dir=(Resolve-Path $ArtifactDir).Path
-$version=if($ExpectedTag){$ExpectedTag.TrimStart('v')}else{throw 'ExpectedTag is required.'}
+if($ExpectedTag -notmatch '^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$'){throw 'ExpectedTag must be an exact v-prefixed semantic version.'}
+$version=$Matches[1]
+if($ExpectedCommit -notmatch '^[0-9a-f]{40}$'){throw 'ExpectedCommit must be a lowercase 40-character SHA.'}
+if($Mode -eq 'Verify' -and $ExpectedManifestSha256 -notmatch '^[0-9a-fA-F]{64}$'){throw 'ExpectedManifestSha256 must be 64 hex characters.'}
 $names=@("Eve.Web.Setup.$version.exe","murmur-$version-x64.nsis.7z",'latest.yml',"eve-v$version-artifact-manifest.json",'SHA256SUMS.txt','SHA512SUMS.txt','THIRD_PARTY_NOTICES.txt')
 $files=Get-ChildItem $dir -File
 $actual=@($files.Name | Sort-Object); $expected=@($names | Sort-Object)
@@ -25,10 +28,27 @@ if($Mode -eq 'Create'){
 if(!(Test-Path $manifest)){throw 'Manifest is missing.'}
 if((Get-FileHash $manifest -Algorithm SHA256).Hash -ne $ExpectedManifestSha256.ToUpperInvariant()){throw 'Manifest SHA-256 mismatch.'}
 $data=Get-Content $manifest -Raw|ConvertFrom-Json
-if($data.tag -ne $ExpectedTag -or $data.commit -ne $ExpectedCommit -or $data.version -ne $version){throw 'Manifest tag, commit, or version mismatch.'}
-foreach($entry in $data.assets){$f=Get-Item (Join-Path $dir $entry.name);if($f.Length -ne $entry.bytes -or (Get-FileHash $f -Algorithm SHA256).Hash.ToLowerInvariant() -ne $entry.sha256 -or (Get-FileHash $f -Algorithm SHA512).Hash.ToLowerInvariant() -ne $entry.sha512){throw "Hash or byte mismatch: $($entry.name)"}}
+if($data.schema -ne 1 -or $data.tag -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $data.commit -notmatch '^[0-9a-f]{40}$' -or $data.version -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $data.tag -ne $ExpectedTag -or $data.commit -ne $ExpectedCommit -or $data.version -ne $version){throw 'Manifest schema, format, tag, commit, or version mismatch.'}
+$manifestNames=[System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+foreach($entry in $data.assets){if(!$manifestNames.Add([string]$entry.name) -or $entry.name -notin $names -or $entry.name -eq (Split-Path $manifest -Leaf) -or [string]$entry.sha256 -notmatch '^[0-9a-f]{64}$' -or [string]$entry.sha512 -notmatch '^[0-9a-f]{128}$' -or [int64]$entry.bytes -lt 0){throw 'Manifest asset entry is malformed.'};$f=Get-Item (Join-Path $dir $entry.name);if($f.Length -ne $entry.bytes -or (Get-FileHash $f -Algorithm SHA256).Hash.ToLowerInvariant() -ne $entry.sha256 -or (Get-FileHash $f -Algorithm SHA512).Hash.ToLowerInvariant() -ne $entry.sha512){throw "Hash or byte mismatch: $($entry.name)"}}
+if($manifestNames.Count -ne ($names.Count-1)){throw 'Manifest asset count mismatch.'}
+foreach($algorithm in @('SHA256','SHA512')){foreach($line in Get-Content (Join-Path $dir "$algorithm`SUMS.txt")){if($line -notmatch '^([0-9a-fA-F]+) \*?(.+)$'){throw "Malformed $algorithm checksum line."};$entry=$data.assets|Where-Object name -eq $Matches[2];if(!$entry -or $Matches[1].ToLowerInvariant() -ne [string]$entry.("sha$($algorithm.Substring(3))")){throw "$algorithm checksum does not match manifest."}}}
 $wrapper=Join-Path $dir "Eve.Web.Setup.$version.exe"; $signature=Get-AuthenticodeSignature $wrapper
 if($AllowUnsigned){if($signature.Status -ne 'NotSigned'){throw "Expected intentionally unsigned wrapper, got $($signature.Status)."}}elseif($signature.Status -ne 'Valid'){throw "Authenticode must be Valid when allow_unsigned=false; got $($signature.Status)."}
 $latest=Get-Content (Join-Path $dir 'latest.yml') -Raw
-if($latest -notmatch [regex]::Escape("Eve.Web.Setup.$version.exe") -or $latest -notmatch [regex]::Escape("murmur-$version-x64.nsis.7z")){throw 'latest.yml does not bind the expected updater assets.'}
+$top=@{};$file=@{};$package=@{};$state='top'
+foreach($line in ($latest -split "`r?`n")){
+  if($line -eq ''){continue}
+  if($line -match '^files:$'){if($state -ne 'top' -or $top.Contains('files')){throw 'Malformed or duplicate latest.yml files section.'};$top.files=$true;$state='files';continue}
+  if($line -match '^  - url: ([^\s]+)$'){if($state -ne 'files' -or $file.Count){throw 'Malformed or duplicate latest.yml file entry.'};$file.url=$Matches[1];continue}
+  if($line -match '^    (sha512|size): ([^\s]+)$'){if($state -ne 'files' -or !$file.Contains('url') -or $file.Contains($Matches[1])){throw 'Malformed or duplicate latest.yml file property.'};$file[$Matches[1]]=$Matches[2];continue}
+  if($line -match '^packages:$'){if($state -ne 'top' -or $top.Contains('packages')){throw 'Malformed or duplicate latest.yml packages section.'};$top.packages=$true;$state='packages';continue}
+  if($line -match '^  x64:$'){if($state -ne 'packages' -or $package.Count){throw 'Malformed or duplicate latest.yml x64 package.'};$package.present=$true;$state='package';continue}
+  if($line -match '^    (size|sha512|blockMapSize|path|file): ([^\s]+)$'){if($state -ne 'package' -or $package.Contains($Matches[1])){throw 'Malformed or duplicate latest.yml package property.'};$package[$Matches[1]]=$Matches[2];continue}
+  if($line -match '^(version|path|sha512|releaseDate): (.+)$'){if($state -eq 'files' -and !$file.Contains('sha512')){throw 'Incomplete latest.yml file entry.'};if($state -eq 'package' -and (!$package.Contains('size') -or !$package.Contains('sha512') -or !$package.Contains('path') -or !$package.Contains('file'))){throw 'Incomplete latest.yml package entry.'};$state='top';if($top.Contains($Matches[1])){throw 'Duplicate latest.yml field.'};$top[$Matches[1]]=$Matches[2].Trim("'");continue}
+  throw "Unknown or malformed latest.yml line: $line"
+}
+if(!$top.Contains('version') -or !$top.Contains('path') -or !$top.Contains('sha512') -or !$top.Contains('releaseDate') -or !$file.Contains('url') -or !$file.Contains('sha512') -or !$package.Contains('size') -or !$package.Contains('sha512') -or !$package.Contains('path') -or !$package.Contains('file')){throw 'Missing required latest.yml fields.'}
+if($top.version -ne $version -or $top.path -ne "Eve.Web.Setup.$version.exe" -or $file.url -ne $top.path -or $package.path -ne "murmur-$version-x64.nsis.7z" -or $package.file -ne $package.path -or $package.size -notmatch '^\d+$' -or ($file.Contains('size') -and $file.size -notmatch '^\d+$')){throw 'latest.yml identity or numeric fields mismatch.'}
+foreach($pair in @(@($top.path,$top.sha512,$null),@($file.url,$file.sha512,$file.Contains('size') ? $file.size : $null),@($package.path,$package.sha512,$package.size))){$manifestEntry=$data.assets|Where-Object name -eq $pair[0];if(!$manifestEntry){throw 'latest.yml asset missing from manifest.'};$expectedBase64=[Convert]::ToBase64String([Convert]::FromHexString([string]$manifestEntry.sha512));if($pair[1] -ne $expectedBase64 -or ($null -ne $pair[2] -and [int64]$pair[2] -ne [int64]$manifestEntry.bytes)){throw 'latest.yml hash or size mismatch.'}}
 if(!(Select-String -LiteralPath (Join-Path $dir 'THIRD_PARTY_NOTICES.txt') -Pattern 'Generated from the exact pre-package closure' -Quiet)){throw 'Third-party notice asset is not the generated notice.'}

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -110,12 +110,16 @@ Remove-Item -LiteralPath $outLog,$errLog,$pidFile -ErrorAction SilentlyContinue
 
 $oldEnv = @{
     MURMUR_PID_FILE = $env:MURMUR_PID_FILE
+    MURMUR_SETTINGS_FILE = $env:MURMUR_SETTINGS_FILE
     MURMUR_PORT = $env:MURMUR_PORT
     MURMUR_ENGINE = $env:MURMUR_ENGINE
     MURMUR_ENGINE_PREFERENCE_MODE = $env:MURMUR_ENGINE_PREFERENCE_MODE
     MURMUR_WHISPER_MODEL = $env:MURMUR_WHISPER_MODEL
     MURMUR_WHISPER_DEVICE = $env:MURMUR_WHISPER_DEVICE
+    MURMUR_WHISPER_COMPUTE_TYPE = $env:MURMUR_WHISPER_COMPUTE_TYPE
     MURMUR_LOG_LEVEL = $env:MURMUR_LOG_LEVEL
+    PYTHONNOUSERSITE = $env:PYTHONNOUSERSITE
+    PYTHONPATH = $env:PYTHONPATH
 }
 
 $env:MURMUR_PID_FILE = $pidFile
@@ -129,6 +133,7 @@ $env:MURMUR_WHISPER_COMPUTE_TYPE = "int8"
 $env:MURMUR_LOG_LEVEL = "INFO"
 $env:PYTHONNOUSERSITE = "1"
 $env:PYTHONPATH = Join-Path $serverRoot ".venv\Lib\site-packages"
+Invoke-Native $pythonExe -c "import faster_whisper, torch, nemo.collections.asr"
 
 $process = Start-Process -FilePath $pythonExe `
     -ArgumentList @("src\main.py") `
@@ -150,7 +155,8 @@ try {
         $process.WaitForExit(5000) | Out-Null
     }
     foreach ($key in $oldEnv.Keys) {
-        Set-Item -Path "env:$key" -Value $oldEnv[$key] -ErrorAction SilentlyContinue
+        if ($null -eq $oldEnv[$key]) { Remove-Item -Path "env:$key" -ErrorAction SilentlyContinue }
+        else { Set-Item -Path "env:$key" -Value $oldEnv[$key] -ErrorAction Stop }
     }
 }
 

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -95,7 +95,7 @@ Assert-Contains -Value (Get-Content -LiteralPath $latestYml -Raw) -Expected $Exp
 Write-Step "Checking installed payload contents"
 $appExe = Join-Path $InstallDir "Eve.exe"
 $serverRoot = Join-Path $InstallDir "resources\server"
-$pythonExe = Join-Path $serverRoot ".venv\Scripts\python.exe"
+$pythonExe = Join-Path $serverRoot ".runtime\python.exe"
 Assert-Path $appExe "Installed Eve.exe"
 Assert-Path $pythonExe "Bundled Python"
 Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\faster_whisper") "faster-whisper package"
@@ -119,12 +119,16 @@ $oldEnv = @{
 }
 
 $env:MURMUR_PID_FILE = $pidFile
+$env:MURMUR_SETTINGS_FILE = Join-Path (Split-Path $InstallDir -Parent) "release-verify-server-settings.json"
 $env:MURMUR_PORT = [string]$HealthPort
 $env:MURMUR_ENGINE = "whisper"
 $env:MURMUR_ENGINE_PREFERENCE_MODE = "manual"
 $env:MURMUR_WHISPER_MODEL = "tiny"
 $env:MURMUR_WHISPER_DEVICE = "cpu"
+$env:MURMUR_WHISPER_COMPUTE_TYPE = "int8"
 $env:MURMUR_LOG_LEVEL = "INFO"
+$env:PYTHONNOUSERSITE = "1"
+$env:PYTHONPATH = Join-Path $serverRoot ".venv\Lib\site-packages"
 
 $process = Start-Process -FilePath $pythonExe `
     -ArgumentList @("src\main.py") `

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -15,7 +15,10 @@ def test_release_workflow_is_manual_and_never_builds_or_uploads() -> None:
     assert "production-release" in workflow
     assert "allow_unsigned" in workflow
     assert "accepted_name_risk" in workflow
-    assert "default: false" in workflow
+    allow_block = workflow.split("allow_unsigned:", 1)[1].split("accepted_name_risk:", 1)[0]
+    name_block = workflow.split("accepted_name_risk:", 1)[1].split("permissions:", 1)[0]
+    assert "default: false" in allow_block
+    assert "default: false" in name_block
     assert "draft=false" in workflow
 
 
@@ -26,6 +29,12 @@ def test_release_asset_contract_and_notice_generator_are_tracked() -> None:
         assert name in artifacts
     assert "2100000000" in artifacts
     assert "NotSigned" in artifacts
+    assert "Authenticode must be Valid when allow_unsigned=false" in artifacts
+    assert "Manifest schema, format, tag, commit, or version mismatch." in artifacts
+    assert 'checksum does not match manifest.' in artifacts
+    assert "Missing required latest.yml fields." in artifacts
+    assert "Unknown or malformed latest.yml line" in artifacts
+    assert "latest.yml hash or size mismatch." in artifacts
     assert "Unclassified shipped component" in notices
     assert "THIRD_PARTY_INVENTORY.json" in notices
     assert "Get-ChildItem $dist.FullName -Recurse -File" in notices
@@ -35,3 +44,28 @@ def test_release_asset_contract_and_notice_generator_are_tracked() -> None:
     assert "unknown|none|n/?a" in notices
     assert "$isBsd3" in notices
     assert "neither the name.*endorse or promote" in notices
+    assert "Reviewed override SHA-256 mismatch" in notices
+    assert "Get-StableSource" in notices
+    assert "Packaged native DLL inventory is empty." in notices
+    assert "Configured native notice absent from packaged DLL inventory" in notices
+
+
+def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None:
+    workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    assert "persist-credentials: false" in workflow
+    assert "targetCommitish -ne $env:EXPECTED_COMMIT" in workflow
+    assert "EXPECTED_MANIFEST_SHA256" in workflow
+    assert "-AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')" in workflow
+    assert "gh release edit $env:TAG" in workflow
+    assert "gh release upload" not in workflow
+    assert "gh release create" not in workflow
+
+
+def test_packaged_resource_and_runtime_harness_guards() -> None:
+    package = (ROOT / "app/package.json").read_text(encoding="utf-8")
+    verify = (ROOT / "scripts/release-verify.ps1").read_text(encoding="utf-8")
+    assert '"package": "bun run notices:generate && bun run build && electron-builder"' in package
+    assert '"to": "legal"' in package
+    assert ".runtime\\python.exe" in verify
+    assert "import faster_whisper, torch, nemo.collections.asr" in verify
+    assert 'Remove-Item -Path "env:$key"' in verify

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -1,0 +1,37 @@
+"""Static guards for the no-rebuild Gate 6C release promotion path."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_release_workflow_is_manual_and_never_builds_or_uploads() -> None:
+    workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in workflow
+    assert "push:" not in workflow
+    for forbidden in ("package:win", "electron-builder", "bun install", "softprops/action-gh-release", "gh release upload", "gh release create"):
+        assert forbidden not in workflow
+    assert "production-release" in workflow
+    assert "allow_unsigned" in workflow
+    assert "accepted_name_risk" in workflow
+    assert "default: false" in workflow
+    assert "draft=false" in workflow
+
+
+def test_release_asset_contract_and_notice_generator_are_tracked() -> None:
+    artifacts = (ROOT / "scripts/release-artifacts.ps1").read_text(encoding="utf-8")
+    notices = (ROOT / "scripts/generate-third-party-notices.ps1").read_text(encoding="utf-8")
+    for name in ("Eve.Web.Setup.$version.exe", "murmur-$version-x64.nsis.7z", "latest.yml", "SHA256SUMS.txt", "SHA512SUMS.txt", "THIRD_PARTY_NOTICES.txt"):
+        assert name in artifacts
+    assert "2100000000" in artifacts
+    assert "NotSigned" in artifacts
+    assert "Unclassified shipped component" in notices
+    assert "THIRD_PARTY_INVENTORY.json" in notices
+    assert "Get-ChildItem $dist.FullName -Recurse -File" in notices
+    assert "the mit license" in notices.lower()
+    assert "$Matches[1].Trim()" in notices
+    assert "ToLowerInvariant" in notices
+    assert "unknown|none|n/?a" in notices
+    assert "$isBsd3" in notices
+    assert "neither the name.*endorse or promote" in notices

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -130,27 +130,16 @@ def test_release_verification_targets_eve_with_legacy_payload_name() -> None:
     assert '"murmur-$ExpectedVersion-x64.nsis.7z"' in contents
 
 
-def test_release_workflow_installs_extras_and_uploads_payloads() -> None:
+def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:
     workflow_path = ROOT / ".github" / "workflows" / "release.yml"
     contents = workflow_path.read_text(encoding="utf-8")
-    assert "--extra all" in contents
-    assert "prepare-python-runtime.ps1" in contents
-    assert "portable Python imports" in contents
-    assert "Verify packaged Python imports" in contents
-    assert "release\\win-unpacked\\resources\\server" in contents
-    assert "torch, nemo.collections.asr" in contents
-    assert '$health.engine.status -eq "ready"' in contents
-    assert '$health.model_download.status -eq "ready"' in contents
-    assert "$maxAssetBytes = 2100000000" in contents
-    assert "uv run --no-sync pytest" in contents
-    assert "--group dev" in contents
-    assert "GH_TOKEN" not in contents
-    assert '$releaseDir = "app\\release\\nsis-web"' in contents
-    assert "app/release/nsis-web/*.exe" in contents
-    assert "app/release/nsis-web/*.yml" in contents
-    assert "app/release/nsis-web/*.blockmap" in contents
-    assert "app/release/nsis-web/*.7z" in contents
-    assert "app/release/**/*.exe" not in contents
+    assert "workflow_dispatch:" in contents
+    assert "production-release" in contents
+    assert "release-artifacts.ps1 -Mode Verify" in contents
+    assert "gh release download" in contents
+    assert "draft=false" in contents
+    for forbidden in ("push:", "package:win", "electron-builder", "softprops/action-gh-release", "gh release upload"):
+        assert forbidden not in contents
 
 
 def test_packaging_includes_relocatable_runtime() -> None:
@@ -164,6 +153,7 @@ def test_packaging_includes_relocatable_runtime() -> None:
         if isinstance(entry, str)
     ]
     assert ".runtime/**/*" in filters
+    assert "resources/generated/legal" in json.dumps(resources)
     assert "!.venv/**/pip*" not in filters
     assert "!.venv/**/wheel*" not in filters
     assert "!.venv/**/setuptools*" not in filters
@@ -200,6 +190,14 @@ def test_server_manager_uses_portable_runtime_and_user_settings() -> None:
     assert "PYTHONPATH" in contents
     assert "MURMUR_SETTINGS_FILE" in contents
     assert "path.join(app.getPath('userData'), 'server-settings.json')" in contents
+
+
+def test_release_verify_uses_packaged_runtime_and_controlled_environment() -> None:
+    contents = (ROOT / "scripts" / "release-verify.ps1").read_text(encoding="utf-8")
+    assert '.runtime\\python.exe' in contents
+    assert '.venv\\Lib\\site-packages' in contents
+    assert "MURMUR_SETTINGS_FILE" in contents
+    assert "MURMUR_WHISPER_COMPUTE_TYPE" in contents
 
 
 def test_runtime_preparation_script_uses_uv_managed_python() -> None:

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -138,6 +138,10 @@ def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:
     assert "release-artifacts.ps1 -Mode Verify" in contents
     assert "gh release download" in contents
     assert "draft=false" in contents
+    allow_block = contents.split("allow_unsigned:", 1)[1].split("accepted_name_risk:", 1)[0]
+    name_block = contents.split("accepted_name_risk:", 1)[1].split("permissions:", 1)[0]
+    assert "default: false" in allow_block
+    assert "default: false" in name_block
     for forbidden in ("push:", "package:win", "electron-builder", "softprops/action-gh-release", "gh release upload"):
         assert forbidden not in contents
 
@@ -153,7 +157,12 @@ def test_packaging_includes_relocatable_runtime() -> None:
         if isinstance(entry, str)
     ]
     assert ".runtime/**/*" in filters
-    assert "resources/generated/legal" in json.dumps(resources)
+    assert any(
+        resource.get("from") == "resources/generated/legal"
+        and resource.get("to") == "legal"
+        for resource in resources
+        if isinstance(resource, dict)
+    )
     assert "!.venv/**/pip*" not in filters
     assert "!.venv/**/wheel*" not in filters
     assert "!.venv/**/setuptools*" not in filters


### PR DESCRIPTION
## Gate 6C preparation

Implements the controlled exact-artifact publication preparation for #24.

- Replaces tag-triggered build/publish with manual draft verification and protected promotion.
- Adds deterministic closure-derived notice inventory, reviewed overrides, and packaged legal resources.
- Preserves unsigned/SmartScreen and accepted Eve name-risk gates as explicit false-by-default dispatch inputs.
- Corrects the release verifier to use the packaged managed runtime.

Validation completed in the isolated Gate6C workspace: deterministic notice scan; 142 server tests; 111 app tests; History check; production build; lock/version/diff/workflow checks. No package, tag, release, upload, or publication occurred.

Closes #24 on merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows release packages now include generated third-party license and notice information.
  * Release artifacts can be validated for exact contents, hashes, metadata, updater compatibility, and required notices.
  * Verification now supports packaged runtime environments for release validation.

* **Documentation**
  * Added third-party notice records and a controlled release publication runbook.
  * Clarified unsigned-installation warnings and accepted publication risks.

* **Bug Fixes**
  * Improved release verification reliability by using the packaged runtime and controlled environment settings.

* **Tests**
  * Added coverage for manual release promotion, artifact validation, notice generation, and packaged-runtime verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->