### PR TITLE
Gate 6C: harden release control-plane verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,17 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: ${{ inputs.expected_commit }}
-          fetch-depth: 0
+          ref: ${{ github.sha }}
+          fetch-depth: 1
           persist-credentials: false
-      - name: Require default-branch dispatch and explicit risk gates
+      - name: Require immutable trunk control-plane checkout
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:GITHUB_REF -ne 'refs/heads/trunk') { throw 'Dispatch only from trunk.' }
+          $head = (git rev-parse HEAD).Trim()
+          if ($head -ne $env:GITHUB_SHA) { throw "Control-plane checkout mismatch: HEAD=$head GITHUB_SHA=$env:GITHUB_SHA" }
+      - name: Require explicit risk gates
         shell: pwsh
         env:
           TAG: ${{ inputs.tag }}
@@ -52,7 +59,6 @@ jobs:
           ACCEPTED_NAME_RISK: ${{ inputs.accepted_name_risk }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if ($env:GITHUB_REF -ne 'refs/heads/trunk') { throw 'Dispatch only from trunk.' }
           if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$') { throw 'Malformed release inputs.' }
           if ($env:ACCEPTED_NAME_RISK -ne 'true') { throw 'Name-risk acceptance must be explicit.' }
       - name: Download existing draft assets only
@@ -62,9 +68,27 @@ jobs:
           TAG: ${{ inputs.tag }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
         run: |
+          $ErrorActionPreference = 'Stop'
+          function Resolve-ReleaseTagCommit {
+            $refJson = gh api "repos/${{ github.repository }}/git/ref/tags/$env:TAG"
+            if ($LASTEXITCODE -ne 0) { throw 'Exact release tag does not exist.' }
+            $object = ($refJson | ConvertFrom-Json).object
+            $depth = 0
+            while ($object.type -eq 'tag') {
+              $depth++
+              if ($depth -gt 4) { throw 'Release tag indirection exceeds the supported bound.' }
+              $tagJson = gh api "repos/${{ github.repository }}/git/tags/$($object.sha)"
+              if ($LASTEXITCODE -ne 0) { throw 'Annotated release tag could not be resolved.' }
+              $object = ($tagJson | ConvertFrom-Json).object
+            }
+            if ($object.type -ne 'commit') { throw 'Release tag does not resolve to a commit.' }
+            return [string]$object.sha
+          }
+          $tagCommit = Resolve-ReleaseTagCommit
+          if ($tagCommit -ne $env:EXPECTED_COMMIT) { throw 'Release tag commit does not match ExpectedCommit.' }
           gh release view $env:TAG --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
           $release = Get-Content release.json -Raw | ConvertFrom-Json
-          if (-not $release.isDraft -or $release.isPrerelease -or $release.targetCommitish -ne $env:EXPECTED_COMMIT) { throw 'An exact-target non-prerelease draft release is required.' }
+          if (-not $release.isDraft -or $release.isPrerelease -or $release.tagName -ne $env:TAG -or $release.targetCommitish -ne $env:EXPECTED_COMMIT) { throw 'An exact-target non-prerelease draft release is required.' }
           gh release download $env:TAG --repo '${{ github.repository }}' --dir release-assets
       - name: Verify draft manifest and artifacts
         shell: pwsh
@@ -88,9 +112,16 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: ${{ inputs.expected_commit }}
-          fetch-depth: 0
+          ref: ${{ github.sha }}
+          fetch-depth: 1
           persist-credentials: false
+      - name: Require immutable trunk control-plane checkout after approval
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:GITHUB_REF -ne 'refs/heads/trunk') { throw 'Dispatch only from trunk.' }
+          $head = (git rev-parse HEAD).Trim()
+          if ($head -ne $env:GITHUB_SHA) { throw "Control-plane checkout mismatch: HEAD=$head GITHUB_SHA=$env:GITHUB_SHA" }
       - name: Re-download and reverify after approval
         shell: pwsh
         env:
@@ -102,9 +133,26 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_MANIFEST_SHA256 -notmatch '^[0-9a-fA-F]{64}$' -or $env:ALLOW_UNSIGNED -notin @('true', 'false')) { throw 'Malformed release inputs.' }
+          function Resolve-ReleaseTagCommit {
+            $refJson = gh api "repos/${{ github.repository }}/git/ref/tags/$env:TAG"
+            if ($LASTEXITCODE -ne 0) { throw 'Exact release tag does not exist.' }
+            $object = ($refJson | ConvertFrom-Json).object
+            $depth = 0
+            while ($object.type -eq 'tag') {
+              $depth++
+              if ($depth -gt 4) { throw 'Release tag indirection exceeds the supported bound.' }
+              $tagJson = gh api "repos/${{ github.repository }}/git/tags/$($object.sha)"
+              if ($LASTEXITCODE -ne 0) { throw 'Annotated release tag could not be resolved.' }
+              $object = ($tagJson | ConvertFrom-Json).object
+            }
+            if ($object.type -ne 'commit') { throw 'Release tag does not resolve to a commit.' }
+            return [string]$object.sha
+          }
+          $tagCommit = Resolve-ReleaseTagCommit
+          if ($tagCommit -ne $env:EXPECTED_COMMIT) { throw 'Release tag commit does not match ExpectedCommit.' }
           gh release view $env:TAG --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
           $release = Get-Content release.json -Raw | ConvertFrom-Json
-          if (-not $release.isDraft -or $release.isPrerelease -or $release.targetCommitish -ne $env:EXPECTED_COMMIT) { throw 'Draft target or state changed after verification.' }
+          if (-not $release.isDraft -or $release.isPrerelease -or $release.tagName -ne $env:TAG -or $release.targetCommitish -ne $env:EXPECTED_COMMIT) { throw 'Draft target or state changed after verification.' }
           gh release download $env:TAG --repo '${{ github.repository }}' --dir release-assets
           & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag $env:TAG -ExpectedCommit $env:EXPECTED_COMMIT -ExpectedManifestSha256 $env:EXPECTED_MANIFEST_SHA256 -AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')
           if ($LASTEXITCODE -ne 0) { throw 'Artifact re-verification failed.' }

--- a/docs/architecture/eve-gate-6-release-plan.md
+++ b/docs/architecture/eve-gate-6-release-plan.md
@@ -445,6 +445,9 @@ Before publication:
 
 - re-audit PR/head/tree, mergeability, CI, CodeRabbit, allowlist, version, and clean
   worktree;
+- run release verification from the reviewed default-branch workflow-dispatch commit,
+  while independently requiring the release tag, draft target, and artifact manifest to
+  identify the accepted release/artifact commit;
 - merge only the accepted release change using the repository's approved merge method;
 - prove canonical `trunk` contains the accepted tree;
 - prove tag `v0.7.0` points at the explicitly approved release commit;

--- a/docs/architecture/eve-gate-6c-publication-runbook.md
+++ b/docs/architecture/eve-gate-6c-publication-runbook.md
@@ -6,8 +6,11 @@
 4. Create the exact annotated tag only after acceptance; tag pushes do not trigger a workflow.
 5. Manually create a draft release and upload exactly the manifest, SHA256/SHA512 sums,
    third-party notice, wrapper, payload, and `latest.yml`.
-6. Dispatch the verifier with exact tag, commit, manifest hash, `allow_unsigned=true`, and
-   `accepted_name_risk=true`. It downloads and verifies only; it never builds or uploads.
+6. Dispatch the verifier from `trunk` with exact tag, release commit, manifest hash,
+   `allow_unsigned=true`, and `accepted_name_risk=true`. The immutable dispatch
+   `github.sha` supplies the reviewed control-plane scripts; the release tag, draft
+   `targetCommitish`, and manifest must independently identify the accepted release
+   commit. The workflow downloads and verifies only; it never builds or uploads.
 7. A configured `production-release` environment reviewer approves the promotion job.
    The job re-downloads and re-verifies, then changes `draft=false`, `prerelease=false`,
    and marks the verified release latest.

--- a/scripts/release-artifacts.ps1
+++ b/scripts/release-artifacts.ps1
@@ -41,14 +41,20 @@ foreach($line in ($latest -split "`r?`n")){
   if($line -eq ''){continue}
   if($line -match '^files:$'){if($state -ne 'top' -or $top.Contains('files')){throw 'Malformed or duplicate latest.yml files section.'};$top.files=$true;$state='files';continue}
   if($line -match '^  - url: ([^\s]+)$'){if($state -ne 'files' -or $file.Count){throw 'Malformed or duplicate latest.yml file entry.'};$file.url=$Matches[1];continue}
-  if($line -match '^    (sha512|size): ([^\s]+)$'){if($state -ne 'files' -or !$file.Contains('url') -or $file.Contains($Matches[1])){throw 'Malformed or duplicate latest.yml file property.'};$file[$Matches[1]]=$Matches[2];continue}
+  if($state -eq 'files' -and $line -match '^    (sha512|size): ([^\s]+)$'){if(!$file.Contains('url') -or $file.Contains($Matches[1])){throw 'Malformed or duplicate latest.yml file property.'};$file[$Matches[1]]=$Matches[2];continue}
   if($line -match '^packages:$'){if($state -ne 'top' -or $top.Contains('packages')){throw 'Malformed or duplicate latest.yml packages section.'};$top.packages=$true;$state='packages';continue}
   if($line -match '^  x64:$'){if($state -ne 'packages' -or $package.Count){throw 'Malformed or duplicate latest.yml x64 package.'};$package.present=$true;$state='package';continue}
-  if($line -match '^    (size|sha512|blockMapSize|path|file): ([^\s]+)$'){if($state -ne 'package' -or $package.Contains($Matches[1])){throw 'Malformed or duplicate latest.yml package property.'};$package[$Matches[1]]=$Matches[2];continue}
+  if($state -eq 'package' -and $line -match '^    (size|sha512|blockMapSize|path|file): ([^\s]+)$'){if($package.Contains($Matches[1])){throw 'Malformed or duplicate latest.yml package property.'};$package[$Matches[1]]=$Matches[2];continue}
   if($line -match '^(version|path|sha512|releaseDate): (.+)$'){if($state -eq 'files' -and !$file.Contains('sha512')){throw 'Incomplete latest.yml file entry.'};if($state -eq 'package' -and (!$package.Contains('size') -or !$package.Contains('sha512') -or !$package.Contains('path') -or !$package.Contains('file'))){throw 'Incomplete latest.yml package entry.'};$state='top';if($top.Contains($Matches[1])){throw 'Duplicate latest.yml field.'};$top[$Matches[1]]=$Matches[2].Trim("'");continue}
   throw "Unknown or malformed latest.yml line: $line"
 }
 if(!$top.Contains('version') -or !$top.Contains('path') -or !$top.Contains('sha512') -or !$top.Contains('releaseDate') -or !$file.Contains('url') -or !$file.Contains('sha512') -or !$package.Contains('size') -or !$package.Contains('sha512') -or !$package.Contains('path') -or !$package.Contains('file')){throw 'Missing required latest.yml fields.'}
 if($top.version -ne $version -or $top.path -ne "Eve.Web.Setup.$version.exe" -or $file.url -ne $top.path -or $package.path -ne "murmur-$version-x64.nsis.7z" -or $package.file -ne $package.path -or $package.size -notmatch '^\d+$' -or ($file.Contains('size') -and $file.size -notmatch '^\d+$')){throw 'latest.yml identity or numeric fields mismatch.'}
-foreach($pair in @(@($top.path,$top.sha512,$null),@($file.url,$file.sha512,$file.Contains('size') ? $file.size : $null),@($package.path,$package.sha512,$package.size))){$manifestEntry=$data.assets|Where-Object name -eq $pair[0];if(!$manifestEntry){throw 'latest.yml asset missing from manifest.'};$expectedBase64=[Convert]::ToBase64String([Convert]::FromHexString([string]$manifestEntry.sha512));if($pair[1] -ne $expectedBase64 -or ($null -ne $pair[2] -and [int64]$pair[2] -ne [int64]$manifestEntry.bytes)){throw 'latest.yml hash or size mismatch.'}}
+$fileSize=if($file.Contains('size')){$file['size']}else{$null}
+$latestAssets=@(
+  [pscustomobject]@{Name=$top.path;Sha512=$top.sha512;Size=$null}
+  [pscustomobject]@{Name=$file.url;Sha512=$file.sha512;Size=$fileSize}
+  [pscustomobject]@{Name=$package.path;Sha512=$package.sha512;Size=$package.size}
+)
+foreach($pair in $latestAssets){$manifestEntry=$data.assets|Where-Object name -eq $pair.Name;if(!$manifestEntry){throw 'latest.yml asset missing from manifest.'};$expectedBase64=[Convert]::ToBase64String([Convert]::FromHexString([string]$manifestEntry.sha512));if($pair.Sha512 -ne $expectedBase64 -or ($null -ne $pair.Size -and [int64]$pair.Size -ne [int64]$manifestEntry.bytes)){throw 'latest.yml hash or size mismatch.'}}
 if(!(Select-String -LiteralPath (Join-Path $dir 'THIRD_PARTY_NOTICES.txt') -Pattern 'Generated from the exact pre-package closure' -Quiet)){throw 'Third-party notice asset is not the generated notice.'}

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -1,9 +1,123 @@
 """Static guards for the no-rebuild Gate 6C release promotion path."""
 
+import base64
+import hashlib
+import json
 from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
+RELEASE_COMMIT = "d03c7eab7e3e10afc2f62662d25ccd63427c22e9"
+
+
+def _digest(path: Path, algorithm: str) -> str:
+    digest = hashlib.new(algorithm)
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _signed_wrapper_fixture() -> bytes:
+    where_exe = shutil.which("where.exe")
+    assert where_exe, "The signed Windows where.exe fixture is required."
+    return Path(where_exe).read_bytes()
+
+
+def _latest_yml(*, release_date_after_packages: bool = False) -> str:
+    wrapper = _signed_wrapper_fixture()
+    payload = b"payload fixture"
+    wrapper_sha512 = base64.b64encode(hashlib.sha512(wrapper).digest()).decode()
+    payload_sha512 = base64.b64encode(hashlib.sha512(payload).digest()).decode()
+    release_date = "releaseDate: '2026-07-29T18:45:18.746Z'\n"
+    packages = (
+        "packages:\n"
+        "  x64:\n"
+        f"    size: {len(payload)}\n"
+        f"    sha512: {payload_sha512}\n"
+        "    blockMapSize: 123\n"
+        "    path: murmur-1.2.3-x64.nsis.7z\n"
+        "    file: murmur-1.2.3-x64.nsis.7z\n"
+    )
+    top = (
+        "version: 1.2.3\n"
+        "files:\n"
+        "  - url: Eve.Web.Setup.1.2.3.exe\n"
+        f"    sha512: {wrapper_sha512}\n"
+        "path: Eve.Web.Setup.1.2.3.exe\n"
+        f"sha512: {wrapper_sha512}\n"
+    )
+    if release_date_after_packages:
+        return top + packages + release_date
+    return top + release_date + packages
+
+
+def _write_release_fixture(directory: Path, latest: str) -> str:
+    files = {
+        "Eve.Web.Setup.1.2.3.exe": _signed_wrapper_fixture(),
+        "murmur-1.2.3-x64.nsis.7z": b"payload fixture",
+        "latest.yml": latest.encode(),
+        "THIRD_PARTY_NOTICES.txt": b"Generated from the exact pre-package closure\n",
+    }
+    for name, content in files.items():
+        (directory / name).write_bytes(content)
+
+    base_names = tuple(files)
+    for algorithm in ("sha256", "sha512"):
+        lines = [f"{_digest(directory / name, algorithm)} *{name}" for name in base_names]
+        (directory / f"{algorithm.upper()}SUMS.txt").write_text(
+            "\n".join(lines) + "\n", encoding="ascii"
+        )
+
+    asset_names = (*base_names, "SHA256SUMS.txt", "SHA512SUMS.txt")
+    manifest = {
+        "schema": 1,
+        "tag": "v1.2.3",
+        "commit": RELEASE_COMMIT,
+        "version": "1.2.3",
+        "assets": [
+            {
+                "name": name,
+                "bytes": (directory / name).stat().st_size,
+                "sha256": _digest(directory / name, "sha256"),
+                "sha512": _digest(directory / name, "sha512"),
+            }
+            for name in asset_names
+        ],
+    }
+    manifest_path = directory / "eve-v1.2.3-artifact-manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return _digest(manifest_path, "sha256")
+
+
+def _verify_release_fixture(
+    directory: Path, manifest_sha256: str
+) -> subprocess.CompletedProcess[str]:
+    pwsh = shutil.which("pwsh")
+    assert pwsh, "PowerShell 7 is required for release-control tests."
+    return subprocess.run(
+        [
+            pwsh,
+            "-NoProfile",
+            "-File",
+            str(ROOT / "scripts" / "release-artifacts.ps1"),
+            "-Mode",
+            "Verify",
+            "-ArtifactDir",
+            str(directory),
+            "-ExpectedTag",
+            "v1.2.3",
+            "-ExpectedCommit",
+            RELEASE_COMMIT,
+            "-ExpectedManifestSha256",
+            manifest_sha256,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 def test_release_workflow_is_manual_and_never_builds_or_uploads() -> None:
@@ -52,8 +166,14 @@ def test_release_asset_contract_and_notice_generator_are_tracked() -> None:
 
 def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None:
     workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
-    assert "persist-credentials: false" in workflow
-    assert "targetCommitish -ne $env:EXPECTED_COMMIT" in workflow
+    assert workflow.count("persist-credentials: false") == 2
+    assert workflow.count("ref: ${{ github.sha }}") == 2
+    assert "ref: ${{ inputs.expected_commit }}" not in workflow
+    assert workflow.count("$head -ne $env:GITHUB_SHA") == 2
+    assert workflow.count("$env:GITHUB_REF -ne 'refs/heads/trunk'") == 2
+    assert workflow.count("Release tag commit does not match ExpectedCommit.") == 2
+    assert workflow.count("$release.tagName -ne $env:TAG") == 2
+    assert workflow.count("targetCommitish -ne $env:EXPECTED_COMMIT") == 2
     assert "EXPECTED_MANIFEST_SHA256" in workflow
     assert "-AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')" in workflow
     assert "gh release edit $env:TAG" in workflow
@@ -69,3 +189,42 @@ def test_packaged_resource_and_runtime_harness_guards() -> None:
     assert ".runtime\\python.exe" in verify
     assert "import faster_whisper, torch, nemo.collections.asr" in verify
     assert 'Remove-Item -Path "env:$key"' in verify
+
+
+@pytest.mark.parametrize("release_date_after_packages", [False, True])
+def test_release_artifacts_accepts_electron_builder_latest_yml_ordering(
+    tmp_path: Path, release_date_after_packages: bool
+) -> None:
+    manifest_sha256 = _write_release_fixture(
+        tmp_path, _latest_yml(release_date_after_packages=release_date_after_packages)
+    )
+    result = _verify_release_fixture(tmp_path, manifest_sha256)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_error"),
+    [
+        (
+            lambda latest: latest.replace(
+                "    size: 15\n", "    size: 15\n    size: 15\n"
+            ),
+            "Malformed or duplicate latest.yml package property.",
+        ),
+        (
+            lambda latest: latest.replace("    size: 15\n", "   size: 15\n"),
+            "Unknown or malformed latest.yml line",
+        ),
+        (
+            lambda latest: latest.replace("    size: 15\n", "    size: 16\n"),
+            "latest.yml hash or size mismatch.",
+        ),
+    ],
+)
+def test_release_artifacts_rejects_adversarial_package_fields(
+    tmp_path: Path, mutate, expected_error: str
+) -> None:
+    manifest_sha256 = _write_release_fixture(tmp_path, mutate(_latest_yml()))
+    result = _verify_release_fixture(tmp_path, manifest_sha256)
+    assert result.returncode != 0
+    assert expected_error in result.stdout + result.stderr


### PR DESCRIPTION
Closes #26.

## Scope
- state-gate strict `latest.yml` file/package properties and preserve all manifest/checksum/hash/size failures;
- run the verifier from immutable `workflow_dispatch` control-plane `github.sha` on `trunk` while independently enforcing the release tag, draft target, and manifest commit against release/artifact commit `d03c7eab7e3e10afc2f62662d25ccd63427c22e9`;
- add valid electron-builder ordering plus duplicate/malformed/mismatched regression fixtures;
- minimally document control-plane versus release-commit identity.

## Validation
- accepted seven-asset verification passed; manifest SHA-256 `41197da7b1ff95508755ae0f7f9ca7b875173f53e15e715b63a410db01e9`;
- app: 111 tests, History test, main/renderer TypeScript, production build;
- server: 149 tests; `uv lock --check`;
- workflow YAML parse, version check, forbidden-action/static audit, exact five-file scope, `git diff --check`.

No package, install change, tag, release, upload, workflow dispatch, publication, artifact mutation, or cleanup occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened release verification to ensure tags, commits, draft releases, and artifacts all refer to the intended release.
  - Improved validation of `latest.yml`, including package sizes, hashes, malformed entries, and varying field order.
  - Added safeguards against verification running from an unapproved branch or commit.

- **Documentation**
  - Clarified the Gate 6C release verification and publication procedures, including reviewed commits, tags, manifests, and verification-only behavior.

- **Tests**
  - Expanded coverage for release identity checks and adversarial or reordered artifact metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->