### PR TITLE
Gate 6C: verify draft release by immutable REST ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
         description: SHA-256 of the uploaded manifest
         required: true
         type: string
+      expected_release_id:
+        description: Immutable numeric ID of the existing draft release
+        required: true
+        type: string
       allow_unsigned:
         description: Permit an intentionally unsigned Windows wrapper
         required: true
@@ -55,11 +59,12 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}
           ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
           ACCEPTED_NAME_RISK: ${{ inputs.accepted_name_risk }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$') { throw 'Malformed release inputs.' }
+          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_RELEASE_ID -notmatch '^[1-9][0-9]*$') { throw 'Malformed release inputs.' }
           if ($env:ACCEPTED_NAME_RISK -ne 'true') { throw 'Name-risk acceptance must be explicit.' }
       - name: Download existing draft assets only
         shell: pwsh
@@ -67,6 +72,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}
         run: |
           $ErrorActionPreference = 'Stop'
           function Resolve-ReleaseTagCommit {
@@ -86,15 +92,41 @@ jobs:
           }
           $tagCommit = Resolve-ReleaseTagCommit
           if ($tagCommit -ne $env:EXPECTED_COMMIT) { throw 'Release tag commit does not match ExpectedCommit.' }
-          gh release view $env:TAG --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
-          $release = Get-Content release.json -Raw | ConvertFrom-Json
-          if (-not $release.isDraft -or $release.isPrerelease -or $release.tagName -ne $env:TAG -or $release.targetCommitish -ne $env:EXPECTED_COMMIT) { throw 'An exact-target non-prerelease draft release is required.' }
-          gh release download $env:TAG --repo '${{ github.repository }}' --dir release-assets
+          $releaseJson = gh api "repos/${{ github.repository }}/releases/$env:EXPECTED_RELEASE_ID"
+          if ($LASTEXITCODE -ne 0) { throw 'Draft release ID could not be fetched.' }
+          $release = $releaseJson | ConvertFrom-Json
+          if ([string]$release.id -ne $env:EXPECTED_RELEASE_ID -or -not $release.draft -or $release.prerelease -or $release.tag_name -ne $env:TAG -or $release.target_commitish -ne $env:EXPECTED_COMMIT) { throw 'An exact-ID, exact-target non-prerelease draft release is required.' }
+          $version = $env:TAG.Substring(1)
+          $expectedNames = @(
+            "Eve.Web.Setup.$version.exe",
+            "murmur-$version-x64.nsis.7z",
+            'latest.yml',
+            "eve-$env:TAG-artifact-manifest.json",
+            'SHA256SUMS.txt',
+            'SHA512SUMS.txt',
+            'THIRD_PARTY_NOTICES.txt'
+          )
+          $assets = @($release.assets)
+          if ($assets.Count -ne $expectedNames.Count -or (@($assets.name | Sort-Object) -join "`n") -ne (@($expectedNames | Sort-Object) -join "`n")) { throw 'Draft release asset allowlist mismatch.' }
+          New-Item -ItemType Directory -Path release-assets | Out-Null
+          foreach ($asset in $assets) {
+            if ([string]$asset.id -notmatch '^[1-9][0-9]*$' -or [int64]$asset.size -le 0 -or $asset.state -ne 'uploaded' -or $asset.digest -notmatch '^sha256:[0-9a-f]{64}$' -or $asset.url -ne "https://api.github.com/repos/${{ github.repository }}/releases/assets/$($asset.id)") { throw "Malformed asset metadata for $($asset.name)." }
+            curl.exe --silent --show-error --fail --location `
+              --header "Authorization: Bearer $env:GH_TOKEN" `
+              --header 'Accept: application/octet-stream' `
+              --output (Join-Path release-assets $asset.name) `
+              $asset.url
+            if ($LASTEXITCODE -ne 0) { throw "Authenticated asset download failed for $($asset.name)." }
+            $download = Get-Item -LiteralPath (Join-Path release-assets $asset.name)
+            $downloadDigest = "sha256:$((Get-FileHash -LiteralPath $download.FullName -Algorithm SHA256).Hash.ToLowerInvariant())"
+            if ($download.Length -ne [int64]$asset.size -or $downloadDigest -ne $asset.digest) { throw "Downloaded asset metadata mismatch for $($asset.name)." }
+          }
       - name: Verify draft manifest and artifacts
         shell: pwsh
         env:
           TAG: ${{ inputs.tag }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}
           EXPECTED_MANIFEST_SHA256: ${{ inputs.expected_manifest_sha256 }}
           ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
         run: |
@@ -132,7 +164,7 @@ jobs:
           ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_MANIFEST_SHA256 -notmatch '^[0-9a-fA-F]{64}$' -or $env:ALLOW_UNSIGNED -notin @('true', 'false')) { throw 'Malformed release inputs.' }
+          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_RELEASE_ID -notmatch '^[1-9][0-9]*$' -or $env:EXPECTED_MANIFEST_SHA256 -notmatch '^[0-9a-fA-F]{64}$' -or $env:ALLOW_UNSIGNED -notin @('true', 'false')) { throw 'Malformed release inputs.' }
           function Resolve-ReleaseTagCommit {
             $refJson = gh api "repos/${{ github.repository }}/git/ref/tags/$env:TAG"
             if ($LASTEXITCODE -ne 0) { throw 'Exact release tag does not exist.' }
@@ -150,10 +182,35 @@ jobs:
           }
           $tagCommit = Resolve-ReleaseTagCommit
           if ($tagCommit -ne $env:EXPECTED_COMMIT) { throw 'Release tag commit does not match ExpectedCommit.' }
-          gh release view $env:TAG --repo '${{ github.repository }}' --json isDraft,isPrerelease,tagName,targetCommitish,assets > release.json
-          $release = Get-Content release.json -Raw | ConvertFrom-Json
-          if (-not $release.isDraft -or $release.isPrerelease -or $release.tagName -ne $env:TAG -or $release.targetCommitish -ne $env:EXPECTED_COMMIT) { throw 'Draft target or state changed after verification.' }
-          gh release download $env:TAG --repo '${{ github.repository }}' --dir release-assets
+          $releaseJson = gh api "repos/${{ github.repository }}/releases/$env:EXPECTED_RELEASE_ID"
+          if ($LASTEXITCODE -ne 0) { throw 'Draft release ID could not be re-fetched after approval.' }
+          $release = $releaseJson | ConvertFrom-Json
+          if ([string]$release.id -ne $env:EXPECTED_RELEASE_ID -or -not $release.draft -or $release.prerelease -or $release.tag_name -ne $env:TAG -or $release.target_commitish -ne $env:EXPECTED_COMMIT) { throw 'Draft ID, target, or state changed after verification.' }
+          $version = $env:TAG.Substring(1)
+          $expectedNames = @(
+            "Eve.Web.Setup.$version.exe",
+            "murmur-$version-x64.nsis.7z",
+            'latest.yml',
+            "eve-$env:TAG-artifact-manifest.json",
+            'SHA256SUMS.txt',
+            'SHA512SUMS.txt',
+            'THIRD_PARTY_NOTICES.txt'
+          )
+          $assets = @($release.assets)
+          if ($assets.Count -ne $expectedNames.Count -or (@($assets.name | Sort-Object) -join "`n") -ne (@($expectedNames | Sort-Object) -join "`n")) { throw 'Draft release asset allowlist changed after verification.' }
+          New-Item -ItemType Directory -Path release-assets | Out-Null
+          foreach ($asset in $assets) {
+            if ([string]$asset.id -notmatch '^[1-9][0-9]*$' -or [int64]$asset.size -le 0 -or $asset.state -ne 'uploaded' -or $asset.digest -notmatch '^sha256:[0-9a-f]{64}$' -or $asset.url -ne "https://api.github.com/repos/${{ github.repository }}/releases/assets/$($asset.id)") { throw "Malformed asset metadata for $($asset.name)." }
+            curl.exe --silent --show-error --fail --location `
+              --header "Authorization: Bearer $env:GH_TOKEN" `
+              --header 'Accept: application/octet-stream' `
+              --output (Join-Path release-assets $asset.name) `
+              $asset.url
+            if ($LASTEXITCODE -ne 0) { throw "Authenticated asset download failed for $($asset.name)." }
+            $download = Get-Item -LiteralPath (Join-Path release-assets $asset.name)
+            $downloadDigest = "sha256:$((Get-FileHash -LiteralPath $download.FullName -Algorithm SHA256).Hash.ToLowerInvariant())"
+            if ($download.Length -ne [int64]$asset.size -or $downloadDigest -ne $asset.digest) { throw "Downloaded asset metadata mismatch for $($asset.name)." }
+          }
           & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag $env:TAG -ExpectedCommit $env:EXPECTED_COMMIT -ExpectedManifestSha256 $env:EXPECTED_MANIFEST_SHA256 -AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')
           if ($LASTEXITCODE -ne 0) { throw 'Artifact re-verification failed.' }
       - name: Publish the existing verified draft only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}
           EXPECTED_MANIFEST_SHA256: ${{ inputs.expected_manifest_sha256 }}
           ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
         run: |

--- a/docs/architecture/eve-gate-6c-publication-runbook.md
+++ b/docs/architecture/eve-gate-6c-publication-runbook.md
@@ -6,11 +6,13 @@
 4. Create the exact annotated tag only after acceptance; tag pushes do not trigger a workflow.
 5. Manually create a draft release and upload exactly the manifest, SHA256/SHA512 sums,
    third-party notice, wrapper, payload, and `latest.yml`.
-6. Dispatch the verifier from `trunk` with exact tag, release commit, manifest hash,
+6. Record the draft's immutable numeric REST release ID, then dispatch the verifier from
+   `trunk` with that release ID, exact tag, release commit, manifest hash,
    `allow_unsigned=true`, and `accepted_name_risk=true`. The immutable dispatch
    `github.sha` supplies the reviewed control-plane scripts; the release tag, draft
    `targetCommitish`, and manifest must independently identify the accepted release
-   commit. The workflow downloads and verifies only; it never builds or uploads.
+   commit. The workflow fetches the draft by release ID and downloads each of the exact
+   seven assets through its authenticated asset API URL; it never builds or uploads.
 7. A configured `production-release` environment reviewer approves the promotion job.
    The job re-downloads and re-verifies, then changes `draft=false`, `prerelease=false`,
    and marks the verified release latest.

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -184,6 +184,12 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
     assert workflow.count("--output (Join-Path release-assets $asset.name)") == 2
     assert workflow.count("$download.Length -ne [int64]$asset.size") == 2
     assert workflow.count("$downloadDigest -ne $asset.digest") == 2
+    promote_step = workflow.split(
+        "- name: Re-download and reverify after approval", 1
+    )[1].split("- name: Publish the existing verified draft only", 1)[0]
+    assert (
+        "EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}" in promote_step
+    )
     assert "gh release view" not in workflow
     assert "gh release download" not in workflow
     assert "EXPECTED_MANIFEST_SHA256" in workflow

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -172,8 +172,20 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
     assert workflow.count("$head -ne $env:GITHUB_SHA") == 2
     assert workflow.count("$env:GITHUB_REF -ne 'refs/heads/trunk'") == 2
     assert workflow.count("Release tag commit does not match ExpectedCommit.") == 2
-    assert workflow.count("$release.tagName -ne $env:TAG") == 2
-    assert workflow.count("targetCommitish -ne $env:EXPECTED_COMMIT") == 2
+    assert "expected_release_id:" in workflow
+    assert workflow.count("$env:EXPECTED_RELEASE_ID -notmatch '^[1-9][0-9]*$'") == 2
+    assert workflow.count('gh api "repos/${{ github.repository }}/releases/$env:EXPECTED_RELEASE_ID"') == 2
+    assert workflow.count("[string]$release.id -ne $env:EXPECTED_RELEASE_ID") == 2
+    assert workflow.count("$release.tag_name -ne $env:TAG") == 2
+    assert workflow.count("$release.target_commitish -ne $env:EXPECTED_COMMIT") == 2
+    assert workflow.count("$assets.Count -ne $expectedNames.Count") == 2
+    assert workflow.count("'Accept: application/octet-stream'") == 2
+    assert workflow.count('"Authorization: Bearer $env:GH_TOKEN"') == 2
+    assert workflow.count("--output (Join-Path release-assets $asset.name)") == 2
+    assert workflow.count("$download.Length -ne [int64]$asset.size") == 2
+    assert workflow.count("$downloadDigest -ne $asset.digest") == 2
+    assert "gh release view" not in workflow
+    assert "gh release download" not in workflow
     assert "EXPECTED_MANIFEST_SHA256" in workflow
     assert "-AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')" in workflow
     assert "gh release edit $env:TAG" in workflow

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -136,7 +136,9 @@ def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:
     assert "workflow_dispatch:" in contents
     assert "production-release" in contents
     assert "release-artifacts.ps1 -Mode Verify" in contents
-    assert "gh release download" in contents
+    assert 'gh api "repos/${{ github.repository }}/releases/$env:EXPECTED_RELEASE_ID"' in contents
+    assert "'Accept: application/octet-stream'" in contents
+    assert "gh release download" not in contents
     assert "draft=false" in contents
     allow_block = contents.split("allow_unsigned:", 1)[1].split("accepted_name_risk:", 1)[0]
     name_block = contents.split("accepted_name_risk:", 1)[1].split("permissions:", 1)[0]


### PR DESCRIPTION
Closes #28.

## Summary
- require an immutable numeric draft release ID at dispatch
- fetch and validate the draft through the authenticated REST release-ID endpoint
- enforce the exact seven-asset metadata allowlist and download each asset once through its authenticated asset API URL
- repeat the same release-ID fetch/download/verification after protected approval
- remove tag-based draft lookup/download paths

## Validation
- focused Gate 6C controls: 9 passed
- full server suite: 149 passed (one existing Transformers deprecation warning)
- app suite: 111 passed; History check, main/renderer TypeScript, production build passed
- YAML, version, frozen locks, workflow invariants, four-file scope, and diff checks passed

No package, tag/release/asset mutation, workflow dispatch, environment approval, publication, installation change, or cleanup occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Windows release verification now targets a specific draft release using its immutable release ID.
  - Release validation confirms the expected tag, commit, asset list, file sizes, and SHA-256 checksums before promotion.
  - Promotion re-verifies the same release and artifacts after approval.

- **Documentation**
  - Updated the publication runbook with the required release ID and verification workflow details.

- **Tests**
  - Expanded automated coverage for release identity, asset validation, downloads, and integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->