### PR TITLE
Gate 6C: grant draft verification release access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
   verify-draft:
     name: Verify existing draft assets (no build or upload)
     runs-on: windows-latest
+    # GitHub requires write-capable contents permission to read an existing draft release.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:

--- a/docs/architecture/eve-gate-6c-publication-runbook.md
+++ b/docs/architecture/eve-gate-6c-publication-runbook.md
@@ -13,6 +13,8 @@
    `targetCommitish`, and manifest must independently identify the accepted release
    commit. The workflow fetches the draft by release ID and downloads each of the exact
    seven assets through its authenticated asset API URL; it never builds or uploads.
+   GitHub requires `contents: write` on this otherwise read/download/verify-only job to
+   access an existing draft release; checkout credentials remain disabled.
 7. A configured `production-release` environment reviewer approves the promotion job.
    The job re-downloads and re-verifies, then changes `draft=false`, `prerelease=false`,
    and marks the verified release latest.

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -173,7 +173,15 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
         "gh release upload",
         "gh release create",
         "gh release delete",
+        "gh api --method",
+        "gh api -X",
+        "curl.exe -X",
+        "curl.exe --request",
+        "--data",
+        "--form",
         "git tag",
+        "git update-ref",
+        "git replace",
         "git push",
     ):
         assert forbidden not in verify_draft

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -166,6 +166,17 @@ def test_release_asset_contract_and_notice_generator_are_tracked() -> None:
 
 def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None:
     workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    verify_draft = workflow.split("  verify-draft:\n", 1)[1].split("\n  promote:", 1)[0]
+    assert "permissions:\n      contents: write" in verify_draft
+    for forbidden in (
+        "gh release edit",
+        "gh release upload",
+        "gh release create",
+        "gh release delete",
+        "git tag",
+        "git push",
+    ):
+        assert forbidden not in verify_draft
     assert workflow.count("persist-credentials: false") == 2
     assert workflow.count("ref: ${{ github.sha }}") == 2
     assert "ref: ${{ inputs.expected_commit }}" not in workflow


### PR DESCRIPTION
Closes #30.

Grant `contents: write` only to the `verify-draft` job because GitHub rejects an otherwise read/download-only `GITHUB_TOKEN` request for an existing draft release with HTTP 403 under `contents: read`. The verification job remains structurally barred from release edit/upload/create/delete and tag mutation; checkout credentials remain disabled.

Validation: focused controls 9 passed; full server 149 passed (one existing deprecation warning); app 111 passed, History, TypeScript main/renderer, and production build passed; YAML/diff/scope/frozen lock checks passed.

No tag, draft, asset, package, install, dispatch, approval, publication, or cleanup occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Operations**
  * Improved Windows release verification so existing draft releases can be accessed reliably.
  * Confirmed verification-only steps cannot modify releases or create and push Git tags.

* **Documentation**
  * Updated the Gate 6C publication runbook with the required release permissions and credential guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->