### PR TITLE
Gate 6C: remove stale verifier exit checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,6 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag $env:TAG -ExpectedCommit $env:EXPECTED_COMMIT -ExpectedManifestSha256 $env:EXPECTED_MANIFEST_SHA256 -AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')
-          if ($LASTEXITCODE -ne 0) { throw 'Artifact verification failed.' }
 
   promote:
     name: Reverify and publish the verified draft
@@ -216,7 +215,6 @@ jobs:
             if ($download.Length -ne [int64]$asset.size -or $downloadDigest -ne $asset.digest) { throw "Downloaded asset metadata mismatch for $($asset.name)." }
           }
           & .\scripts\release-artifacts.ps1 -Mode Verify -ArtifactDir release-assets -ExpectedTag $env:TAG -ExpectedCommit $env:EXPECTED_COMMIT -ExpectedManifestSha256 $env:EXPECTED_MANIFEST_SHA256 -AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')
-          if ($LASTEXITCODE -ne 0) { throw 'Artifact re-verification failed.' }
       - name: Publish the existing verified draft only
         shell: pwsh
         env:

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -203,12 +203,23 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
     assert workflow.count("--output (Join-Path release-assets $asset.name)") == 2
     assert workflow.count("$download.Length -ne [int64]$asset.size") == 2
     assert workflow.count("$downloadDigest -ne $asset.digest") == 2
+    verifier = "& .\\scripts\\release-artifacts.ps1 -Mode Verify"
+    assert workflow.count(verifier) == 2
+    assert "Artifact verification failed." not in workflow
+    assert "Artifact re-verification failed." not in workflow
+    verify_manifest_step = workflow.split(
+        "- name: Verify draft manifest and artifacts", 1
+    )[1].split("\n  promote:", 1)[0]
+    assert "$ErrorActionPreference = 'Stop'" in verify_manifest_step
+    assert verifier in verify_manifest_step
     promote_step = workflow.split(
         "- name: Re-download and reverify after approval", 1
     )[1].split("- name: Publish the existing verified draft only", 1)[0]
     assert (
         "EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}" in promote_step
     )
+    assert "$ErrorActionPreference = 'Stop'" in promote_step
+    assert verifier in promote_step
     assert "gh release view" not in workflow
     assert "gh release download" not in workflow
     assert "EXPECTED_MANIFEST_SHA256" in workflow


### PR DESCRIPTION
Closes #32.

Remove only the two stale `$LASTEXITCODE` checks after PowerShell `release-artifacts.ps1` invocations. The workflow already uses `$ErrorActionPreference = Stop`; terminating verifier errors still fail closed. Native `gh` and `curl` exit-code checks remain unchanged.

Validation: focused 9 passed; full server 149 passed (one existing warning); app 111 passed; History, TypeScript, production build, YAML and diff checks passed.

No package, install, tag, draft, asset, dispatch, approval, publication, or cleanup occurred.