### PR TITLE
Fix overlay transcript follow scrolling

### DIFF
--- a/app/src/renderer/overlay/components/TextDisplay.svelte
+++ b/app/src/renderer/overlay/components/TextDisplay.svelte
@@ -11,14 +11,20 @@
   let scrollRef = $state<HTMLDivElement | null>(null);
   let isOverflowing = $state(false);
 
-  // Auto-scroll to bottom when text changes and check overflow
+  // Keep the newest transcript line visible in the fixed two-line viewport.
   $effect(() => {
-    if (text && scrollRef) {
-      tick().then(() => {
-        scrollRef!.scrollTop = scrollRef!.scrollHeight;
-        isOverflowing = scrollRef!.scrollHeight > scrollRef!.clientHeight;
-      });
+    if (!text) {
+      isOverflowing = false;
+      return;
     }
+
+    if (!scrollRef) return;
+
+    tick().then(() => {
+      if (!scrollRef || !text) return;
+      scrollRef.scrollTop = scrollRef.scrollHeight;
+      isOverflowing = scrollRef.scrollHeight > scrollRef.clientHeight;
+    });
   });
 </script>
 
@@ -31,7 +37,7 @@
     class="h-11 overflow-hidden {isOverflowing ? '[mask-image:linear-gradient(to_bottom,transparent_0%,black_28%,black_100%)]' : ''}"
     bind:this={scrollRef}
   >
-    <p class="line-clamp-2 break-words text-center text-sm font-medium leading-[22px] text-zinc-100">
+    <p class="break-words text-center text-sm font-medium leading-[22px] text-zinc-100">
       {text}
     </p>
   </div>

--- a/app/tests/gate5-accessibility.test.ts
+++ b/app/tests/gate5-accessibility.test.ts
@@ -59,11 +59,12 @@ describe('Gate 5 accessibility contracts', () => {
     expect(overlayView).not.toMatch(/<button|tabindex=|on(?:click|pointer|mouse)/);
   });
 
-  test('uses fixed two-line auto-follow without an operable scrollbar or glow', () => {
-    expect(overlayText).toContain('scrollTop = scrollRef!.scrollHeight');
+  test('uses a fixed two-line auto-follow viewport without an operable scrollbar or glow', () => {
+    expect(overlayText).toContain('scrollRef.scrollTop = scrollRef.scrollHeight');
     expect(overlayText).toContain('h-16');
-    expect(overlayText).toContain('line-clamp-2');
+    expect(overlayText).toContain('h-11');
     expect(overlayText).toContain('overflow-hidden');
+    expect(overlayText).not.toContain('line-clamp-2');
     expect(overlayText).not.toContain('overflow-y-auto');
     expect(overlayPill).not.toContain('shadow-[');
   });

--- a/app/tests/overlay-transcript-follow.test.ts
+++ b/app/tests/overlay-transcript-follow.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+const textDisplay = source('../src/renderer/overlay/components/TextDisplay.svelte');
+const overlayApp = source('../src/renderer/overlay/App.svelte');
+const overlayCss = source('../src/renderer/overlay/app.css');
+
+describe('overlay transcript follow', () => {
+  test('renders one, two, and three-or-more lines in full while showing only a two-line viewport', () => {
+    expect(textDisplay).toContain('class="h-11 overflow-hidden');
+    expect(textDisplay).toContain('leading-[22px]');
+    expect(textDisplay).not.toContain('line-clamp-2');
+    expect(textDisplay).toMatch(/<p class="[^"]+">\s*\{text\}\s*<\/p>/);
+  });
+
+  test('supports the quick and long overlay widths without changing transcript flow', () => {
+    expect(textDisplay).toContain("mode === 'long' ? 'w-full max-w-[320px]' : 'w-full max-w-[280px]'");
+    expect(textDisplay).toContain('break-words');
+  });
+
+  test('follows the newest line after each rendered partial update, including rapid appends', () => {
+    expect(textDisplay).toContain("import { tick } from 'svelte'");
+    expect(textDisplay).toContain('tick().then(() => {');
+    expect(textDisplay).toContain('scrollRef.scrollTop = scrollRef.scrollHeight');
+    expect(textDisplay).toContain('scrollRef.scrollHeight > scrollRef.clientHeight');
+    expect(textDisplay).toContain('if (!scrollRef || !text) return;');
+  });
+
+  test('clears overflow treatment between dictation sessions', () => {
+    expect(textDisplay).toContain('if (!text) {');
+    expect(textDisplay).toContain('isOverflowing = false;');
+    expect(overlayApp).toMatch(/transcriptionText = '';\s+transcriptionType = 'partial';/);
+  });
+
+  test('preserves noninteractive and reduced-motion accessibility protections', () => {
+    expect(overlayApp).toContain('aria-hidden="true"');
+    expect(overlayApp).not.toMatch(/<button|tabindex=|on(?:click|pointer|mouse)/);
+    expect(overlayCss).toContain('@media (forced-colors: active)');
+    expect(overlayCss).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(overlayCss).toContain('scroll-behavior: auto !important;');
+  });
+});


### PR DESCRIPTION
## Summary
- remove the paragraph clamp so transcript content can overflow the fixed two-line viewport
- retain tick-then-follow-bottom, the fixed viewport, fade treatment, and full DOM text
- add focused follow-scroll and accessibility regression coverage

## Validation
- un test tests/overlay-transcript-follow.test.ts tests/gate5-accessibility.test.ts (11 passing tests, 52 assertions)
- git diff --check`n
## Environment note
The clean clone has no dependency tree. A hash-matched Windows dependency junction was used without installing dependencies; its tree is incomplete (@esbuild/win32-x64, Electron command shim, and compiler transitive corn are absent), so the unrelated full-suite Gate 2/Gate 5 checks and type/build matrix cannot complete locally. Hosted CI is requested as the authoritative full matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved overlay transcript scrolling so the latest text stays visible as new content appears.
  * Updated transcript display to support natural multi-line wrapping within its viewing area.
  * Improved handling when transcripts are empty or when a new dictation session begins.
  * Preserved accessibility behavior, including reduced-motion and forced-colors support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->