### PR TITLE
Add Home and shared server status

### DIFF
--- a/app/src/main/preload/main.ts
+++ b/app/src/main/preload/main.ts
@@ -170,16 +170,20 @@ const murmurMainAPI = {
     return ipcRenderer.invoke(IPC_CHANNELS.SERVER_GET_LOGS);
   },
 
-  onServerStateChange: (callback: (state: ServerStatePayload) => void): void => {
-    ipcRenderer.on(IPC_CHANNELS.SERVER_STATE_CHANGE, (_event, state) => {
+  onServerStateChange: (callback: (state: ServerStatePayload) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, state: ServerStatePayload) => {
       callback(state);
-    });
+    };
+    ipcRenderer.on(IPC_CHANNELS.SERVER_STATE_CHANGE, handler);
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.SERVER_STATE_CHANGE, handler);
   },
 
-  onServerLog: (callback: (entry: ServerLogEntry) => void): void => {
-    ipcRenderer.on(IPC_CHANNELS.SERVER_LOG, (_event, entry) => {
+  onServerLog: (callback: (entry: ServerLogEntry) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, entry: ServerLogEntry) => {
       callback(entry);
-    });
+    };
+    ipcRenderer.on(IPC_CHANNELS.SERVER_LOG, handler);
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.SERVER_LOG, handler);
   },
 
   removeServerListeners: (): void => {

--- a/app/src/renderer/app/App.svelte
+++ b/app/src/renderer/app/App.svelte
@@ -1,19 +1,23 @@
 <script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
   import TitleBar from './components/TitleBar.svelte';
   import Toasts from './components/Toasts.svelte';
   import HistoryView from './views/HistoryView.svelte';
   import InsightsView from './views/InsightsView.svelte';
   import SettingsView from './views/SettingsView.svelte';
+  import HomeView from './views/HomeView.svelte';
   import TestView from './views/TestView.svelte';
   import ModelProgressBanner from './components/ModelProgressBanner.svelte';
+  import { disposeServerStatus, initializeServerStatus, serverStatusState } from './server-status';
 
-  type PrimaryView = 'history' | 'insights' | 'settings';
+  type PrimaryView = 'home' | 'history' | 'insights' | 'settings';
   type View = PrimaryView | 'test';
 
-  let activeView = $state<View>('history');
+  let activeView = $state<View>('home');
   let settingsVisited = $state(false);
 
   const primaryTabs: Array<{ id: PrimaryView; label: string }> = [
+    { id: 'home', label: 'Home' },
     { id: 'history', label: 'History' },
     { id: 'insights', label: 'Insights' },
     { id: 'settings', label: 'Settings' },
@@ -24,7 +28,7 @@
 
   function resolveView(candidate: string): View {
     const match = developmentTabs.find((tab) => tab.id === candidate);
-    return match?.id ?? 'history';
+    return match?.id ?? 'home';
   }
 
   function selectView(candidate: string) {
@@ -32,6 +36,9 @@
     if (nextView === 'settings') settingsVisited = true;
     activeView = nextView;
   }
+
+  onMount(() => initializeServerStatus());
+  onDestroy(disposeServerStatus);
 </script>
 
 <div class="flex h-screen flex-col overflow-hidden bg-[#08090a] text-zinc-100">
@@ -60,8 +67,13 @@
   </header>
 
   <ModelProgressBanner visible />
+  <p class="sr-only" aria-live="polite" aria-atomic="true">{$serverStatusState.announcement}</p>
 
   <main id="main-content" class="flex-1 overflow-hidden" tabindex="-1">
+    {#if activeView === 'home'}
+      <HomeView onNavigate={selectView} />
+    {/if}
+
     {#if activeView === 'history'}
       <HistoryView />
     {/if}

--- a/app/src/renderer/app/components/ModelProgressBanner.svelte
+++ b/app/src/renderer/app/components/ModelProgressBanner.svelte
@@ -18,7 +18,14 @@
       <section class="rounded-xl border border-red-900/60 bg-zinc-950/95 p-4 shadow-lg">
         <p class="text-sm font-medium text-red-300 text-pretty">Speech model setup failed</p>
         <p class="mt-1 text-xs text-red-300/80 text-pretty">
-          {modelDownload.detail ?? 'Check your connection.'} Open Server and use Restart to retry.
+          {modelDownload.detail ?? 'Check your connection.'} Open Settings &gt; Advanced for details.
+          {#if $serverStatusState.state?.managed}
+            You can restart the managed server there.
+          {:else if $serverStatusState.state}
+            Eve cannot restart an external server.
+          {:else}
+            Management mode cannot be confirmed yet.
+          {/if}
         </p>
       </section>
     {:else}

--- a/app/src/renderer/app/components/ModelProgressBanner.svelte
+++ b/app/src/renderer/app/components/ModelProgressBanner.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { shouldShowModelProgress } from '$shared/model-progress';
   import ModelProgressCard from './ModelProgressCard.svelte';
-  import { serverStatusState } from '../server-status';
+  import { getServerManagementMode, serverStatusState } from '../server-status';
 
   let { visible = true }: { visible?: boolean } = $props();
   let modelDownload = $derived($serverStatusState.state?.modelDownload);
   let showBanner = $derived(
     modelDownload?.status === 'error' || shouldShowModelProgress(modelDownload)
   );
+  let managementMode = $derived(getServerManagementMode($serverStatusState));
 </script>
 
 {#if visible && modelDownload && showBanner}
@@ -19,9 +20,9 @@
         <p class="text-sm font-medium text-red-300 text-pretty">Speech model setup failed</p>
         <p class="mt-1 text-xs text-red-300/80 text-pretty">
           {modelDownload.detail ?? 'Check your connection.'} Open Settings &gt; Advanced for details.
-          {#if $serverStatusState.state?.managed}
+          {#if managementMode === 'managed'}
             You can restart the managed server there.
-          {:else if $serverStatusState.state}
+          {:else if managementMode === 'external'}
             Eve cannot restart an external server.
           {:else}
             Management mode cannot be confirmed yet.

--- a/app/src/renderer/app/components/ModelProgressBanner.svelte
+++ b/app/src/renderer/app/components/ModelProgressBanner.svelte
@@ -1,29 +1,13 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import type { ServerStatePayload } from '$shared/types';
   import { shouldShowModelProgress } from '$shared/model-progress';
   import ModelProgressCard from './ModelProgressCard.svelte';
+  import { serverStatusState } from '../server-status';
 
   let { visible = true }: { visible?: boolean } = $props();
-  let serverState = $state<ServerStatePayload | null>(null);
-  let modelDownload = $derived(serverState?.modelDownload);
+  let modelDownload = $derived($serverStatusState.state?.modelDownload);
   let showBanner = $derived(
     modelDownload?.status === 'error' || shouldShowModelProgress(modelDownload)
   );
-
-  async function refreshServerState() {
-    try {
-      serverState = await window.murmurMain.getServerStatus();
-    } catch {
-      // The managed server can be unavailable briefly while the app starts.
-    }
-  }
-
-  onMount(() => {
-    void refreshServerState();
-    const timer = window.setInterval(refreshServerState, 3000);
-    return () => window.clearInterval(timer);
-  });
 </script>
 
 {#if visible && modelDownload && showBanner}
@@ -31,14 +15,14 @@
     class="pointer-events-none fixed left-1/2 top-[calc(env(safe-area-inset-top)+7rem)] z-20 w-[calc(100%-2rem)] max-w-2xl -translate-x-1/2"
   >
     {#if modelDownload.status === 'error'}
-      <section aria-live="assertive" class="rounded-xl border border-red-900/60 bg-zinc-950/95 p-4 shadow-lg">
+      <section class="rounded-xl border border-red-900/60 bg-zinc-950/95 p-4 shadow-lg">
         <p class="text-sm font-medium text-red-300 text-pretty">Speech model setup failed</p>
         <p class="mt-1 text-xs text-red-300/80 text-pretty">
           {modelDownload.detail ?? 'Check your connection.'} Open Server and use Restart to retry.
         </p>
       </section>
     {:else}
-      <ModelProgressCard state={modelDownload} />
+      <ModelProgressCard state={modelDownload} announce={false} />
     {/if}
   </div>
 {/if}

--- a/app/src/renderer/app/components/ModelProgressCard.svelte
+++ b/app/src/renderer/app/components/ModelProgressCard.svelte
@@ -2,14 +2,14 @@
   import type { ModelDownloadState } from '$shared/types';
   import { getModelProgressView } from '$shared/model-progress';
 
-  let { state }: { state?: ModelDownloadState } = $props();
+  let { state, announce = false }: { state?: ModelDownloadState; announce?: boolean } = $props();
   let view = $derived(getModelProgressView(state));
 </script>
 
 {#if view}
   <section
-    aria-live="polite"
-    aria-atomic="true"
+    aria-live={announce ? 'polite' : undefined}
+    aria-atomic={announce ? 'true' : undefined}
     class="rounded-xl border border-amber-900/60 bg-zinc-950/95 p-4 shadow-lg"
   >
     <div class="flex items-start justify-between gap-4">

--- a/app/src/renderer/app/server-status.ts
+++ b/app/src/renderer/app/server-status.ts
@@ -1,0 +1,151 @@
+import { writable } from 'svelte/store';
+import { shouldShowModelProgress } from '$shared/model-progress';
+import type { ServerStatePayload } from '$shared/types';
+
+export type ServerStatusPhase =
+  | 'connecting'
+  | 'stale'
+  | 'unavailable'
+  | 'missing'
+  | 'partial'
+  | 'checking'
+  | 'downloading'
+  | 'loading'
+  | 'ready'
+  | 'error';
+
+export interface SharedServerStatus {
+  state: ServerStatePayload | null;
+  phase: ServerStatusPhase;
+  announcement: string;
+}
+
+const initialStatus: SharedServerStatus = {
+  state: null,
+  phase: 'connecting',
+  announcement: 'Checking Eve speech readiness.',
+};
+
+export const serverStatusState = writable<SharedServerStatus>(initialStatus);
+
+export function getServerStatusPhase(state: ServerStatePayload | null): ServerStatusPhase {
+  if (!state) return 'unavailable';
+  if (state.status === 'error' || state.engineStatus?.status === 'error' || state.modelDownload?.status === 'error') {
+    return 'error';
+  }
+  if (state.status === 'starting' || state.status === 'stopping') return 'connecting';
+
+  const model = state.modelDownload;
+  if (model?.phase === 'checking') return 'checking';
+  if (model?.phase === 'downloading' || model?.status === 'downloading') return 'downloading';
+  if (model?.phase === 'loading' || state.engineStatus?.status === 'loading') return 'loading';
+  if (model?.status === 'missing') return 'missing';
+  if (model?.status === 'partial') return 'partial';
+  if (state.status === 'running' && state.engineStatus?.status === 'ready') return 'ready';
+  if (state.status === 'idle') return 'stale';
+  return 'unavailable';
+}
+
+function phaseAnnouncement(phase: ServerStatusPhase, state: ServerStatePayload | null): string {
+  const model = state?.modelDownload?.model;
+  switch (phase) {
+    case 'connecting': return 'Connecting to Eve speech services.';
+    case 'stale': return 'Speech readiness is being refreshed.';
+    case 'unavailable': return 'Speech service is unavailable.';
+    case 'missing': return model ? `${model} is not prepared.` : 'A speech model is not prepared.';
+    case 'partial': return model ? `${model} has a partial download.` : 'A speech model has a partial download.';
+    case 'checking': return 'Checking speech model files.';
+    case 'downloading': return 'Downloading the speech model.';
+    case 'loading': return 'Loading the speech model.';
+    case 'ready': return 'Speech model is ready.';
+    case 'error': return 'Speech model setup needs attention.';
+  }
+}
+
+function milestone(state: ServerStatePayload | null): number | null {
+  const percent = state?.modelDownload?.progress_percent;
+  return typeof percent === 'number' && Number.isFinite(percent) ? Math.floor(percent / 25) : null;
+}
+
+let current = initialStatus;
+let unsubscribe: (() => void) | null = null;
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+let pollInFlight = false;
+let initialized = false;
+let announcedMilestone: number | null = null;
+
+function reseedOnFocus(): void {
+  void refresh();
+}
+
+function publish(state: ServerStatePayload | null): void {
+  const phase = getServerStatusPhase(state);
+  const nextMilestone = milestone(state);
+  const phaseChanged = phase !== current.phase;
+  const milestoneChanged = phase === 'downloading' && nextMilestone !== null && nextMilestone !== announcedMilestone;
+  const announcement = phaseChanged || milestoneChanged
+    ? (milestoneChanged ? `Speech model download ${nextMilestone * 25}% complete.` : phaseAnnouncement(phase, state))
+    : current.announcement;
+
+  announcedMilestone = nextMilestone;
+  current = { state, phase, announcement };
+  serverStatusState.set(current);
+  schedulePoll();
+}
+
+function clearPoll(): void {
+  if (pollTimer !== null) {
+    clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+}
+
+function schedulePoll(): void {
+  clearPoll();
+  if (!current.state || !shouldShowModelProgress(current.state.modelDownload) || !initialized) return;
+  pollTimer = setTimeout(() => void refresh(), 3000);
+}
+
+export async function refresh(): Promise<void> {
+  if (pollInFlight) return;
+  pollInFlight = true;
+  try {
+    publish(await window.murmurMain.getServerStatus());
+  } catch {
+    // A failed reseed must clear the old state rather than continuing to show Ready.
+    publish(null);
+  } finally {
+    pollInFlight = false;
+  }
+}
+
+export function initializeServerStatus(): void {
+  if (initialized) return;
+  initialized = true;
+  current = initialStatus;
+  announcedMilestone = null;
+  serverStatusState.set(current);
+  unsubscribe = window.murmurMain.onServerStateChange((state) => publish(state));
+  window.addEventListener('focus', reseedOnFocus);
+  void refresh();
+}
+
+export function disposeServerStatus(): void {
+  initialized = false;
+  clearPoll();
+  unsubscribe?.();
+  unsubscribe = null;
+  window.removeEventListener('focus', reseedOnFocus);
+  pollInFlight = false;
+}
+
+export async function retryManagedServer(): Promise<boolean> {
+  if (!current.state?.managed) return false;
+  try {
+    publish(await window.murmurMain.restartServer());
+    return true;
+  } catch {
+    publish(null);
+    return false;
+  }
+}

--- a/app/src/renderer/app/server-status.ts
+++ b/app/src/renderer/app/server-status.ts
@@ -18,15 +18,27 @@ export interface SharedServerStatus {
   state: ServerStatePayload | null;
   phase: ServerStatusPhase;
   announcement: string;
+  configuredExternalServer: boolean | null;
 }
 
 const initialStatus: SharedServerStatus = {
   state: null,
   phase: 'connecting',
   announcement: 'Checking Eve speech readiness.',
+  configuredExternalServer: null,
 };
 
 export const serverStatusState = writable<SharedServerStatus>(initialStatus);
+
+export type ServerManagementMode = 'managed' | 'external' | 'unknown';
+
+export function getServerManagementMode(status: SharedServerStatus): ServerManagementMode {
+  if (status.configuredExternalServer === true || (status.state !== null && !status.state.managed)) {
+    return 'external';
+  }
+  if (status.state?.managed) return 'managed';
+  return 'unknown';
+}
 
 export function getServerStatusPhase(state: ServerStatePayload | null): ServerStatusPhase {
   if (!state) return 'unavailable';
@@ -75,8 +87,13 @@ let current = initialStatus;
 let unsubscribe: (() => void) | null = null;
 let pollTimer: ReturnType<typeof setTimeout> | null = null;
 let pollInFlight = false;
+let retryInFlight = false;
 let initialized = false;
 let announcedMilestone: number | null = null;
+let lifecycleGeneration = 0;
+let eventRevision = 0;
+let pollRequestGeneration = 0;
+let retryRequestGeneration = 0;
 
 function reseedOnFocus(): void {
   void refresh();
@@ -92,9 +109,24 @@ function publish(state: ServerStatePayload | null): void {
     : current.announcement;
 
   announcedMilestone = nextMilestone;
-  current = { state, phase, announcement };
+  current = { ...current, state, phase, announcement };
   serverStatusState.set(current);
   schedulePoll();
+}
+
+function setConfiguredExternalServer(configuredExternalServer: boolean): void {
+  current = { ...current, configuredExternalServer };
+  serverStatusState.set(current);
+}
+
+async function refreshConfiguredExternalServer(): Promise<void> {
+  const requestLifecycle = lifecycleGeneration;
+  try {
+    const settings = await window.murmurMain.getSettings();
+    if (requestLifecycle === lifecycleGeneration) setConfiguredExternalServer(settings.useExternalServer);
+  } catch {
+    // Keep management mode unknown when its settings cannot be read.
+  }
 }
 
 function clearPoll(): void {
@@ -111,45 +143,66 @@ function schedulePoll(): void {
 }
 
 export async function refresh(): Promise<void> {
-  if (pollInFlight) return;
+  if (!initialized || pollInFlight) return;
   pollInFlight = true;
+  const requestLifecycle = lifecycleGeneration;
+  const requestEventRevision = eventRevision;
+  const requestGeneration = ++pollRequestGeneration;
   try {
-    publish(await window.murmurMain.getServerStatus());
+    const state = await window.murmurMain.getServerStatus();
+    if (requestLifecycle === lifecycleGeneration && requestEventRevision === eventRevision) publish(state);
   } catch {
     // A failed reseed must clear the old state rather than continuing to show Ready.
-    publish(null);
+    if (requestLifecycle === lifecycleGeneration && requestEventRevision === eventRevision) publish(null);
   } finally {
-    pollInFlight = false;
+    if (requestLifecycle === lifecycleGeneration && requestGeneration === pollRequestGeneration) pollInFlight = false;
   }
 }
 
 export function initializeServerStatus(): void {
   if (initialized) return;
+  lifecycleGeneration += 1;
+  eventRevision += 1;
   initialized = true;
   current = initialStatus;
   announcedMilestone = null;
   serverStatusState.set(current);
-  unsubscribe = window.murmurMain.onServerStateChange((state) => publish(state));
+  unsubscribe = window.murmurMain.onServerStateChange((state) => {
+    eventRevision += 1;
+    publish(state);
+  });
   window.addEventListener('focus', reseedOnFocus);
+  void refreshConfiguredExternalServer();
   void refresh();
 }
 
 export function disposeServerStatus(): void {
+  lifecycleGeneration += 1;
+  eventRevision += 1;
   initialized = false;
   clearPoll();
   unsubscribe?.();
   unsubscribe = null;
   window.removeEventListener('focus', reseedOnFocus);
   pollInFlight = false;
+  retryInFlight = false;
 }
 
 export async function retryManagedServer(): Promise<boolean> {
-  if (!current.state?.managed) return false;
+  if (!initialized || !current.state?.managed || retryInFlight) return false;
+  retryInFlight = true;
+  const requestLifecycle = lifecycleGeneration;
+  const requestEventRevision = eventRevision;
+  const requestGeneration = ++retryRequestGeneration;
   try {
-    publish(await window.murmurMain.restartServer());
+    const state = await window.murmurMain.restartServer();
+    if (requestLifecycle !== lifecycleGeneration || requestEventRevision !== eventRevision) return false;
+    publish(state);
     return true;
   } catch {
-    publish(null);
+    if (requestLifecycle === lifecycleGeneration && requestEventRevision === eventRevision) publish(null);
     return false;
+  } finally {
+    if (requestLifecycle === lifecycleGeneration && requestGeneration === retryRequestGeneration) retryInFlight = false;
   }
 }

--- a/app/src/renderer/app/server-status.ts
+++ b/app/src/renderer/app/server-status.ts
@@ -62,9 +62,13 @@ function phaseAnnouncement(phase: ServerStatusPhase, state: ServerStatePayload |
   }
 }
 
+export function getDownloadMilestone(percent?: number): number | null {
+  if (typeof percent !== 'number' || !Number.isFinite(percent) || percent < 25) return null;
+  return Math.min(100, Math.floor(percent / 25) * 25);
+}
+
 function milestone(state: ServerStatePayload | null): number | null {
-  const percent = state?.modelDownload?.progress_percent;
-  return typeof percent === 'number' && Number.isFinite(percent) ? Math.floor(percent / 25) : null;
+  return getDownloadMilestone(state?.modelDownload?.progress_percent);
 }
 
 let current = initialStatus;
@@ -84,7 +88,7 @@ function publish(state: ServerStatePayload | null): void {
   const phaseChanged = phase !== current.phase;
   const milestoneChanged = phase === 'downloading' && nextMilestone !== null && nextMilestone !== announcedMilestone;
   const announcement = phaseChanged || milestoneChanged
-    ? (milestoneChanged ? `Speech model download ${nextMilestone * 25}% complete.` : phaseAnnouncement(phase, state))
+    ? (milestoneChanged ? `Speech model download ${nextMilestone}% complete.` : phaseAnnouncement(phase, state))
     : current.announcement;
 
   announcedMilestone = nextMilestone;

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import ModelProgressCard from '../components/ModelProgressCard.svelte';
+  import { shouldShowModelProgress } from '$shared/model-progress';
+  import type { ServerStatusPhase } from '../server-status';
+  import { retryManagedServer, serverStatusState } from '../server-status';
+
+  interface Props {
+    onNavigate: (view: 'history' | 'insights' | 'settings') => void;
+  }
+
+  let { onNavigate }: Props = $props();
+  let quickHotkey = $state('Checking shortcut…');
+  let longHotkey = $state('Checking shortcut…');
+  let shortcutsError = $state(false);
+  let snapshot = $derived($serverStatusState);
+  let server = $derived(snapshot.state);
+  let engine = $derived(server?.engineStatus?.info);
+  let model = $derived(server?.modelDownload ?? null);
+  let showModelProgress = $derived(shouldShowModelProgress(model ?? undefined));
+
+  const phaseCopy: Record<ServerStatusPhase, { title: string; detail: string }> = {
+    connecting: { title: 'Connecting', detail: 'Checking the local speech service.' },
+    stale: { title: 'Refreshing readiness', detail: 'Waiting for a current speech-service status.' },
+    unavailable: { title: 'Speech service unavailable', detail: 'Eve cannot currently confirm speech readiness.' },
+    missing: { title: 'Speech model not prepared', detail: 'Open Settings to prepare the selected model.' },
+    partial: { title: 'Speech model needs completion', detail: 'Open Settings to continue preparing the selected model.' },
+    checking: { title: 'Checking model files', detail: 'Looking for the selected speech model.' },
+    downloading: { title: 'Preparing speech model', detail: 'The selected model is downloading in the background.' },
+    loading: { title: 'Loading speech model', detail: 'The selected model is being loaded into memory.' },
+    ready: { title: 'Ready for dictation', detail: 'Eve can accept Quick and Long dictation.' },
+    error: { title: 'Speech setup needs attention', detail: 'Open Settings for the current speech-service details.' },
+  };
+
+  let readiness = $derived(phaseCopy[snapshot.phase]);
+  let externalMode = $derived(server !== null && !server.managed);
+
+  onMount(async () => {
+    try {
+      const settings = await window.murmurMain.getSettings();
+      [quickHotkey, longHotkey] = await Promise.all([
+        window.murmurMain.getHotkeyDisplayName(settings.hotkey),
+        window.murmurMain.getHotkeyDisplayName(settings.longHotkey),
+      ]);
+    } catch {
+      shortcutsError = true;
+      quickHotkey = 'Shortcut unavailable';
+      longHotkey = 'Shortcut unavailable';
+    }
+  });
+
+  function retry(): void {
+    void retryManagedServer();
+  }
+</script>
+
+<div class="h-full overflow-y-auto p-4 sm:p-6">
+  <div class="mx-auto flex max-w-4xl flex-col gap-5">
+    <section class="rounded-2xl border border-white/10 bg-white/[0.03] p-5 sm:p-6" aria-labelledby="home-readiness-heading">
+      <p class="text-xs font-medium uppercase tracking-[0.16em] text-zinc-500">Eve</p>
+      <div class="mt-3 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 id="home-readiness-heading" class="text-2xl font-semibold text-zinc-50">{readiness.title}</h1>
+          <p class="mt-1 max-w-xl text-sm text-zinc-400">{readiness.detail}</p>
+        </div>
+        {#if externalMode}
+          <p class="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
+            External server — Eve cannot restart this endpoint.
+          </p>
+        {:else if snapshot.phase === 'error' || snapshot.phase === 'unavailable'}
+          <button
+            type="button"
+            onclick={retry}
+            disabled={!server?.managed}
+            class="rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08090a]
+              {server?.managed ? 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer' : 'bg-zinc-800 text-zinc-500 cursor-not-allowed'}"
+          >
+            Retry managed server
+          </button>
+        {/if}
+      </div>
+
+      <dl class="mt-5 grid gap-3 sm:grid-cols-2">
+        <div class="rounded-xl border border-white/10 bg-black/20 p-3">
+          <dt class="text-xs font-medium uppercase tracking-[0.12em] text-zinc-500">Current engine</dt>
+          <dd class="mt-1 text-sm text-zinc-100">{engine?.name ?? server?.engineStatus?.current ?? 'Checking current engine…'}</dd>
+        </div>
+        <div class="rounded-xl border border-white/10 bg-black/20 p-3">
+          <dt class="text-xs font-medium uppercase tracking-[0.12em] text-zinc-500">Selected model</dt>
+          <dd class="mt-1 text-sm text-zinc-100">{model?.model ?? engine?.model ?? 'Checking selected model…'}</dd>
+        </div>
+      </dl>
+
+      {#if engine}
+        <p class="mt-4 text-xs leading-5 text-zinc-400">
+          {engine.languages.length > 0 ? `Languages: ${engine.languages.join(', ')}.` : 'Language coverage is not reported by the current engine.'}
+          {#if engine.model_size_gb > 0} Approx. {engine.model_size_gb.toFixed(1)} GB.{/if}
+          {#if engine.device} Running on {engine.device}.{/if}
+        </p>
+      {/if}
+
+      {#if model && snapshot.phase === 'downloading'}
+        <p class="mt-4 text-sm text-zinc-300">
+          {#if typeof model.downloaded_bytes === 'number' && typeof model.total_bytes === 'number' && model.total_bytes > 0}
+            Download progress is available in the preparation banner.
+          {:else}
+            Downloading with progress details still being established.
+          {/if}
+        </p>
+      {/if}
+
+      {#if showModelProgress}
+        <div class="mt-4 max-w-2xl">
+          <ModelProgressCard state={model ?? undefined} announce={false} />
+        </div>
+      {/if}
+    </section>
+
+    <section class="grid gap-4 lg:grid-cols-2" aria-label="Dictation shortcuts and guidance">
+      <article class="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+        <h2 class="text-base font-semibold text-zinc-100">Quick dictation</h2>
+        <p class="mt-1 text-sm text-zinc-400">Use for short, immediate speech-to-text input.</p>
+        <p class="mt-4 font-mono text-sm text-zinc-200">{quickHotkey}</p>
+      </article>
+      <article class="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+        <h2 class="text-base font-semibold text-zinc-100">Long dictation</h2>
+        <p class="mt-1 text-sm text-zinc-400">Use for longer recordings that Eve processes after capture.</p>
+        <p class="mt-4 font-mono text-sm text-zinc-200">{longHotkey}</p>
+      </article>
+    </section>
+
+    <section class="rounded-2xl border border-white/10 bg-white/[0.03] p-5" aria-labelledby="home-privacy-heading">
+      <h2 id="home-privacy-heading" class="text-base font-semibold text-zinc-100">Private by design</h2>
+      <p class="mt-1 text-sm leading-6 text-zinc-400">Speech processing uses your configured local or external speech service. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
+      {#if shortcutsError}
+        <p class="mt-3 text-xs text-zinc-500">Shortcut labels could not be read. Open Settings to review them.</p>
+      {/if}
+    </section>
+
+    <nav aria-label="Home actions" class="flex flex-wrap gap-2">
+      <button type="button" onclick={() => onNavigate('history')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Open History</button>
+      <button type="button" onclick={() => onNavigate('insights')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Open Insights</button>
+      <button type="button" onclick={() => onNavigate('settings')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Open Settings</button>
+    </nav>
+  </div>
+</div>

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -13,6 +13,7 @@
   let quickHotkey = $state('Checking shortcut…');
   let longHotkey = $state('Checking shortcut…');
   let shortcutsError = $state(false);
+  let useExternalServer = $state<boolean | null>(null);
   let snapshot = $derived($serverStatusState);
   let server = $derived(snapshot.state);
   let engine = $derived(server?.engineStatus?.info);
@@ -33,11 +34,13 @@
   };
 
   let readiness = $derived(phaseCopy[snapshot.phase]);
-  let externalMode = $derived(server !== null && !server.managed);
+  let externalMode = $derived(useExternalServer === true || (server !== null && !server.managed));
+  let managementModeUnknown = $derived(server === null && useExternalServer === null);
 
   onMount(async () => {
     try {
       const settings = await window.murmurMain.getSettings();
+      useExternalServer = settings.useExternalServer;
       [quickHotkey, longHotkey] = await Promise.all([
         window.murmurMain.getHotkeyDisplayName(settings.hotkey),
         window.murmurMain.getHotkeyDisplayName(settings.longHotkey),
@@ -67,7 +70,7 @@
           <p class="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
             External server — Eve cannot restart this endpoint.
           </p>
-        {:else if snapshot.phase === 'error' || snapshot.phase === 'unavailable'}
+        {:else if server?.managed && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
           <button
             type="button"
             onclick={retry}
@@ -77,6 +80,10 @@
           >
             Retry managed server
           </button>
+        {:else if managementModeUnknown && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
+          <p class="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
+            Management mode cannot be confirmed. Open Settings &gt; Advanced.
+          </p>
         {/if}
       </div>
 
@@ -130,8 +137,8 @@
     </section>
 
     <section class="rounded-2xl border border-white/10 bg-white/[0.03] p-5" aria-labelledby="home-privacy-heading">
-      <h2 id="home-privacy-heading" class="text-base font-semibold text-zinc-100">Private by design</h2>
-      <p class="mt-1 text-sm leading-6 text-zinc-400">Speech processing uses your configured local or external speech service. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
+      <h2 id="home-privacy-heading" class="text-base font-semibold text-zinc-100">Processing and privacy</h2>
+      <p class="mt-1 text-sm leading-6 text-zinc-400">By default, Eve processes speech locally. If you configure an external endpoint, audio is sent to that endpoint under your control. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
       {#if shortcutsError}
         <p class="mt-3 text-xs text-zinc-500">Shortcut labels could not be read. Open Settings to review them.</p>
       {/if}

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -3,7 +3,7 @@
   import ModelProgressCard from '../components/ModelProgressCard.svelte';
   import { shouldShowModelProgress } from '$shared/model-progress';
   import type { ServerStatusPhase } from '../server-status';
-  import { retryManagedServer, serverStatusState } from '../server-status';
+  import { getServerManagementMode, retryManagedServer, serverStatusState } from '../server-status';
 
   interface Props {
     onNavigate: (view: 'history' | 'insights' | 'settings') => void;
@@ -13,7 +13,7 @@
   let quickHotkey = $state('Checking shortcut…');
   let longHotkey = $state('Checking shortcut…');
   let shortcutsError = $state(false);
-  let useExternalServer = $state<boolean | null>(null);
+  let retrying = $state(false);
   let snapshot = $derived($serverStatusState);
   let server = $derived(snapshot.state);
   let engine = $derived(server?.engineStatus?.info);
@@ -34,26 +34,34 @@
   };
 
   let readiness = $derived(phaseCopy[snapshot.phase]);
-  let externalMode = $derived(useExternalServer === true || (server !== null && !server.managed));
-  let managementModeUnknown = $derived(server === null && useExternalServer === null);
+  let managementMode = $derived(getServerManagementMode(snapshot));
 
-  onMount(async () => {
-    try {
-      const settings = await window.murmurMain.getSettings();
-      useExternalServer = settings.useExternalServer;
-      [quickHotkey, longHotkey] = await Promise.all([
-        window.murmurMain.getHotkeyDisplayName(settings.hotkey),
-        window.murmurMain.getHotkeyDisplayName(settings.longHotkey),
-      ]);
-    } catch {
-      shortcutsError = true;
-      quickHotkey = 'Shortcut unavailable';
-      longHotkey = 'Shortcut unavailable';
+  onMount(() => {
+    async function loadSettings(): Promise<void> {
+      try {
+        const settings = await window.murmurMain.getSettings();
+        [quickHotkey, longHotkey] = await Promise.all([
+          window.murmurMain.getHotkeyDisplayName(settings.hotkey),
+          window.murmurMain.getHotkeyDisplayName(settings.longHotkey),
+        ]);
+      } catch {
+        shortcutsError = true;
+        quickHotkey = 'Shortcut unavailable';
+        longHotkey = 'Shortcut unavailable';
+      }
     }
+
+    void loadSettings();
   });
 
-  function retry(): void {
-    void retryManagedServer();
+  async function retry(): Promise<void> {
+    if (retrying) return;
+    retrying = true;
+    try {
+      await retryManagedServer();
+    } finally {
+      retrying = false;
+    }
   }
 </script>
 
@@ -66,7 +74,7 @@
           <h1 id="home-readiness-heading" class="text-2xl font-semibold text-zinc-50">{readiness.title}</h1>
           <p class="mt-1 max-w-xl text-sm text-zinc-400">{readiness.detail}</p>
         </div>
-        {#if externalMode}
+        {#if managementMode === 'external'}
           <p class="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
             External server — Eve cannot restart this endpoint.
           </p>
@@ -74,13 +82,13 @@
           <button
             type="button"
             onclick={retry}
-            disabled={!server?.managed}
-            class="rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08090a]
-              {server?.managed ? 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer' : 'bg-zinc-800 text-zinc-500 cursor-not-allowed'}"
+            disabled={retrying}
+            class="rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08090a]
+              {retrying ? 'bg-zinc-800 text-zinc-500 cursor-not-allowed' : 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer'}"
           >
-            Retry managed server
+            {retrying ? 'Retrying…' : 'Retry managed server'}
           </button>
-        {:else if managementModeUnknown && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
+        {:else if managementMode === 'unknown' && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
           <p class="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
             Management mode cannot be confirmed. Open Settings &gt; Advanced.
           </p>
@@ -145,9 +153,9 @@
     </section>
 
     <nav aria-label="Home actions" class="flex flex-wrap gap-2">
-      <button type="button" onclick={() => onNavigate('history')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Open History</button>
-      <button type="button" onclick={() => onNavigate('insights')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Open Insights</button>
-      <button type="button" onclick={() => onNavigate('settings')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Open Settings</button>
+      <button type="button" onclick={() => onNavigate('history')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100">Open History</button>
+      <button type="button" onclick={() => onNavigate('insights')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100">Open Insights</button>
+      <button type="button" onclick={() => onNavigate('settings')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100">Open Settings</button>
     </nav>
   </div>
 </div>

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -6,6 +6,7 @@
   import ModelProgressCard from '../components/ModelProgressCard.svelte';
   import type { ServerStatePayload, ServerLogEntry, Settings } from '$shared/types';
   import { shouldShowModelProgress } from '$shared/model-progress';
+  import { serverStatusState } from '../server-status';
 
   interface Props {
     embedded?: boolean;
@@ -14,10 +15,11 @@
   let { embedded = false }: Props = $props();
 
   // Server state
-  let serverState = $state<ServerStatePayload>({
+  const unavailableState: ServerStatePayload = {
     status: 'idle',
     managed: false,
-  });
+  };
+  let serverState = $derived($serverStatusState.state ?? unavailableState);
   let logs = $state<ServerLogEntry[]>([]);
   let showLogs = $state(false);
   let autoStart = $state(true);
@@ -30,6 +32,7 @@
   let pendingLogs: ServerLogEntry[] = [];
   let logFrame: number | null = null;
   let scrollAfterLogBatch = false;
+  let removeLogListener: (() => void) | null = null;
 
   // Status badge colors and labels
   const statusConfig: Record<
@@ -190,8 +193,6 @@
   }
 
   onMount(async () => {
-    // Load initial state
-    serverState = await window.murmurMain.getServerStatus();
     logs = await window.murmurMain.getServerLogs();
 
     // Load settings
@@ -199,12 +200,7 @@
     autoStart = settings.serverAutoStart;
     useExternalServer = settings.useExternalServer;
 
-    // Subscribe to state changes
-    window.murmurMain.onServerStateChange((state) => {
-      serverState = state;
-    });
-
-    window.murmurMain.onServerLog((entry) => {
+    removeLogListener = window.murmurMain.onServerLog((entry) => {
       queueLog(entry);
     });
   });
@@ -212,7 +208,8 @@
   onDestroy(() => {
     if (logFrame !== null) cancelAnimationFrame(logFrame);
     if (diagnosticsCopyTimer !== null) clearTimeout(diagnosticsCopyTimer);
-    window.murmurMain.removeServerListeners();
+    removeLogListener?.();
+    removeLogListener = null;
   });
 </script>
 
@@ -276,12 +273,7 @@
               {/if}
               <span class="relative w-3 h-3 rounded-full {statusDisplay.bgColor}"></span>
             </div>
-            <span
-              class="text-lg font-medium {statusDisplay.color}"
-              role="status"
-              aria-live="polite"
-              aria-atomic="true"
-            >
+            <span class="text-lg font-medium {statusDisplay.color}">
               {statusDisplay.label}
             </span>
             {#if !serverState.managed && serverState.status === 'running'}

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -192,17 +192,29 @@
     });
   }
 
-  onMount(async () => {
-    logs = await window.murmurMain.getServerLogs();
+  onMount(() => {
+    let active = true;
 
-    // Load settings
-    const settings = await window.murmurMain.getSettings();
-    autoStart = settings.serverAutoStart;
-    useExternalServer = settings.useExternalServer;
+    async function load(): Promise<void> {
+      const initialLogs = await window.murmurMain.getServerLogs();
+      if (!active) return;
+      logs = initialLogs;
 
-    removeLogListener = window.murmurMain.onServerLog((entry) => {
-      queueLog(entry);
-    });
+      const settings = await window.murmurMain.getSettings();
+      if (!active) return;
+      autoStart = settings.serverAutoStart;
+      useExternalServer = settings.useExternalServer;
+
+      if (!active) return;
+      removeLogListener = window.murmurMain.onServerLog((entry) => {
+        queueLog(entry);
+      });
+    }
+
+    void load();
+    return () => {
+      active = false;
+    };
   });
 
   onDestroy(() => {

--- a/app/src/renderer/global.d.ts
+++ b/app/src/renderer/global.d.ts
@@ -54,8 +54,8 @@ declare global {
       stopServer: () => Promise<ServerStatePayload>;
       restartServer: () => Promise<ServerStatePayload>;
       getServerLogs: () => Promise<ServerLogEntry[]>;
-      onServerStateChange: (callback: (state: ServerStatePayload) => void) => void;
-      onServerLog: (callback: (entry: ServerLogEntry) => void) => void;
+      onServerStateChange: (callback: (state: ServerStatePayload) => void) => () => void;
+      onServerLog: (callback: (entry: ServerLogEntry) => void) => () => void;
       removeServerListeners: () => void;
       getServerSettings: () => Promise<ServerSettingsResponse>;
       updateServerSettings: (patch: Record<string, unknown>) => Promise<ServerSettingsResponse>;

--- a/app/tests/gate5-information-architecture.test.ts
+++ b/app/tests/gate5-information-architecture.test.ts
@@ -10,8 +10,9 @@ const settingsView = source('../src/renderer/app/views/SettingsView.svelte');
 const serverView = source('../src/renderer/app/views/ServerView.svelte');
 
 describe('Gate 5 information architecture', () => {
-  test('keeps production navigation to History, Insights, and Settings', () => {
+  test('keeps production navigation to Home, History, Insights, and Settings', () => {
     expect(appView).toContain("const primaryTabs");
+    expect(appView).toContain("{ id: 'home', label: 'Home' }");
     expect(appView).toContain("{ id: 'history', label: 'History' }");
     expect(appView).toContain("{ id: 'insights', label: 'Insights' }");
     expect(appView).toContain("{ id: 'settings', label: 'Settings' }");
@@ -24,9 +25,9 @@ describe('Gate 5 information architecture', () => {
     expect(appView).toContain("<TestView />");
   });
 
-  test('falls back to History for unknown internal views', () => {
+  test('falls back to Home for unknown internal views', () => {
     expect(appView).toContain("function resolveView");
-    expect(appView).toContain("return match?.id ?? 'history'");
+    expect(appView).toContain("return match?.id ?? 'home'");
   });
 
   test('embeds every existing server surface under Settings Advanced', () => {
@@ -35,7 +36,6 @@ describe('Gate 5 information architecture', () => {
     expect(settingsView).toContain("<ServerView embedded />");
 
     for (const operation of [
-      'getServerStatus',
       'startServer',
       'stopServer',
       'restartServer',
@@ -44,5 +44,6 @@ describe('Gate 5 information architecture', () => {
     ]) {
       expect(serverView).toContain(`window.murmurMain.${operation}`);
     }
+    expect(serverView).toContain('serverStatusState');
   });
 });

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -4,6 +4,7 @@ import { get } from 'svelte/store';
 import {
   disposeServerStatus,
   getDownloadMilestone,
+  getServerManagementMode,
   getServerStatusPhase,
   initializeServerStatus,
   refresh,
@@ -94,6 +95,50 @@ describe('Home and shared server status', () => {
     disposeServerStatus();
   });
 
+  test('does not let an older status snapshot overwrite an event or a new controller lifecycle', async () => {
+    let resolveFirstStatus: ((state: { status: 'running'; managed: boolean; engineStatus: { current: string; status: 'ready' } }) => void) | undefined;
+    const firstStatus = new Promise<{ status: 'running'; managed: boolean; engineStatus: { current: string; status: 'ready' } }>((resolve) => {
+      resolveFirstStatus = resolve;
+    });
+    let stateCallback: ((state: { status: 'running'; managed: boolean; engineStatus: { current: string; status: 'ready' } }) => void) | undefined;
+    const eventStatus = { status: 'running' as const, managed: false, engineStatus: { current: 'event', status: 'ready' as const } };
+    const reinitializedStatus = { status: 'running' as const, managed: true, engineStatus: { current: 'new', status: 'ready' as const } };
+
+    (globalThis as { window: unknown }).window = {
+      murmurMain: {
+        getServerStatus: async () => firstStatus,
+        onServerStateChange: (callback: typeof stateCallback) => { stateCallback = callback; return () => {}; },
+        restartServer: async () => reinitializedStatus,
+      },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    };
+
+    initializeServerStatus();
+    stateCallback?.(eventStatus);
+    resolveFirstStatus?.({ status: 'running', managed: true, engineStatus: { current: 'old', status: 'ready' } });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(get(serverStatusState).state).toEqual(eventStatus);
+
+    disposeServerStatus();
+    let resolveDisposedStatus: ((state: typeof reinitializedStatus) => void) | undefined;
+    const disposedStatus = new Promise<typeof reinitializedStatus>((resolve) => {
+      resolveDisposedStatus = resolve;
+    });
+    (globalThis as { window: { murmurMain: { getServerStatus: () => Promise<typeof reinitializedStatus> } } }).window.murmurMain.getServerStatus = async () => disposedStatus;
+    initializeServerStatus();
+    disposeServerStatus();
+    (globalThis as { window: { murmurMain: { getServerStatus: () => Promise<typeof reinitializedStatus> } } }).window.murmurMain.getServerStatus = async () => reinitializedStatus;
+    initializeServerStatus();
+    await Promise.resolve();
+    resolveDisposedStatus?.({ status: 'running', managed: false, engineStatus: { current: 'disposed', status: 'ready' } });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(get(serverStatusState).state).toEqual(reinitializedStatus);
+    disposeServerStatus();
+  });
+
   test('makes Home the default and keeps primary navigation in the required order', () => {
     expect(appView).toContain("let activeView = $state<View>('home')");
     expect(appView).toMatch(/\{ id: 'home', label: 'Home' \}[\s\S]*\{ id: 'history', label: 'History' \}[\s\S]*\{ id: 'insights', label: 'Insights' \}[\s\S]*\{ id: 'settings', label: 'Settings' \}/);
@@ -134,6 +179,8 @@ describe('Home and shared server status', () => {
     expect(statusController).toContain('unsubscribe?.();');
     expect(statusController).toContain("window.removeEventListener('focus', reseedOnFocus);");
     expect(statusController).not.toContain('setInterval');
+    expect(statusController).toContain('lifecycleGeneration');
+    expect(statusController).toContain('eventRevision');
     expect(banner).not.toContain('getServerStatus');
     expect(banner).not.toContain('onMount');
   });
@@ -149,15 +196,18 @@ describe('Home and shared server status', () => {
   });
 
   test('keeps Home read-only until an explicit managed retry click', () => {
-    const mount = homeView.match(/onMount\(async \(\) => \{([\s\S]*?)\n  \}\);/)?.[1] ?? '';
+    const mount = homeView.match(/async function loadSettings\(\): Promise<void> \{([\s\S]*?)\n    \}/)?.[1] ?? '';
     expect(mount).toContain('getSettings');
     expect(mount).not.toContain('restartServer');
     expect(mount).not.toContain('updateServerSettings');
     expect(homeView).toContain('onclick={retry}');
     expect(homeView).toContain('External server — Eve cannot restart this endpoint.');
     expect(homeView).toContain('Management mode cannot be confirmed. Open Settings &gt; Advanced.');
-    expect(homeView).toContain('useExternalServer = settings.useExternalServer;');
-    expect(statusController).toContain('if (!current.state?.managed) return false;');
+    expect(statusController).toContain('const settings = await window.murmurMain.getSettings();');
+    expect(statusController).toContain('setConfiguredExternalServer(settings.useExternalServer);');
+    expect(homeView).toContain('if (retrying) return;');
+    expect(homeView).toContain('disabled={retrying}');
+    expect(statusController).toContain('if (!initialized || !current.state?.managed || retryInFlight) return false;');
     expect(statusController).toContain('await window.murmurMain.restartServer()');
   });
 
@@ -174,10 +224,21 @@ describe('Home and shared server status', () => {
     expect(card).toContain("aria-live={announce ? 'polite' : undefined}");
     expect(banner).not.toContain('aria-live="assertive"');
     expect(serverView).not.toContain('aria-live="polite"');
+    expect(appView).toContain('aria-live="polite"');
+    expect(serverView).toContain('let active = true;');
+    expect(serverView).toContain('if (!active) return;');
     expect(banner).toContain('Open Settings &gt; Advanced for details.');
     expect(banner).not.toContain('Open Server and use Restart');
     expect(homeView).toContain('By default, Eve processes speech locally.');
     expect(homeView).toContain('audio is sent to that endpoint under your control.');
+  });
+
+  test('shares external management truth and retains a forced-colors focus fallback', () => {
+    expect(getServerManagementMode({ state: null, phase: 'unavailable', announcement: '', configuredExternalServer: null })).toBe('unknown');
+    expect(getServerManagementMode({ state: null, phase: 'unavailable', announcement: '', configuredExternalServer: true })).toBe('external');
+    expect(getServerManagementMode({ state: { status: 'running', managed: true }, phase: 'stale', announcement: '', configuredExternalServer: false })).toBe('managed');
+    expect(homeView).toContain('focus-visible:outline-hidden');
+    expect(banner).toContain('getServerManagementMode($serverStatusState)');
   });
 
   test('preserves the frozen Eve identity and version baseline', () => {

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { get } from 'svelte/store';
 import {
   disposeServerStatus,
+  getDownloadMilestone,
   getServerStatusPhase,
   initializeServerStatus,
   refresh,
@@ -114,6 +115,16 @@ describe('Home and shared server status', () => {
     expect(statusController).toContain('publish(null);');
   });
 
+  test('announces only bounded download milestones after 25%', () => {
+    expect(getDownloadMilestone(0)).toBeNull();
+    expect(getDownloadMilestone(24)).toBeNull();
+    expect(getDownloadMilestone(25)).toBe(25);
+    expect(getDownloadMilestone(50)).toBe(50);
+    expect(getDownloadMilestone(75)).toBe(75);
+    expect(getDownloadMilestone(100)).toBe(100);
+    expect(getDownloadMilestone(99)).toBe(75);
+  });
+
   test('owns one root subscription and bounded transfer-only polling with cleanup', () => {
     expect(statusController).toContain('let unsubscribe: (() => void) | null = null;');
     expect(statusController).toContain('unsubscribe = window.murmurMain.onServerStateChange');
@@ -144,6 +155,8 @@ describe('Home and shared server status', () => {
     expect(mount).not.toContain('updateServerSettings');
     expect(homeView).toContain('onclick={retry}');
     expect(homeView).toContain('External server — Eve cannot restart this endpoint.');
+    expect(homeView).toContain('Management mode cannot be confirmed. Open Settings &gt; Advanced.');
+    expect(homeView).toContain('useExternalServer = settings.useExternalServer;');
     expect(statusController).toContain('if (!current.state?.managed) return false;');
     expect(statusController).toContain('await window.murmurMain.restartServer()');
   });
@@ -157,10 +170,14 @@ describe('Home and shared server status', () => {
     expect(homeView).toContain("onNavigate('insights')");
     expect(homeView).toContain("onNavigate('settings')");
     expect(appView).toContain('aria-live="polite"');
-    expect(statusController).toContain('Math.floor(percent / 25)');
+    expect(statusController).toContain('percent < 25');
     expect(card).toContain("aria-live={announce ? 'polite' : undefined}");
     expect(banner).not.toContain('aria-live="assertive"');
     expect(serverView).not.toContain('aria-live="polite"');
+    expect(banner).toContain('Open Settings &gt; Advanced for details.');
+    expect(banner).not.toContain('Open Server and use Restart');
+    expect(homeView).toContain('By default, Eve processes speech locally.');
+    expect(homeView).toContain('audio is sent to that endpoint under your control.');
   });
 
   test('preserves the frozen Eve identity and version baseline', () => {

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { get } from 'svelte/store';
+import {
+  disposeServerStatus,
+  getServerStatusPhase,
+  initializeServerStatus,
+  refresh,
+  retryManagedServer,
+  serverStatusState,
+} from '../src/renderer/app/server-status';
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+const appView = source('../src/renderer/app/App.svelte');
+const homeView = source('../src/renderer/app/views/HomeView.svelte');
+const statusController = source('../src/renderer/app/server-status.ts');
+const banner = source('../src/renderer/app/components/ModelProgressBanner.svelte');
+const card = source('../src/renderer/app/components/ModelProgressCard.svelte');
+const serverView = source('../src/renderer/app/views/ServerView.svelte');
+const preload = source('../src/main/preload/main.ts');
+const declarations = source('../src/renderer/global.d.ts');
+const packageJson = source('../package.json');
+
+describe('Home and shared server status', () => {
+  test('initializes one subscription, reseeds on focus, and tears down only its own listener', async () => {
+    let getCalls = 0;
+    let stateSubscriptions = 0;
+    let stateUnsubscriptions = 0;
+    let focusHandler: (() => void) | undefined;
+    let removedFocusHandler: (() => void) | undefined;
+    const ready = { status: 'running' as const, managed: true, engineStatus: { current: 'whisper', status: 'ready' as const } };
+
+    (globalThis as { window: unknown }).window = {
+      murmurMain: {
+        getServerStatus: async () => { getCalls += 1; return ready; },
+        onServerStateChange: () => { stateSubscriptions += 1; return () => { stateUnsubscriptions += 1; }; },
+        restartServer: async () => ready,
+      },
+      addEventListener: (_type: string, handler: () => void) => { focusHandler = handler; },
+      removeEventListener: (_type: string, handler: () => void) => { removedFocusHandler = handler; },
+    };
+
+    initializeServerStatus();
+    initializeServerStatus();
+    await Promise.resolve();
+    expect(stateSubscriptions).toBe(1);
+    expect(getCalls).toBe(1);
+    expect(get(serverStatusState).phase).toBe('ready');
+
+    focusHandler?.();
+    await Promise.resolve();
+    expect(getCalls).toBe(2);
+
+    disposeServerStatus();
+    expect(stateUnsubscriptions).toBe(1);
+    expect(removedFocusHandler).toBe(focusHandler);
+  });
+
+  test('clears a previously ready snapshot after a refresh failure and retries only managed servers', async () => {
+    let resolveStatus = true;
+    let restartCalls = 0;
+    let stateCallback: ((state: { status: 'running'; managed: boolean; engineStatus: { current: string; status: 'ready' } }) => void) | undefined;
+    const ready = { status: 'running' as const, managed: true, engineStatus: { current: 'whisper', status: 'ready' as const } };
+
+    (globalThis as { window: unknown }).window = {
+      murmurMain: {
+        getServerStatus: async () => {
+          if (!resolveStatus) throw new Error('offline');
+          return ready;
+        },
+        onServerStateChange: (callback: typeof stateCallback) => { stateCallback = callback; return () => {}; },
+        restartServer: async () => { restartCalls += 1; return ready; },
+      },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    };
+
+    initializeServerStatus();
+    await Promise.resolve();
+    expect(await retryManagedServer()).toBeTrue();
+    expect(restartCalls).toBe(1);
+
+    resolveStatus = false;
+    await refresh();
+    expect(get(serverStatusState)).toMatchObject({ state: null, phase: 'unavailable' });
+
+    stateCallback?.({ ...ready, managed: false });
+    expect(await retryManagedServer()).toBeFalse();
+    expect(restartCalls).toBe(1);
+    disposeServerStatus();
+  });
+
+  test('makes Home the default and keeps primary navigation in the required order', () => {
+    expect(appView).toContain("let activeView = $state<View>('home')");
+    expect(appView).toMatch(/\{ id: 'home', label: 'Home' \}[\s\S]*\{ id: 'history', label: 'History' \}[\s\S]*\{ id: 'insights', label: 'Insights' \}[\s\S]*\{ id: 'settings', label: 'Settings' \}/);
+    expect(appView).toContain('<HomeView onNavigate={selectView} />');
+    expect(appView).toContain("return match?.id ?? 'home'");
+  });
+
+  test('covers connecting, stale, unavailable, model, loading, ready, and error phases without stale Ready', () => {
+    expect(getServerStatusPhase(null)).toBe('unavailable');
+    expect(getServerStatusPhase({ status: 'starting', managed: true })).toBe('connecting');
+    expect(getServerStatusPhase({ status: 'idle', managed: true })).toBe('stale');
+    expect(getServerStatusPhase({ status: 'running', managed: true, modelDownload: { model: 'm', size_gb: 1, status: 'missing' } })).toBe('missing');
+    expect(getServerStatusPhase({ status: 'running', managed: true, modelDownload: { model: 'm', size_gb: 1, status: 'partial' } })).toBe('partial');
+    expect(getServerStatusPhase({ status: 'running', managed: true, modelDownload: { model: 'm', size_gb: 1, status: 'missing', phase: 'checking' } })).toBe('checking');
+    expect(getServerStatusPhase({ status: 'running', managed: true, modelDownload: { model: 'm', size_gb: 1, status: 'downloading' } })).toBe('downloading');
+    expect(getServerStatusPhase({ status: 'running', managed: true, engineStatus: { current: 'whisper', status: 'loading' } })).toBe('loading');
+    expect(getServerStatusPhase({ status: 'running', managed: true, engineStatus: { current: 'whisper', status: 'ready' } })).toBe('ready');
+    expect(getServerStatusPhase({ status: 'error', managed: true })).toBe('error');
+    expect(statusController).toContain('publish(null);');
+  });
+
+  test('owns one root subscription and bounded transfer-only polling with cleanup', () => {
+    expect(statusController).toContain('let unsubscribe: (() => void) | null = null;');
+    expect(statusController).toContain('unsubscribe = window.murmurMain.onServerStateChange');
+    expect(statusController).toContain("window.addEventListener('focus', reseedOnFocus);");
+    expect(statusController).toContain('shouldShowModelProgress(current.state.modelDownload)');
+    expect(statusController).toContain('setTimeout(() => void refresh(), 3000)');
+    expect(statusController).toContain('unsubscribe?.();');
+    expect(statusController).toContain("window.removeEventListener('focus', reseedOnFocus);");
+    expect(statusController).not.toContain('setInterval');
+    expect(banner).not.toContain('getServerStatus');
+    expect(banner).not.toContain('onMount');
+  });
+
+  test('uses individual preload unsubscriptions so the settings view cannot remove root state listeners', () => {
+    expect(preload).toContain('return () => ipcRenderer.removeListener(IPC_CHANNELS.SERVER_STATE_CHANGE, handler);');
+    expect(preload).toContain('return () => ipcRenderer.removeListener(IPC_CHANNELS.SERVER_LOG, handler);');
+    expect(declarations).toContain('onServerStateChange: (callback: (state: ServerStatePayload) => void) => () => void;');
+    expect(serverView).toContain('removeLogListener = window.murmurMain.onServerLog');
+    expect(serverView).toContain('removeLogListener?.();');
+    expect(serverView).not.toContain('removeServerListeners();');
+    expect(serverView).not.toContain('onServerStateChange((state)');
+  });
+
+  test('keeps Home read-only until an explicit managed retry click', () => {
+    const mount = homeView.match(/onMount\(async \(\) => \{([\s\S]*?)\n  \}\);/)?.[1] ?? '';
+    expect(mount).toContain('getSettings');
+    expect(mount).not.toContain('restartServer');
+    expect(mount).not.toContain('updateServerSettings');
+    expect(homeView).toContain('onclick={retry}');
+    expect(homeView).toContain('External server — Eve cannot restart this endpoint.');
+    expect(statusController).toContain('if (!current.state?.managed) return false;');
+    expect(statusController).toContain('await window.murmurMain.restartServer()');
+  });
+
+  test('shares phase and progress UI while retaining factual shortcuts, privacy, actions, and restrained live announcements', () => {
+    expect(homeView).toContain('<ModelProgressCard state={model ?? undefined} announce={false} />');
+    expect(homeView).toContain('getHotkeyDisplayName(settings.hotkey)');
+    expect(homeView).toContain('getHotkeyDisplayName(settings.longHotkey)');
+    expect(homeView).toContain('does not automatically import personal data');
+    expect(homeView).toContain("onNavigate('history')");
+    expect(homeView).toContain("onNavigate('insights')");
+    expect(homeView).toContain("onNavigate('settings')");
+    expect(appView).toContain('aria-live="polite"');
+    expect(statusController).toContain('Math.floor(percent / 25)');
+    expect(card).toContain("aria-live={announce ? 'polite' : undefined}");
+    expect(banner).not.toContain('aria-live="assertive"');
+    expect(serverView).not.toContain('aria-live="polite"');
+  });
+
+  test('preserves the frozen Eve identity and version baseline', () => {
+    expect(packageJson).toContain('"version": "0.7.0"');
+    expect(packageJson).toContain('"appId": "io.github.burntcookiedough.eve"');
+    expect(packageJson).toContain('"guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204"');
+  });
+});


### PR DESCRIPTION
## Summary
- add Home as the default view with factual readiness, current engine/model, shortcuts, guidance, privacy, and navigation actions
- create one root-owned renderer server/model status controller with reseeding, event updates, transfer-only polling, freshness handling, and throttled announcements
- move banner and Settings > Advanced server status to shared state; add disposable per-channel preload subscriptions

## Validation
- un test tests/home-shared-status.test.ts tests/gate5-information-architecture.test.ts tests/model-progress.test.ts tests/gate5-accessibility.test.ts (25 passing tests, 137 assertions)
- un test (121 passing; 2 unrelated environment failures from missing @esbuild/win32-x64 and Electron binary)
- git diff --check`n
## Local environment limitation
The clean clone has no dependency tree. A hash-matched Windows dependency junction was used without installation, but that tree lacks the esbuild Windows binary and Electron executable. Consequently un run build and the History/Insights guard cannot complete locally; hosted CI is requested as the authoritative full app build/test matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Home screen as the default view with server readiness, model, shortcut, privacy, and navigation information.
  * Added shared server-status updates with download progress, readiness phases, announcements, and managed-server retry actions.
  * Improved model setup guidance, including Settings → Advanced instructions and contextual recovery messaging.
  * Added safer listener cleanup when navigating between views.

* **Accessibility**
  * Added restrained screen-reader announcements for server status and model progress updates.

* **Bug Fixes**
  * Server status now clears after refresh failures, preventing stale “ready” displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->