### PR TITLE
Add explicit curated speech model preparation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,8 @@ This roadmap separates shipped behavior from design and research. It is not a re
 
 ## Current baseline
 
-Eve v0.7.0 is the prepared source baseline; it is not yet a public release. The latest
-public download remains the historical Murmur v0.6.3 release. The prepared Eve source
+Eve v0.7.0 is public. The latest public download is Eve v0.7.0; historical Murmur
+v0.6.3 assets remain immutable. The Eve source
 retains the frozen Murmur installer chain while using the Eve product identity, an
 isolated Eve profile, the approved visual/accessibility system, and packaged cactus
 resources. Its portable Python runtime and separately downloaded models remain subject to
@@ -24,24 +24,19 @@ Gates 1–4 completed the compatibility, fresh-profile, visible-identity, and
 AppUserModelID cutover. Gates 5A and 5B completed the approved renderer/accessibility
 system and cactus Windows resources. Trademark work remains separate and incomplete.
 
-Before Eve v0.7.0 is published:
-
-- complete the binary-distribution third-party notice audit;
-- resolve or explicitly accept the Eve name/mark publication risk; and
-- run a fresh exact-head release-candidate lifecycle, then follow a separately approved
-  tag/publication procedure.
+The v0.7.0 publication gates were completed under the separate Gate 6 record. Future
+work continues to preserve the established identity, profile, installer, and privacy boundaries.
 
 The completed gates established a fresh Eve profile that does not automatically import
 Murmur History, settings, hotwords, browser storage, credentials, or external-server
 configuration. They also proved the compatibility lifecycle for the accepted candidates;
 the public release still requires fresh Gate 6 evidence.
 
-## Next: release readiness
+## Next: model-management clarity
 
-Gate 6 prepares version metadata, release notes, factual status records, NOTICE readiness,
-and publication controls. It does not publish merely because the source is prepared. The
-final package, lifecycle, merge, tag, release, and public-download checks remain separate
-approval gates.
+v0.8 work clarifies curated model choices and explicit first-use preparation while keeping
+the bundled runtime separate from downloaded model weights. It does not add engine packs,
+an updater, cache management, signing, or thin-client distribution.
 
 ## Later: component-based distribution
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,8 +29,8 @@ work continues to preserve the established identity, profile, installer, and pri
 
 The completed gates established a fresh Eve profile that does not automatically import
 Murmur History, settings, hotwords, browser storage, credentials, or external-server
-configuration. They also proved the compatibility lifecycle for the accepted candidates;
-the public release still requires fresh Gate 6 evidence.
+configuration. Gate 6 completed the public v0.7.0 lifecycle without changing those
+privacy boundaries.
 
 ## Next: model-management clarity
 

--- a/app/src/renderer/app/components/SpeechModelChooser.svelte
+++ b/app/src/renderer/app/components/SpeechModelChooser.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { EngineStatus, ModelDownloadState } from '$shared/types';
+  import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesEngine, type SpeechModelPreset } from '../speech-model-presets';
+
+  interface Props {
+    selected: SpeechModelPreset | null;
+    availableEngines: string[];
+    availabilityKnown: boolean;
+    engineStatus: EngineStatus | null;
+    modelDownload?: ModelDownloadState;
+    externalMode: boolean;
+    onSelect: (preset: SpeechModelPreset) => void;
+  }
+
+  let { selected, availableEngines, availabilityKnown, engineStatus, modelDownload, externalMode, onSelect }: Props = $props();
+  function unavailable(preset: SpeechModelPreset): boolean {
+    return availabilityKnown && !availableEngines.includes(preset.engine);
+  }
+</script>
+
+<fieldset class="space-y-3" aria-describedby="speech-model-help">
+  <legend class="text-sm font-medium text-zinc-200">Choose a speech model</legend>
+  <p id="speech-model-help" class="text-xs text-zinc-500">Choosing a model only stages it. Apply and prepare model confirms the change.</p>
+  {#if externalMode}
+    <p class="rounded-lg border border-zinc-700 p-3 text-xs text-zinc-400">An external server controls its own model preparation. Configure it through its own endpoint.</p>
+  {:else}
+    <div class="grid gap-2 sm:grid-cols-2">
+      {#each SPEECH_MODEL_PRESETS as preset}
+        {@const disabled = unavailable(preset)}
+        <label class="rounded-xl border p-3 transition-colors focus-within:outline-hidden focus-within:ring-2 focus-within:ring-zinc-100 {disabled ? 'border-zinc-800 opacity-60 cursor-not-allowed' : 'border-white/10 hover:bg-white/[0.04] cursor-pointer'}">
+          <input class="sr-only" type="radio" name="speech-model-preset" checked={selected?.id === preset.id} disabled={disabled} onchange={() => onSelect(preset)} aria-describedby={`preset-${preset.id}-detail`} />
+          <span class="flex items-start justify-between gap-3"><span class="text-sm font-medium text-zinc-100">{preset.label}</span><span class="text-xs text-zinc-400">{presetMatchesEngine(preset, engineStatus) ? 'Current' : selected?.id === preset.id ? 'Selected' : presetDownloadLabel(modelDownload, preset)}</span></span>
+          <span id={`preset-${preset.id}-detail`} class="mt-1 block text-xs leading-5 text-zinc-400">{preset.language} · approx. {preset.sizeGb} GB. {preset.summary}</span>
+          {#if disabled}<span class="mt-2 block text-xs text-amber-300">This server does not have the required {preset.engine} runtime.</span>{/if}
+        </label>
+      {/each}
+    </div>
+  {/if}
+</fieldset>

--- a/app/src/renderer/app/components/SpeechModelChooser.svelte
+++ b/app/src/renderer/app/components/SpeechModelChooser.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { EngineStatus, ModelDownloadState } from '$shared/types';
-  import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesEngine, type SpeechModelPreset } from '../speech-model-presets';
+  import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesCurrentEngine, type SpeechModelPreset } from '../speech-model-presets';
 
   interface Props {
     selected: SpeechModelPreset | null;
@@ -29,7 +29,7 @@
         {@const disabled = unavailable(preset)}
         <label class="rounded-xl border p-3 transition-colors focus-within:outline-hidden focus-within:ring-2 focus-within:ring-zinc-100 {disabled ? 'border-zinc-800 opacity-60 cursor-not-allowed' : 'border-white/10 hover:bg-white/[0.04] cursor-pointer'}">
           <input class="sr-only" type="radio" name="speech-model-preset" checked={selected?.id === preset.id} disabled={disabled} onchange={() => onSelect(preset)} aria-describedby={`preset-${preset.id}-detail`} />
-          <span class="flex items-start justify-between gap-3"><span class="text-sm font-medium text-zinc-100">{preset.label}</span><span class="text-xs text-zinc-400">{presetMatchesEngine(preset, engineStatus) ? 'Current' : selected?.id === preset.id ? 'Selected' : presetDownloadLabel(modelDownload, preset)}</span></span>
+          <span class="flex items-start justify-between gap-3"><span class="text-sm font-medium text-zinc-100">{preset.label}</span><span class="text-xs text-zinc-400">{presetMatchesCurrentEngine(preset, engineStatus) ? 'Current' : selected?.id === preset.id ? 'Selected' : presetDownloadLabel(modelDownload, preset)}</span></span>
           <span id={`preset-${preset.id}-detail`} class="mt-1 block text-xs leading-5 text-zinc-400">{preset.language} · approx. {preset.sizeGb} GB. {preset.summary}</span>
           {#if disabled}<span class="mt-2 block text-xs text-amber-300">This server does not have the required {preset.engine} runtime.</span>{/if}
         </label>

--- a/app/src/renderer/app/speech-model-presets.ts
+++ b/app/src/renderer/app/speech-model-presets.ts
@@ -22,6 +22,12 @@ export function presetPatch(preset: SpeechModelPreset): Record<string, string> {
   return { engine: preset.engine, [preset.setting]: preset.model };
 }
 
+export function stagedPresetFromPending(pending: Record<string, unknown>): SpeechModelPreset | null {
+  return SPEECH_MODEL_PRESETS.find((preset) =>
+    pending.engine === preset.engine && pending[preset.setting] === preset.model
+  ) ?? null;
+}
+
 export function presetMatchesCurrentEngine(preset: SpeechModelPreset, status: EngineStatus | null): boolean {
   if (status?.current !== preset.engine) return false;
   return status.info?.model === preset.model;

--- a/app/src/renderer/app/speech-model-presets.ts
+++ b/app/src/renderer/app/speech-model-presets.ts
@@ -1,0 +1,38 @@
+import type { EngineStatus, ModelDownloadState } from '$shared/types';
+
+export interface SpeechModelPreset {
+  id: 'english-performance' | 'recommended-multilingual' | 'maximum-multilingual-accuracy' | 'lightweight';
+  label: string;
+  engine: 'nemotron' | 'whisper';
+  setting: 'nemotron_model' | 'whisper_model';
+  model: string;
+  sizeGb: number;
+  language: string;
+  summary: string;
+}
+
+export const SPEECH_MODEL_PRESETS: readonly SpeechModelPreset[] = [
+  { id: 'english-performance', label: 'English Performance', engine: 'nemotron', setting: 'nemotron_model', model: 'nvidia/nemotron-speech-streaming-en-0.6b', sizeGb: 2.3, language: 'English only', summary: 'A focused English option for capable hardware.' },
+  { id: 'recommended-multilingual', label: 'Recommended Multilingual', engine: 'whisper', setting: 'whisper_model', model: 'large-v3-turbo', sizeGb: 1.5, language: 'Multilingual', summary: 'A balanced multilingual option.' },
+  { id: 'maximum-multilingual-accuracy', label: 'Maximum Multilingual Accuracy', engine: 'whisper', setting: 'whisper_model', model: 'large-v3', sizeGb: 2.9, language: 'Multilingual', summary: 'A larger multilingual option for quality-focused use.' },
+  { id: 'lightweight', label: 'Lightweight', engine: 'whisper', setting: 'whisper_model', model: 'small', sizeGb: 0.5, language: 'Multilingual', summary: 'A smaller option for constrained hardware.' },
+];
+
+export function presetPatch(preset: SpeechModelPreset): Record<string, string> {
+  return { engine: preset.engine, [preset.setting]: preset.model };
+}
+
+export function presetMatchesEngine(preset: SpeechModelPreset, status: EngineStatus | null): boolean {
+  if (status?.current !== preset.engine || status.status !== 'ready' || status.pending) return false;
+  return status.info?.model === preset.model;
+}
+
+export function presetDownloadLabel(model: ModelDownloadState | undefined, preset: SpeechModelPreset): string {
+  if (model?.model !== preset.model) return 'Available';
+  if (model.status === 'error') return 'Needs attention';
+  if (model.phase === 'checking') return 'Checking';
+  if (model.status === 'downloading' || model.phase === 'downloading' || model.phase === 'loading') return 'Preparing';
+  if (model.status === 'ready') return 'Installed';
+  if (model.status === 'partial') return 'Partial download';
+  return 'Available';
+}

--- a/app/src/renderer/app/speech-model-presets.ts
+++ b/app/src/renderer/app/speech-model-presets.ts
@@ -22,9 +22,13 @@ export function presetPatch(preset: SpeechModelPreset): Record<string, string> {
   return { engine: preset.engine, [preset.setting]: preset.model };
 }
 
-export function presetMatchesEngine(preset: SpeechModelPreset, status: EngineStatus | null): boolean {
-  if (status?.current !== preset.engine || status.status !== 'ready' || status.pending) return false;
+export function presetMatchesCurrentEngine(preset: SpeechModelPreset, status: EngineStatus | null): boolean {
+  if (status?.current !== preset.engine) return false;
   return status.info?.model === preset.model;
+}
+
+export function presetMatchesReadyEngine(preset: SpeechModelPreset, status: EngineStatus | null): boolean {
+  return presetMatchesCurrentEngine(preset, status) && status?.status === 'ready' && !status.pending;
 }
 
 export function presetDownloadLabel(model: ModelDownloadState | undefined, preset: SpeechModelPreset): string {

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -6,6 +6,9 @@
   import HotkeyCaptureModal from '../components/HotkeyCaptureModal.svelte';
   import SettingsSkeleton from '../components/SettingsSkeleton.svelte';
   import ServerView from './ServerView.svelte';
+  import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
+  import { SPEECH_MODEL_PRESETS, presetMatchesEngine, presetPatch } from '../speech-model-presets';
+  import { getServerManagementMode, serverStatusState } from '../server-status';
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting } from '$shared/types';
   import { HOTWORDS_WARNING_THRESHOLD, formatHotwordsCsl, parseHotwordsCsl } from '$shared/hotwords';
@@ -78,6 +81,9 @@
 
   // Local engine settings (track pending changes before apply)
   let pendingEngine = $state<Record<string, unknown>>({});
+  let sharedServerState = $derived($serverStatusState.state);
+  let sharedEngineStatus = $derived(sharedServerState?.engineStatus ?? engineStatus);
+  let externalMode = $derived(getServerManagementMode($serverStatusState) === 'external');
 
   // Derive current values (server value overridden by pending)
   function getSettingValue<T>(key: string): T | undefined {
@@ -87,6 +93,9 @@
   }
 
   let selectedEngine = $derived(getSettingValue<string>('engine') ?? 'nemotron');
+  let selectedPreset = $derived(SPEECH_MODEL_PRESETS.find((preset) =>
+    getSettingValue<string>('engine') === preset.engine && getSettingValue<string>(preset.setting) === preset.model
+  ) ?? null);
 
   // Whether the current engine supports hotwords (Whisper: yes, Nemotron: no)
   let hotwordsSupported = $derived(engineStatus?.info?.supports_hotwords ?? true);
@@ -403,6 +412,17 @@
     pendingEngine = { ...pendingEngine, [key]: value };
   }
 
+  function selectPreset(preset: typeof SPEECH_MODEL_PRESETS[number]): void {
+    if (externalMode || !isEngineAvailable(preset.engine)) return;
+    pendingEngine = { ...pendingEngine, ...presetPatch(preset) };
+    engineApplyError = '';
+  }
+
+  function revertPreset(): void {
+    pendingEngine = {};
+    engineApplyError = '';
+  }
+
   async function applyEngineSettings() {
     if (engineApplying || Object.keys(pendingEngine).length === 0) return;
     engineApplying = true;
@@ -415,16 +435,7 @@
       serverSettings = response.settings;
       engineStatus = response.engine_status;
       availableEngines = response.available_engines ?? availableEngines;
-      pendingEngine = {};
-
-      // Poll when a reload has started (or is already visible as pending/loading).
-      if (
-        response.reload_started ||
-        response.engine_status.status === 'loading' ||
-        response.engine_status.pending
-      ) {
-        pollEngineStatus();
-      }
+      if (!response.reload_started && response.engine_status.status === 'ready' && !response.engine_status.pending) pendingEngine = {};
     } catch (error) {
       // Keep pending changes on failure so user can retry
       engineApplyError = error instanceof Error ? error.message : 'Failed to apply engine settings.';
@@ -433,37 +444,17 @@
     }
   }
 
-  async function pollEngineStatus() {
-    const maxAttempts = 60; // 30 seconds at 500ms interval
-    for (let i = 0; i < maxAttempts; i++) {
-      await new Promise((r) => setTimeout(r, 500));
-      try {
-        const status = await window.murmurMain.getEngineStatus();
-        engineStatus = status;
-        if (status.status === 'ready' && !status.pending) {
-          // Refresh full settings to get updated values
-          const data = await window.murmurMain.getServerSettings();
-          serverSettings = data.settings;
-          engineStatus = data.engine_status;
-          availableEngines = data.available_engines ?? availableEngines;
-          return;
-        }
-        if (status.status === 'error') {
-          engineApplyError = status.message ?? 'Engine reload failed.';
-          const data = await window.murmurMain.getServerSettings();
-          serverSettings = data.settings;
-          engineStatus = data.engine_status;
-          availableEngines = data.available_engines ?? availableEngines;
-          return;
-        }
-      } catch {
-        engineApplyError = 'Failed while checking engine status.';
-        return;
-      }
+  $effect(() => {
+    if (Object.keys(pendingEngine).length === 0) return;
+    if (sharedEngineStatus?.status === 'error') {
+      engineApplyError = sharedEngineStatus.message ?? 'Engine reload failed.';
+      return;
     }
-
-    engineApplyError = 'Timed out waiting for engine reload to finish.';
-  }
+    if (selectedPreset && presetMatchesEngine(selectedPreset, sharedEngineStatus)) {
+      pendingEngine = {};
+      engineApplyError = '';
+    }
+  });
 </script>
 
 <div class="mx-auto h-full w-full max-w-[560px] px-4 py-4 pr-2">
@@ -471,8 +462,8 @@
     {#if settingsLoaded}
     <div class="space-y-6">
 
-    <!-- Activation -->
-    <SettingsSection title="Activation">
+    <!-- Shortcuts & activation -->
+    <SettingsSection title="Shortcuts &amp; activation">
       <SettingsRow label="Fast dictation hotkey" description="Start or stop fast dictation">
         <div class="flex items-center gap-2">
           <button
@@ -566,8 +557,8 @@
 
     </SettingsSection>
 
-    <!-- Post-Processing -->
-    <SettingsSection title="Post-Processing">
+    <!-- Dictation/output -->
+    <SettingsSection title="Dictation/output">
       <SettingsRow label="Append period" description="Add a period at the end of transcriptions">
         <Toggle
           enabled={settings.appendPeriod}
@@ -678,8 +669,34 @@
       </div>
     </SettingsSection>
 
-    <!-- Behavior -->
-    <SettingsSection title="Behavior">
+    <SettingsSection title="Speech model">
+      {#if !serverConnected || !serverSettings}
+        <p class="text-xs text-zinc-500">Speech model choices are available when the server reports its settings.</p>
+      {:else}
+        <SpeechModelChooser
+          selected={selectedPreset}
+          availableEngines={availableEngines}
+          availabilityKnown={availableEngines.length > 0}
+          engineStatus={sharedEngineStatus}
+          modelDownload={sharedServerState?.modelDownload}
+          externalMode={externalMode}
+          onSelect={selectPreset}
+        />
+        {#if selectedPreset && !presetMatchesEngine(selectedPreset, sharedEngineStatus)}
+          <p class="mt-3 text-xs text-amber-300">{sharedEngineStatus?.status === 'error' ? 'Preparation failed. Retry or revert your selected model.' : 'Selected model is pending preparation; the current engine remains active until the selected model is ready.'}</p>
+        {/if}
+        {#if Object.keys(pendingEngine).length > 0 && !externalMode}
+          <div class="mt-3 flex flex-wrap items-center gap-2">
+            <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : sharedEngineStatus?.status === 'error' ? 'Retry preparation' : 'Apply and prepare model'}</button>
+            <button type="button" onclick={revertPreset} disabled={engineApplying} class="rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-800 cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100">Revert</button>
+          </div>
+          {#if engineApplyError}<p class="mt-2 text-xs text-red-300">{engineApplyError}</p>{/if}
+        {/if}
+      {/if}
+    </SettingsSection>
+
+    <!-- App behavior -->
+    <SettingsSection title="App behavior">
       <SettingsRow label="Auto-copy" description="Copy transcription to clipboard automatically">
         <Toggle
           enabled={settings.autoCopy}
@@ -836,9 +853,19 @@
             Advanced
           </button>
 
-          {#if engineAdvancedOpen}
-            <div class="mt-2 space-y-2">
-              <!-- Device setting (show whichever is visible) -->
+           {#if engineAdvancedOpen}
+             <div class="mt-2 space-y-2">
+               {#if serverSettings.nemotron_model && isVisible(serverSettings.nemotron_model)}
+                 <SettingsRow label={serverSettings.nemotron_model.label} description="Raw Nemotron model name or path">
+                   <input value={getSettingValue<string>('nemotron_model') ?? String(serverSettings.nemotron_model.value)} oninput={(e) => updateEngineSetting('nemotron_model', e.currentTarget.value)} class="w-56 rounded-lg bg-zinc-800 px-3 py-1.5 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-zinc-100" />
+                 </SettingsRow>
+               {/if}
+               {#if serverSettings.whisper_language && isVisible(serverSettings.whisper_language)}
+                 <SettingsRow label={serverSettings.whisper_language.label} description={serverSettings.whisper_language.description}>
+                   <input value={getSettingValue<string>('whisper_language') ?? String(serverSettings.whisper_language.value ?? '')} oninput={(e) => updateEngineSetting('whisper_language', e.currentTarget.value)} class="w-28 rounded-lg bg-zinc-800 px-3 py-1.5 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-zinc-100" />
+                 </SettingsRow>
+               {/if}
+               <!-- Device setting (show whichever is visible) -->
               {#if serverSettings.nemotron_device && isVisible(serverSettings.nemotron_device)}
                 <SettingsRow label="Device" description="Hardware device for inference">
                   <select

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -98,7 +98,7 @@
   ) ?? null);
   let stagedPreset = $derived(stagedPresetFromPending(pendingEngine));
   let preparationFailed = $derived(
-    !!sharedEngineStatus?.message || sharedEngineStatus?.status === 'error' ||
+    !!sharedEngineStatus?.message || sharedEngineStatus?.status === 'error' || sharedEngineStatus?.pending?.status === 'error' ||
     (stagedPreset !== null && sharedServerState?.modelDownload?.model === stagedPreset.model && sharedServerState.modelDownload.status === 'error')
   );
 
@@ -454,7 +454,7 @@
   $effect(() => {
     if (Object.keys(pendingEngine).length === 0) return;
     if (preparationFailed) {
-      engineApplyError = sharedEngineStatus.message ?? 'Engine reload failed.';
+      engineApplyError = sharedEngineStatus?.pending?.message ?? sharedEngineStatus?.message ?? 'Engine reload failed.';
       return;
     }
     if (stagedPreset && presetMatchesReadyEngine(stagedPreset, sharedEngineStatus)) {

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -7,7 +7,7 @@
   import SettingsSkeleton from '../components/SettingsSkeleton.svelte';
   import ServerView from './ServerView.svelte';
   import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
-  import { SPEECH_MODEL_PRESETS, presetMatchesReadyEngine, presetPatch } from '../speech-model-presets';
+  import { SPEECH_MODEL_PRESETS, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../speech-model-presets';
   import { getServerManagementMode, serverStatusState } from '../server-status';
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting } from '$shared/types';
@@ -96,9 +96,10 @@
   let selectedPreset = $derived(SPEECH_MODEL_PRESETS.find((preset) =>
     getSettingValue<string>('engine') === preset.engine && getSettingValue<string>(preset.setting) === preset.model
   ) ?? null);
+  let stagedPreset = $derived(stagedPresetFromPending(pendingEngine));
   let preparationFailed = $derived(
     !!sharedEngineStatus?.message || sharedEngineStatus?.status === 'error' ||
-    (selectedPreset !== null && sharedServerState?.modelDownload?.model === selectedPreset.model && sharedServerState.modelDownload.status === 'error')
+    (stagedPreset !== null && sharedServerState?.modelDownload?.model === stagedPreset.model && sharedServerState.modelDownload.status === 'error')
   );
 
   // Whether the current engine supports hotwords (Whisper: yes, Nemotron: no)
@@ -423,7 +424,9 @@
   }
 
   function revertPreset(): void {
-    pendingEngine = {};
+    if (!stagedPreset) return;
+    const { engine: _engine, [stagedPreset.setting]: _model, ...advancedPending } = pendingEngine;
+    pendingEngine = advancedPending;
     engineApplyError = '';
   }
 
@@ -454,7 +457,7 @@
       engineApplyError = sharedEngineStatus.message ?? 'Engine reload failed.';
       return;
     }
-    if (selectedPreset && presetMatchesReadyEngine(selectedPreset, sharedEngineStatus)) {
+    if (stagedPreset && presetMatchesReadyEngine(stagedPreset, sharedEngineStatus)) {
       pendingEngine = {};
       engineApplyError = '';
     }
@@ -683,10 +686,10 @@
           externalMode={externalMode}
           onSelect={selectPreset}
         />
-        {#if selectedPreset && !presetMatchesReadyEngine(selectedPreset, sharedEngineStatus)}
+        {#if stagedPreset && !presetMatchesReadyEngine(stagedPreset, sharedEngineStatus)}
           <p class="mt-3 text-xs {preparationFailed ? 'text-red-300' : 'text-amber-300'}">{preparationFailed ? 'Preparation failed. Retry or revert your selected model.' : 'Selected model is pending preparation; the current engine remains active until the selected model is ready.'}</p>
         {/if}
-        {#if Object.keys(pendingEngine).length > 0 && !externalMode}
+        {#if stagedPreset && !externalMode}
           <div class="mt-3 flex flex-wrap items-center gap-2">
             <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
             <button type="button" onclick={revertPreset} disabled={engineApplying} class="rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
@@ -768,7 +771,20 @@
           </p>
         </div>
       {:else if serverSettings}
-        {#if serverSettings.whisper_compute_type && isVisible(serverSettings.whisper_compute_type)}
+        {#if serverSettings.whisper_model}
+          <SettingsRow label={serverSettings.whisper_model.label} description="Raw Whisper compatibility model, including Medium and Tiny">
+            <select
+              value={getSettingValue('whisper_model') ?? serverSettings.whisper_model.value}
+              onchange={(e) => updateEngineSetting('whisper_model', e.currentTarget.value)}
+              class="pl-3 pr-8 py-1.5 bg-zinc-800 hover:bg-zinc-700 rounded-lg text-xs text-zinc-300 border-none cursor-pointer focus:ring-1 focus:ring-zinc-600"
+            >
+              {#each getOptions('whisper_model') as option}
+                <option value={option.value}>{option.label}</option>
+              {/each}
+            </select>
+          </SettingsRow>
+        {/if}
+        {#if serverSettings.whisper_compute_type}
           <SettingsRow label={serverSettings.whisper_compute_type.label} description={serverSettings.whisper_compute_type.description}>
             <select
               value={getSettingValue('whisper_compute_type') ?? serverSettings.whisper_compute_type.value}
@@ -854,7 +870,7 @@
         </div>
 
         <!-- Advanced compatibility changes remain explicit. -->
-        {#if Object.keys(pendingEngine).length > 0 && !selectedPreset}
+        {#if Object.keys(pendingEngine).length > 0 && !stagedPreset}
           <div class="w-full rounded-xl border border-zinc-700 bg-zinc-900/50 p-4">
             <div class="flex items-center gap-2 mb-3">
               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400">

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -7,7 +7,7 @@
   import SettingsSkeleton from '../components/SettingsSkeleton.svelte';
   import ServerView from './ServerView.svelte';
   import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
-  import { SPEECH_MODEL_PRESETS, presetMatchesEngine, presetPatch } from '../speech-model-presets';
+  import { SPEECH_MODEL_PRESETS, presetMatchesReadyEngine, presetPatch } from '../speech-model-presets';
   import { getServerManagementMode, serverStatusState } from '../server-status';
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting } from '$shared/types';
@@ -96,6 +96,10 @@
   let selectedPreset = $derived(SPEECH_MODEL_PRESETS.find((preset) =>
     getSettingValue<string>('engine') === preset.engine && getSettingValue<string>(preset.setting) === preset.model
   ) ?? null);
+  let preparationFailed = $derived(
+    !!sharedEngineStatus?.message || sharedEngineStatus?.status === 'error' ||
+    (selectedPreset !== null && sharedServerState?.modelDownload?.model === selectedPreset.model && sharedServerState.modelDownload.status === 'error')
+  );
 
   // Whether the current engine supports hotwords (Whisper: yes, Nemotron: no)
   let hotwordsSupported = $derived(engineStatus?.info?.supports_hotwords ?? true);
@@ -446,11 +450,11 @@
 
   $effect(() => {
     if (Object.keys(pendingEngine).length === 0) return;
-    if (sharedEngineStatus?.status === 'error') {
+    if (preparationFailed) {
       engineApplyError = sharedEngineStatus.message ?? 'Engine reload failed.';
       return;
     }
-    if (selectedPreset && presetMatchesEngine(selectedPreset, sharedEngineStatus)) {
+    if (selectedPreset && presetMatchesReadyEngine(selectedPreset, sharedEngineStatus)) {
       pendingEngine = {};
       engineApplyError = '';
     }
@@ -589,10 +593,7 @@
           <option value="command">Command Mode</option>
         </select>
       </SettingsRow>
-    </SettingsSection>
-
-    <!-- Recognition -->
-    <SettingsSection title="Recognition">
+    <!-- Recognition/output controls remain in Dictation/output. -->
       {#if !hotwordsSupported}
         <div class="flex items-start gap-3 p-4 bg-zinc-900/50 rounded-xl border border-zinc-700 w-full">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-zinc-400 shrink-0 mt-0.5">
@@ -682,12 +683,12 @@
           externalMode={externalMode}
           onSelect={selectPreset}
         />
-        {#if selectedPreset && !presetMatchesEngine(selectedPreset, sharedEngineStatus)}
-          <p class="mt-3 text-xs text-amber-300">{sharedEngineStatus?.status === 'error' ? 'Preparation failed. Retry or revert your selected model.' : 'Selected model is pending preparation; the current engine remains active until the selected model is ready.'}</p>
+        {#if selectedPreset && !presetMatchesReadyEngine(selectedPreset, sharedEngineStatus)}
+          <p class="mt-3 text-xs {preparationFailed ? 'text-red-300' : 'text-amber-300'}">{preparationFailed ? 'Preparation failed. Retry or revert your selected model.' : 'Selected model is pending preparation; the current engine remains active until the selected model is ready.'}</p>
         {/if}
         {#if Object.keys(pendingEngine).length > 0 && !externalMode}
           <div class="mt-3 flex flex-wrap items-center gap-2">
-            <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : sharedEngineStatus?.status === 'error' ? 'Retry preparation' : 'Apply and prepare model'}</button>
+            <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
             <button type="button" onclick={revertPreset} disabled={engineApplying} class="rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
           </div>
           {#if engineApplyError}<p class="mt-2 text-xs text-red-300">{engineApplyError}</p>{/if}
@@ -759,8 +760,7 @@
       </div>
       <div class="space-y-6">
 
-    <!-- Engine -->
-    <SettingsSection title="Engine">
+    <SettingsSection title="Model compatibility">
       {#if !serverConnected}
         <div class="p-4 bg-zinc-900/50 rounded-xl w-full">
           <p class="text-xs text-zinc-500 text-center">
@@ -768,61 +768,6 @@
           </p>
         </div>
       {:else if serverSettings}
-        <!-- Engine selection (radio group) -->
-        <div class="w-full rounded-xl border border-zinc-700 bg-zinc-900/50 p-4">
-          <p class="text-sm text-zinc-200 mb-3">Transcription Engine</p>
-          <div class="space-y-2">
-            {#each getOptions('engine') as option}
-              <label class="flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-colors
-                {!isEngineAvailable(option.value)
-                  ? 'opacity-50 cursor-not-allowed bg-zinc-800/30'
-                  : selectedEngine === option.value
-                    ? 'bg-zinc-800'
-                    : 'hover:bg-zinc-800/50'}">
-                <input
-                  type="radio"
-                  name="engine"
-                  value={option.value}
-                  checked={selectedEngine === option.value}
-                  disabled={!isEngineAvailable(option.value)}
-                  onchange={() => isEngineAvailable(option.value) && updateEngineSetting('engine', option.value)}
-                  class="mt-0.5 accent-emerald-500
-                    {isEngineAvailable(option.value) ? 'cursor-pointer' : 'cursor-not-allowed'}"
-                />
-                <div>
-                  <p class="text-sm text-zinc-200">{option.label}</p>
-                  {#if option.description}
-                    <p class="text-xs text-zinc-500 mt-0.5">{option.description}</p>
-                  {/if}
-                  {#if !isEngineAvailable(option.value)}
-                    <p class="text-xs text-amber-300 mt-0.5">Not available in the currently running server environment.</p>
-                  {/if}
-                </div>
-              </label>
-            {/each}
-          </div>
-          {#if getOptions('engine').some((option) => !isEngineAvailable(option.value))}
-            <p class="text-xs text-zinc-500 mt-3">
-              Install missing engine dependencies and restart the server to enable those options.
-            </p>
-          {/if}
-        </div>
-
-        <!-- Conditional settings based on selected engine -->
-        {#if serverSettings.whisper_model && isVisible(serverSettings.whisper_model)}
-          <SettingsRow label={serverSettings.whisper_model.label} description={serverSettings.whisper_model.description}>
-            <select
-              value={getSettingValue('whisper_model') ?? serverSettings.whisper_model.value}
-              onchange={(e) => updateEngineSetting('whisper_model', e.currentTarget.value)}
-              class="pl-3 pr-8 py-1.5 bg-zinc-800 hover:bg-zinc-700 rounded-lg text-xs text-zinc-300 border-none cursor-pointer focus:ring-1 focus:ring-zinc-600"
-            >
-              {#each getOptions('whisper_model') as option}
-                <option value={option.value}>{option.label}</option>
-              {/each}
-            </select>
-          </SettingsRow>
-        {/if}
-
         {#if serverSettings.whisper_compute_type && isVisible(serverSettings.whisper_compute_type)}
           <SettingsRow label={serverSettings.whisper_compute_type.label} description={serverSettings.whisper_compute_type.description}>
             <select
@@ -908,8 +853,8 @@
           {/if}
         </div>
 
-        <!-- Apply & Reload button (shown when pending changes exist) -->
-        {#if hasPendingReloadChanges() || Object.keys(pendingEngine).length > 0}
+        <!-- Advanced compatibility changes remain explicit. -->
+        {#if Object.keys(pendingEngine).length > 0 && !selectedPreset}
           <div class="w-full rounded-xl border border-zinc-700 bg-zinc-900/50 p-4">
             <div class="flex items-center gap-2 mb-3">
               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400">
@@ -934,7 +879,7 @@
                   Applying...
                 </span>
               {:else}
-                Apply & Reload Engine
+                Apply advanced changes
               {/if}
             </button>
             {#if engineApplyError}

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -688,7 +688,7 @@
         {#if Object.keys(pendingEngine).length > 0 && !externalMode}
           <div class="mt-3 flex flex-wrap items-center gap-2">
             <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : sharedEngineStatus?.status === 'error' ? 'Retry preparation' : 'Apply and prepare model'}</button>
-            <button type="button" onclick={revertPreset} disabled={engineApplying} class="rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-800 cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100">Revert</button>
+            <button type="button" onclick={revertPreset} disabled={engineApplying} class="rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
           </div>
           {#if engineApplyError}<p class="mt-2 text-xs text-red-300">{engineApplyError}</p>{/if}
         {/if}

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
-import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesEngine, presetPatch } from '../src/renderer/app/speech-model-presets';
+import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesCurrentEngine, presetMatchesReadyEngine, presetPatch } from '../src/renderer/app/speech-model-presets';
 
 describe('speech model presets', () => {
   test('keeps the four exact supported mappings and factual established sizes', () => {
@@ -16,8 +16,13 @@ describe('speech model presets', () => {
 
   test('promotes a selected preset only when its actual engine status is ready', () => {
     const preset = SPEECH_MODEL_PRESETS[1];
-    expect(presetMatchesEngine(preset, { current: 'whisper', status: 'loading', pending: { engine: 'whisper' } })).toBeFalse();
-    expect(presetMatchesEngine(preset, { current: 'whisper', status: 'ready', info: { id: 'whisper', name: 'Faster-Whisper', model: 'large-v3-turbo', languages: [], model_size_gb: 1.5 } })).toBeTrue();
+    const oldWhisperDuringCrossEngineSwap = { current: 'whisper', status: 'loading', pending: { engine: 'nemotron' }, info: { id: 'whisper', name: 'Faster-Whisper', model: 'large-v3-turbo', languages: [], model_size_gb: 1.5 } };
+    const oldTurboDuringSameEngineSwap = { current: 'whisper', status: 'loading', pending: { engine: 'whisper' }, info: { id: 'whisper', name: 'Faster-Whisper', model: 'large-v3-turbo', languages: [], model_size_gb: 1.5 } };
+    expect(presetMatchesCurrentEngine(preset, oldWhisperDuringCrossEngineSwap)).toBeTrue();
+    expect(presetMatchesReadyEngine(preset, oldWhisperDuringCrossEngineSwap)).toBeFalse();
+    expect(presetMatchesCurrentEngine(preset, oldTurboDuringSameEngineSwap)).toBeTrue();
+    expect(presetMatchesReadyEngine(preset, oldTurboDuringSameEngineSwap)).toBeFalse();
+    expect(presetMatchesReadyEngine(preset, { current: 'whisper', status: 'ready', info: { id: 'whisper', name: 'Faster-Whisper', model: 'large-v3-turbo', languages: [], model_size_gb: 1.5 } })).toBeTrue();
     expect(presetDownloadLabel({ model: 'large-v3-turbo', size_gb: 1.5, status: 'partial' }, preset)).toBe('Partial download');
   });
 
@@ -29,6 +34,8 @@ describe('speech model presets', () => {
     expect(settings).toContain('Apply and prepare model');
     expect(settings).toContain('serverStatusState');
     expect(settings).not.toContain('async function pollEngineStatus');
+    expect(settings).toContain('!!sharedEngineStatus?.message');
+    expect(settings).toContain("'Retry preparation'");
     expect(settings).toContain("'nemotron_model'");
     expect(settings).toContain("'whisper_language'");
     const config = readFileSync(new URL('../../server/src/config.py', import.meta.url), 'utf8');

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
-import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesCurrentEngine, presetMatchesReadyEngine, presetPatch } from '../src/renderer/app/speech-model-presets';
+import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesCurrentEngine, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../src/renderer/app/speech-model-presets';
 
 describe('speech model presets', () => {
   test('keeps the four exact supported mappings and factual established sizes', () => {
@@ -42,5 +42,15 @@ describe('speech model presets', () => {
     expect(config).toContain('"medium"');
     expect(config).toContain('"tiny"');
     expect(settings).toContain('whisper_compute_type');
+    expect(settings).toContain('Raw Whisper compatibility model, including Medium and Tiny');
+    expect(settings).toContain('!stagedPreset');
+    expect(settings).toContain('const { engine: _engine, [stagedPreset.setting]: _model, ...advancedPending }');
+  });
+
+  test('routes only an actual staged preset through model preparation and preserves advanced pending values on revert', () => {
+    expect(stagedPresetFromPending({ whisper_compute_type: 'int8' })).toBeNull();
+    expect(stagedPresetFromPending({ engine: 'whisper', whisper_model: 'medium' })).toBeNull();
+    expect(stagedPresetFromPending({ engine: 'whisper', whisper_model: 'large-v3-turbo', whisper_compute_type: 'int8' })?.id).toBe('recommended-multilingual');
+    expect(stagedPresetFromPending({ engine: 'nemotron', nemotron_model: 'nvidia/nemotron-speech-streaming-en-0.6b', nemotron_device: 'cuda' })?.id).toBe('english-performance');
   });
 });

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -35,6 +35,8 @@ describe('speech model presets', () => {
     expect(settings).toContain('serverStatusState');
     expect(settings).not.toContain('async function pollEngineStatus');
     expect(settings).toContain('!!sharedEngineStatus?.message');
+    expect(settings).toContain("sharedEngineStatus?.pending?.status === 'error'");
+    expect(settings).toContain('sharedEngineStatus?.pending?.message ?? sharedEngineStatus?.message');
     expect(settings).toContain("'Retry preparation'");
     expect(settings).toContain("'nemotron_model'");
     expect(settings).toContain("'whisper_language'");

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesEngine, presetPatch } from '../src/renderer/app/speech-model-presets';
+
+describe('speech model presets', () => {
+  test('keeps the four exact supported mappings and factual established sizes', () => {
+    expect(SPEECH_MODEL_PRESETS.map(({ label, engine, model, sizeGb }) => ({ label, engine, model, sizeGb }))).toEqual([
+      { label: 'English Performance', engine: 'nemotron', model: 'nvidia/nemotron-speech-streaming-en-0.6b', sizeGb: 2.3 },
+      { label: 'Recommended Multilingual', engine: 'whisper', model: 'large-v3-turbo', sizeGb: 1.5 },
+      { label: 'Maximum Multilingual Accuracy', engine: 'whisper', model: 'large-v3', sizeGb: 2.9 },
+      { label: 'Lightweight', engine: 'whisper', model: 'small', sizeGb: 0.5 },
+    ]);
+    expect(presetPatch(SPEECH_MODEL_PRESETS[0])).toEqual({ engine: 'nemotron', nemotron_model: 'nvidia/nemotron-speech-streaming-en-0.6b' });
+    expect(presetPatch(SPEECH_MODEL_PRESETS[1])).toEqual({ engine: 'whisper', whisper_model: 'large-v3-turbo' });
+  });
+
+  test('promotes a selected preset only when its actual engine status is ready', () => {
+    const preset = SPEECH_MODEL_PRESETS[1];
+    expect(presetMatchesEngine(preset, { current: 'whisper', status: 'loading', pending: { engine: 'whisper' } })).toBeFalse();
+    expect(presetMatchesEngine(preset, { current: 'whisper', status: 'ready', info: { id: 'whisper', name: 'Faster-Whisper', model: 'large-v3-turbo', languages: [], model_size_gb: 1.5 } })).toBeTrue();
+    expect(presetDownloadLabel({ model: 'large-v3-turbo', size_gb: 1.5, status: 'partial' }, preset)).toBe('Partial download');
+  });
+
+  test('keeps selection and preparation explicit in the Settings surface', () => {
+    const settings = readFileSync(new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url), 'utf8');
+    const chooser = readFileSync(new URL('../src/renderer/app/components/SpeechModelChooser.svelte', import.meta.url), 'utf8');
+    expect(chooser).toContain('type="radio"');
+    expect(chooser).toContain('Apply and prepare model confirms the change.');
+    expect(settings).toContain('Apply and prepare model');
+    expect(settings).toContain('serverStatusState');
+    expect(settings).not.toContain('async function pollEngineStatus');
+    expect(settings).toContain("'nemotron_model'");
+    expect(settings).toContain("'whisper_language'");
+    const config = readFileSync(new URL('../../server/src/config.py', import.meta.url), 'utf8');
+    expect(config).toContain('"medium"');
+    expect(config).toContain('"tiny"');
+    expect(settings).toContain('whisper_compute_type');
+  });
+});

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted for staged implementation. Gates 1–3 are merged through PR #17 at
+Accepted and implemented. Gates 1–3 are merged through PR #17 at
 `822a353d9e232a1b365b61c972db4195ac23ba48`. Gate 4 is authorized with the exact
 AppUserModelID `io.github.burntcookiedough.eve`. Visual redesign, publication, and
 merge remain separately gated.

--- a/docs/architecture/adr-001-eve-application-identity-migration.md
+++ b/docs/architecture/adr-001-eve-application-identity-migration.md
@@ -3,9 +3,9 @@
 ## Status
 
 Accepted and implemented. Gates 1–3 are merged through PR #17 at
-`822a353d9e232a1b365b61c972db4195ac23ba48`. Gate 4 is authorized with the exact
-AppUserModelID `io.github.burntcookiedough.eve`. Visual redesign, publication, and
-merge remain separately gated.
+`822a353d9e232a1b365b61c972db4195ac23ba48`. Gate 4 uses the exact
+AppUserModelID `io.github.burntcookiedough.eve`. The visual redesign and Gate 6
+publication stages referenced below are completed historical milestones.
 
 The companion [cutover checklist](eve-identity-cutover-checklist.md) maps this decision to exact files, release gates, checks, and remaining work.
 

--- a/docs/architecture/eve-gate-6-release-plan.md
+++ b/docs/architecture/eve-gate-6-release-plan.md
@@ -1,6 +1,6 @@
 # Eve Gate 6 release plan
 
-- Status: Gate 6B accepted; Gate 6C preparation PR authorized
+- Status: Gate 6 completed; Eve v0.7.0 is public. Historical Gate 6 evidence remains unchanged.
 - Repository: `burntcookiedough/eve-windows-dictation`
 - Canonical release-candidate base: `f88067ff7bb31ec7f0b5a124fefbeaff0d7829ca`
 - Tracking issue: [#21](https://github.com/burntcookiedough/eve-windows-dictation/issues/21)

--- a/docs/speech-model-selection.md
+++ b/docs/speech-model-selection.md
@@ -1,0 +1,16 @@
+# Speech model selection
+
+Eve v0.8 presents four curated choices over the engines already bundled with the app:
+
+- English Performance: Nemotron Speech with `nvidia/nemotron-speech-streaming-en-0.6b` (English only, approximately 2.3 GB).
+- Recommended Multilingual: Faster-Whisper `large-v3-turbo` (multilingual, approximately 1.5 GB).
+- Maximum Multilingual Accuracy: Faster-Whisper `large-v3` (multilingual, approximately 2.9 GB).
+- Lightweight: Faster-Whisper `small` (multilingual, approximately 0.5 GB).
+
+The labels describe relative use cases, not Eve benchmark claims. Engine availability comes from the running server; a missing engine runtime is not installed by this UI.
+
+Selecting a choice is local to the renderer. **Apply and prepare model** is the explicit action that persists the existing server settings and begins the existing engine/model swap path. Eve keeps the current engine active while the selected model downloads or loads where the server supports that behavior. A selected choice is not called current until the server reports that engine and model ready.
+
+The bundled engine runtime and separately downloaded model weights are different lifecycles. Eve reports only the selected/active model-download state; it does not inventory, pre-download, move, or delete model caches. Hugging Face cache partials remain resumable through the existing server download plumbing.
+
+Before a missing or partial selected-model download begins, the server checks free capacity on the existing Hugging Face cache filesystem (or its nearest existing parent). It estimates remaining selected-repository bytes from model metadata and already-present required files, with the larger of 10% or 512 MiB reserved as cushion. The check reads capacity and selected-repository metadata only; an unavailable or insufficient filesystem produces an explicit selected-model error and leaves partial data untouched.

--- a/server/src/transcription/engines/nemotron.py
+++ b/server/src/transcription/engines/nemotron.py
@@ -14,7 +14,7 @@ from numpy.typing import NDArray
 
 from transcription.base import EngineInfo
 from transcription.errors import VramExhaustedError
-from transcription.model_download import is_repo_cached, update_model_download_state
+from transcription.model_download import DownloadDiskPreflightError, check_download_disk_space, is_repo_cached, update_model_download_state
 from transcription.types import TranscribeOptions, TranscribeResult
 
 logger = logging.getLogger(__name__)
@@ -128,6 +128,14 @@ class NemotronEngine:
                     progress_percent=100.0,
                 )
             else:
+                try:
+                    check_download_disk_space(repo_id, _MODEL_SIZE_GB)
+                except DownloadDiskPreflightError as exc:
+                    update_model_download_state(
+                        model=model_name, size_gb=_MODEL_SIZE_GB, status="error", cached=False,
+                        detail=str(exc), repo_id=repo_id, phase="error",
+                    )
+                    raise
                 update_model_download_state(
                     model=model_name,
                     size_gb=_MODEL_SIZE_GB,

--- a/server/src/transcription/engines/whisper.py
+++ b/server/src/transcription/engines/whisper.py
@@ -22,6 +22,8 @@ from config import Settings
 from transcription.base import EngineInfo
 from transcription.model_download import (
     begin_model_download_progress,
+    check_download_disk_space,
+    DownloadDiskPreflightError,
     get_cached_required_bytes,
     get_repo_cache_status,
     mark_model_loading,
@@ -188,6 +190,15 @@ class WhisperEngine:
                     progress_percent=100.0,
                 )
             else:
+                try:
+                    check_download_disk_space(repo_id, model_size_gb)
+                except DownloadDiskPreflightError as exc:
+                    update_model_download_state(
+                        model=model, size_gb=model_size_gb, status="error", cached=False,
+                        detail=str(exc), repo_id=repo_id, path=cache_status.snapshot_path or cache_status.repo_path,
+                        missing_files=cache_status.missing_files, partial_files=cache_status.partial_files, phase="error",
+                    )
+                    raise
                 begin_model_download_progress(
                     model=model,
                     repo_id=repo_id,

--- a/server/src/transcription/model_download.py
+++ b/server/src/transcription/model_download.py
@@ -8,6 +8,7 @@ from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 import importlib
 from pathlib import Path
+import shutil
 import threading
 import time
 from typing import Iterator, Literal
@@ -38,6 +39,9 @@ _DEFAULT_REQUIRED_FILES = (
     "model.bin",
     "tokenizer.json",
 )
+_MIB = 1024**2
+_GIB = 1024**3
+_MIN_DOWNLOAD_CUSHION_BYTES = 512 * _MIB
 
 
 @dataclass(frozen=True)
@@ -72,6 +76,19 @@ class ModelCacheStatus:
     snapshot_path: str | None = None
     missing_files: list[str] = field(default_factory=list)
     partial_files: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DownloadDiskPreflight:
+    available_bytes: int
+    required_bytes: int
+    remaining_estimated_bytes: int
+    cushion_bytes: int
+    inspected_path: str
+
+
+class DownloadDiskPreflightError(RuntimeError):
+    """The selected model cannot safely begin its existing cache download."""
 
 
 _MODEL_DOWNLOAD_STATE: ModelDownloadState | None = None
@@ -260,6 +277,36 @@ def get_cached_required_bytes(repo_id: str) -> int:
                 continue
         totals.append(total)
     return max(totals, default=0)
+
+
+def check_download_disk_space(repo_id: str, model_size_gb: float) -> DownloadDiskPreflight:
+    """Check free capacity for one selected Hugging Face repo without touching cache data.
+
+    Model metadata is approximate, so the remaining estimate includes the larger of a
+    10% cushion or 512 MiB. Only the selected repo's required-file metadata is read.
+    """
+    cache_dir = _get_hf_cache_dir()
+    inspected = cache_dir
+    while not inspected.exists() and inspected.parent != inspected:
+        inspected = inspected.parent
+    if not inspected.exists():
+        raise DownloadDiskPreflightError("Cannot inspect the selected model cache filesystem.")
+    try:
+        available = shutil.disk_usage(inspected).free
+    except OSError as exc:
+        raise DownloadDiskPreflightError("Cannot inspect free space for the selected model cache filesystem.") from exc
+
+    estimated = max(0, int(model_size_gb * _GIB))
+    cached = get_cached_required_bytes(repo_id)
+    remaining = max(0, estimated - cached)
+    cushion = max(int(estimated * 0.10), _MIN_DOWNLOAD_CUSHION_BYTES)
+    required = remaining + cushion
+    result = DownloadDiskPreflight(available, required, remaining, cushion, str(inspected))
+    if available < required:
+        raise DownloadDiskPreflightError(
+            f"Not enough free space to prepare the selected model (needs about {required / _GIB:.1f} GB free; {available / _GIB:.1f} GB available)."
+        )
+    return result
 
 
 def update_model_download_state(

--- a/server/tests/test_model_download.py
+++ b/server/tests/test_model_download.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+from types import SimpleNamespace
 
 from config import Settings
 import app as app_module
@@ -63,6 +64,36 @@ def test_is_repo_cached_rejects_empty_snapshot(tmp_path, monkeypatch) -> None:
     status = model_download.get_repo_cache_status("Systran/faster-whisper-large-v3-turbo")
     assert status.status == "partial"
     assert model_download.is_repo_cached("Systran/faster-whisper-large-v3-turbo") is False
+
+
+def test_download_disk_preflight_uses_custom_hf_cache_and_selected_partial_bytes(tmp_path, monkeypatch) -> None:
+    cache_dir = tmp_path / "custom-hf-cache"
+    monkeypatch.setenv("HF_HUB_CACHE", str(cache_dir))
+    repo_dir = cache_dir / "models--mobiuslabsgmbh--faster-whisper-large-v3-turbo"
+    snapshot = repo_dir / "snapshots" / "partial"
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_bytes(b"x" * 100)
+    monkeypatch.setattr(model_download.shutil, "disk_usage", lambda path: SimpleNamespace(free=3 * 1024**3))
+
+    result = model_download.check_download_disk_space("mobiuslabsgmbh/faster-whisper-large-v3-turbo", 1.5)
+
+    assert result.inspected_path == str(cache_dir)
+    assert result.remaining_estimated_bytes < int(1.5 * 1024**3)
+    assert result.cushion_bytes == 512 * 1024**2
+
+
+def test_download_disk_preflight_rejects_insufficient_space_without_cache_mutation(tmp_path, monkeypatch) -> None:
+    cache_dir = tmp_path / "hub"
+    monkeypatch.setenv("HF_HUB_CACHE", str(cache_dir))
+    monkeypatch.setattr(model_download.shutil, "disk_usage", lambda path: SimpleNamespace(free=1))
+
+    try:
+        model_download.check_download_disk_space("nvidia/nemotron-speech-streaming-en-0.6b", 2.3)
+    except model_download.DownloadDiskPreflightError as exc:
+        assert "Not enough free space" in str(exc)
+    else:
+        raise AssertionError("expected disk preflight failure")
+    assert not cache_dir.exists()
 
 
 def test_is_repo_cached_detects_complete_snapshot(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- adds four curated, explicit speech-model choices over existing engines
- keeps preparation explicit and surfaces shared selected-model status
- adds selected-repository HF cache capacity preflight for both current engines

## Validation
- focused renderer/model-status tests passed
- disk-preflight server tests passed
- full local Bun suite: 131 passed, 0 failed
- full local server suite: 151 passed, 0 failed
- `bunx tsc -p tsconfig.main.json --noEmit`
- `bunx tsc -p tsconfig.json --noEmit`
- `bun run build`
- hosted Version Consistency, App Test And Build, and Server Tests passed

The disposable clone now uses frozen lockfile-controlled Windows dependency environments. `app/bun.lock`, `server/uv.lock`, and both package manifests remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added curated speech model selection with language, size, and intended-use details.
  * Added clear model preparation, download, installation, and error statuses.
  * Added Apply and Revert controls for speech model changes.
  * Added disk-space checks before model downloads to prevent incomplete preparations.
  * Added model compatibility settings while preserving other pending configuration changes.

* **Documentation**
  * Added guidance on speech model selection, availability, preparation, and download storage.
  * Updated release documentation to reflect Eve v0.7.0 as public and outline v0.8 priorities.

* **Bug Fixes**
  * Improved engine preparation status handling and removed unreliable reload polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->