### PR TITLE
Prepare Eve v0.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Local dictation for Windows, built as an Electron desktop client with a packaged
 <img src="https://img.shields.io/badge/v0.8.0-orange?style=flat-square" alt="v0.8.0">
 
 > [!IMPORTANT]
-> Current source builds use the visible **Eve** product, executable, installer, and shortcut names, the `io.github.burntcookiedough.eve` AppUserModelID, and a separate `%APPDATA%\Eve` profile. Eve v0.7.0 is public; the historical v0.6.3 **Murmur** download table below remains unchanged. The frozen installer GUID, internal `murmur` package name, compatibility payload name, and `MURMUR_*` interfaces remain stable for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.
+> Current source builds use the visible **Eve** product, executable, installer, and shortcut names, the `io.github.burntcookiedough.eve` AppUserModelID, and a separate `%APPDATA%\Eve` profile. Eve v0.7.0 is public; historical v0.6.3 **Murmur** assets remain immutable. The frozen installer GUID, internal `murmur` package name, compatibility payload name, and `MURMUR_*` interfaces remain stable for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.
 
 ## What works today
 
@@ -31,13 +31,13 @@ Models are not embedded in the installer payload. The selected engine downloads 
 
 ## Current release
 
-[Download v0.6.3](https://github.com/burntcookiedough/eve-windows-dictation/releases/tag/v0.6.3). The release is currently unsigned and may trigger Windows reputation warnings.
+[Download Eve v0.7.0](https://github.com/burntcookiedough/eve-windows-dictation/releases/tag/v0.7.0) (release ID `362027119`, tag target `d03c7eab7e3e10afc2f62662d25ccd63427c22e9`). The release is unsigned and may trigger Windows reputation warnings.
 
 | Asset | Bytes | SHA-256 |
 |---|---:|---|
-| `Murmur.Web.Setup.0.6.3.exe` | 887,561 | `366088a4266f54ea7c39e2e7fd1fc7177cac46bf8a4b3f43d58a6d025e15cd33` |
-| `murmur-0.6.3-x64.nsis.7z` | 2,034,188,308 | `0b557fde05853da1f7c0aef77cecbad1faf8c5fc9314457ea45119d3a69f4fbd` |
-| `latest.yml` | 564 | `b211cdb0322a0f6da01eee77921f6c6961735de59d4ffd8cacc31d9a3f7395a9` |
+| `Eve.Web.Setup.0.7.0.exe` | 654,555 | `e27646c15be0563c45e35b34b157105af2a61424ef1bff6cf8a9c72f8a763e4a` |
+| `murmur-0.7.0-x64.nsis.7z` | 2,033,658,084 | `9f3137a096ac2183828e393a41b19e23a0b7387c2f44d40f6285d059ae2ae619` |
+| `latest.yml` | 558 | `fd23678bbed97980152fe9495c27f39081e61c1207f76f0eb614afac9d5c6221` |
 
 The small `nsis-web` installer downloads the large application payload during installation. Internet access is also required when an engine fetches its model for the first time.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Local dictation for Windows, built as an Electron desktop client with a packaged Python transcription service.
 
-<img src="https://img.shields.io/badge/v0.7.0-orange?style=flat-square" alt="v0.7.0">
+<img src="https://img.shields.io/badge/v0.8.0-orange?style=flat-square" alt="v0.8.0">
 
 > [!IMPORTANT]
-> Current source builds use the visible **Eve** product, executable, installer, and shortcut names, the `io.github.burntcookiedough.eve` AppUserModelID, and a separate `%APPDATA%\Eve` profile. The published v0.6.3 download remains **Murmur** and is listed below unchanged. The frozen installer GUID, internal `murmur` package name, compatibility payload name, and `MURMUR_*` interfaces remain stable for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.
+> Current source builds use the visible **Eve** product, executable, installer, and shortcut names, the `io.github.burntcookiedough.eve` AppUserModelID, and a separate `%APPDATA%\Eve` profile. Eve v0.7.0 is public; the historical v0.6.3 **Murmur** download table below remains unchanged. The frozen installer GUID, internal `murmur` package name, compatibility payload name, and `MURMUR_*` interfaces remain stable for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.
 
 ## What works today
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,11 +32,12 @@ Murmur History, settings, hotwords, browser storage, credentials, or external-se
 configuration. Gate 6 completed the public v0.7.0 lifecycle without changing those
 privacy boundaries.
 
-## Next: model-management clarity
+## In preparation: model-management clarity
 
-v0.8 work clarifies curated model choices and explicit first-use preparation while keeping
-the bundled runtime separate from downloaded model weights. It does not add engine packs,
-an updater, cache management, signing, or thin-client distribution.
+Eve v0.8.0 release preparation covers curated model choices and explicit first-use
+preparation while keeping the bundled runtime separate from downloaded model weights.
+It is not yet published. It does not add engine packs, an updater, cache management,
+signing, or thin-client distribution.
 
 ## Later: component-based distribution
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -241,8 +241,8 @@ describe('Home and shared server status', () => {
     expect(banner).toContain('getServerManagementMode($serverStatusState)');
   });
 
-  test('preserves the frozen Eve identity and version baseline', () => {
-    expect(packageJson).toContain('"version": "0.7.0"');
+  test('preserves the frozen Eve identity and v0.8.0 version baseline', () => {
+    expect(packageJson).toContain('"version": "0.8.0"');
     expect(packageJson).toContain('"appId": "io.github.burntcookiedough.eve"');
     expect(packageJson).toContain('"guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204"');
   });

--- a/docs/architecture/eve-v0.8-release-preparation.md
+++ b/docs/architecture/eve-v0.8-release-preparation.md
@@ -1,0 +1,27 @@
+# Eve v0.8.0 release preparation
+
+Status: preparation in progress. This record covers source metadata, release notes, and
+validation only; it does not authorize packaging, tagging, draft-release creation, asset
+upload, or publication.
+
+## Scope
+
+Eve v0.8.0 combines the accepted v0.8 UX/model-management work: accessible transcript
+follow-scroll, read-only Home readiness, renderer-owned shared server/model status,
+explicit curated model preparation, and safe selected-model download preflight. The
+bundled runtime remains distinct from separately downloaded model weights.
+
+## Frozen boundaries
+
+The preparation retains AppUserModelID `io.github.burntcookiedough.eve`, NSIS GUID
+`0204d005-75b3-5b31-b1f6-ef2831e2b204`, Eve visible identity, `nsis-web`, the active
+`%APPDATA%\Eve` profile, preserved `%APPDATA%\murmur` profile, shared model-cache
+behavior, and internal Murmur runtime/protocol/environment/install-chain names. It does
+not inspect personal content or cache contents, and it does not add signing, an updater,
+thin-client/engine packs, a single-file installer, or cache migration/deletion.
+
+## Required later gates
+
+Before any public v0.8.0 release, a separately authorized exact-head Windows package and
+lifecycle validation must pass. Publication remains a separate consequential decision;
+historical v0.7.0 release assets and hashes are immutable.

--- a/docs/releases/eve-v0.7.0-release-notes.md
+++ b/docs/releases/eve-v0.7.0-release-notes.md
@@ -1,6 +1,7 @@
 # Eve v0.7.0 release notes
 
-Status: prepared release notes; Eve v0.7.0 has not been published.
+Status: historical release notes. Eve v0.7.0 is public; its release assets and hashes
+remain immutable.
 
 ## Highlights
 
@@ -26,11 +27,9 @@ Status: prepared release notes; Eve v0.7.0 has not been published.
 - The internal `murmur` package name, payload compatibility name, `MURMUR_*` interfaces,
   preload bridges, and local protocol remain unchanged for compatibility.
 
-## Before publication
+## Historical publication notes
 
-These notes describe the accepted source preparation, not an available download. A fresh
-exact-head package and Windows lifecycle, complete third-party notice readiness, and the
-approved draft-release procedure are still required. The user accepted the Eve name/mark
-publication risk; this is not legal clearance. The planned Windows release is unsigned:
-Windows may show an Unknown Publisher warning and Microsoft Defender SmartScreen may
-require an explicit user decision before installation.
+Eve v0.7.0 was published after its separately approved release procedure. The release was
+unsigned: Windows may show an Unknown Publisher warning and Microsoft Defender SmartScreen
+may require an explicit user decision before installation. The accepted Eve name/mark risk
+was not legal clearance.

--- a/docs/releases/eve-v0.8.0-release-notes.md
+++ b/docs/releases/eve-v0.8.0-release-notes.md
@@ -1,0 +1,38 @@
+# Eve v0.8.0 release notes
+
+Status: release preparation only. Eve v0.8.0 is not published and no release artifact is
+created by these notes.
+
+## Highlights
+
+- The transcript overlay keeps a fixed two-line viewport while retaining full accessible
+  transcript text and following the newest line as partial dictation arrives.
+- Home is the default view and presents read-only server and model readiness, current
+  shortcuts, dictation guidance, privacy information, and links to the rest of Eve.
+- Model/server status is shared by the renderer so Home, banners, and settings describe
+  the same connection, preparation, download, and error state without duplicate polling.
+- Speech model settings provide four curated choices over existing bundled engines:
+  English Performance, Recommended Multilingual, Maximum Multilingual Accuracy, and
+  Lightweight. Selecting a choice does not start work; **Apply and prepare model** is the
+  explicit action that may prepare its separately downloaded model weights.
+- Downloads remain resumable. Before a missing or partial selected model download begins,
+  Eve checks available space on the existing Hugging Face cache filesystem without moving,
+  deleting, or inventorying unrelated cached data.
+
+## Compatibility and privacy
+
+- Eve processes audio locally by default. If a user configures an external endpoint, audio
+  is sent to that endpoint under the user's control.
+- Eve does not automatically read, import, merge, prompt for, or delete legacy Murmur
+  personal data. `%APPDATA%\murmur` remains untouched; `%APPDATA%\Eve` is the active
+  profile.
+- The Eve app identity, frozen NSIS GUID, `nsis-web` installer chain, shared model-cache
+  location, and internal Murmur package/runtime/protocol/environment compatibility names
+  remain unchanged.
+
+## Before publication
+
+This is a source-release-preparation record, not a public download announcement. A
+separately authorized exact-head package, Windows lifecycle validation, release artifact
+audit, and publication decision are still required. No updater, signing, thin-client,
+single-file installer, or public release-asset cleanup is included in v0.8.0.

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$ExpectedVersion = "0.7.0",
+    [string]$ExpectedVersion = "0.8.0",
     [string]$InstallerDir = "E:\EveRelease\release-prep\full-nsis-web\nsis-web",
     [string]$InstallDir = "E:\EveRelease\release-prep\smoke-install\Eve",
     [string]$BaseBranch = "trunk",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.7.0"
+version = "0.8.0"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.7.0"
+SERVER_VERSION = "0.8.0"

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "murmur"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- bump the repository-controlled Eve version surfaces from 0.7.0 to 0.8.0 using the existing version-consistency tool
- add v0.8.0 source-release-preparation notes and a bounded preparation record
- correct stale v0.7.0 public-status wording while preserving historical assets and hashes

## Validation
- `python scripts/version.py check --tag v0.8.0`
- `bun test` (132 pass), `bun run build`, and both app TypeScript checks
- `uv sync --extra whisper --group dev --frozen` and `uv run pytest` (151 pass)

No package, tag, draft release, asset upload, or publication was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Eve v0.8.0 release-preparation notes covering transcript overlays, Home view updates, model/server status, curated speech-model settings, resumable downloads, privacy, and legacy data isolation.
  - Clarified that v0.8.0 is not yet publicly released and has no downloadable release artifact.
  - Updated v0.7.0 historical release information, compatibility details, and roadmap language.

- **Chores**
  - Updated application and server version references to 0.8.0.
  - Refreshed release verification and version-baseline checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->