### PR TITLE
fix: make bundled Python runtime self-contained

### DIFF
--- a/scripts/prepare-python-runtime.ps1
+++ b/scripts/prepare-python-runtime.ps1
@@ -83,7 +83,12 @@ if ((Test-PathWithin -Path $pythonPath -Root $serverPath) -or
 }
 
 $runtimeSource = Split-Path -Parent $pythonPath
-foreach ($required in @("python.exe", "python311.dll", "Lib", "DLLs")) {
+$pythonAbi = (& $pythonPath -I -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")').Trim()
+if ($LASTEXITCODE -ne 0 -or -not $pythonAbi) {
+    throw "Could not determine the managed Python ABI version."
+}
+
+foreach ($required in @("python.exe", "python$pythonAbi.dll", "Lib", "DLLs")) {
     if (-not (Test-Path -LiteralPath (Join-Path $runtimeSource $required))) {
         throw "Managed Python root is incomplete; missing $required at $runtimeSource"
     }

--- a/scripts/prepare-python-runtime.ps1
+++ b/scripts/prepare-python-runtime.ps1
@@ -10,13 +10,85 @@ $ErrorActionPreference = "Stop"
 $serverPath = (Resolve-Path $ServerDir).Path
 $runtimePath = Join-Path $serverPath ".runtime"
 
+function Test-PathWithin {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Root
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $resolvedRoot = [System.IO.Path]::GetFullPath($Root).TrimEnd([char[]]@('\', '/'))
+    return $resolvedPath.StartsWith("$resolvedRoot$([System.IO.Path]::DirectorySeparatorChar)", [System.StringComparison]::OrdinalIgnoreCase) -or
+        $resolvedPath.Equals($resolvedRoot, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Assert-SelfContainedRuntime {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RuntimePath
+    )
+
+    $bundledPython = Join-Path $RuntimePath "python.exe"
+    $probeScript = 'import json, sys; print(json.dumps({"prefix": sys.prefix, "base_prefix": sys.base_prefix, "executable": sys.executable, "path": sys.path}))'
+    $probe = & $bundledPython -I -c $probeScript
+    if ($LASTEXITCODE -ne 0) {
+        throw "Bundled Python isolation probe failed with exit code $LASTEXITCODE."
+    }
+
+    $runtimeProbe = $probe | ConvertFrom-Json
+    foreach ($property in @("prefix", "base_prefix", "executable")) {
+        $value = [string]$runtimeProbe.$property
+        if (-not (Test-PathWithin -Path $value -Root $RuntimePath)) {
+            throw "Bundled Python $property resolves outside the runtime: $value"
+        }
+    }
+
+    foreach ($entry in @($runtimeProbe.path)) {
+        $value = [string]$entry
+        if (-not [System.IO.Path]::IsPathRooted($value) -or -not (Test-PathWithin -Path $value -Root $RuntimePath)) {
+            throw "Bundled Python sys.path entry resolves outside the runtime: $value"
+        }
+    }
+}
+
 uv python install $PythonVersion
-$pythonPath = (& uv python find --managed-python $PythonVersion).Trim()
+$previousVirtualEnv = $env:VIRTUAL_ENV
+try {
+    Remove-Item Env:VIRTUAL_ENV -ErrorAction SilentlyContinue
+    Push-Location $PSScriptRoot
+    try {
+        $pythonPath = (& uv python find --managed-python --no-project --resolve-links $PythonVersion).Trim()
+    } finally {
+        Pop-Location
+    }
+} finally {
+    if ($null -eq $previousVirtualEnv) {
+        Remove-Item Env:VIRTUAL_ENV -ErrorAction SilentlyContinue
+    } else {
+        $env:VIRTUAL_ENV = $previousVirtualEnv
+    }
+}
+
 if (-not $pythonPath -or -not (Test-Path -LiteralPath $pythonPath -PathType Leaf)) {
     throw "uv did not return a managed Python executable for $PythonVersion."
 }
 
+$pythonPath = [System.IO.Path]::GetFullPath($pythonPath)
+if ((Test-PathWithin -Path $pythonPath -Root $serverPath) -or
+    $pythonPath -match '(?i)(^|[\\/])\.venv([\\/]|$)' -or
+    (Split-Path -Parent $pythonPath) -match '(?i)(^|[\\/])Scripts$') {
+    throw "uv returned a project or virtual-environment interpreter instead of a standalone managed Python: $pythonPath"
+}
+
 $runtimeSource = Split-Path -Parent $pythonPath
+foreach ($required in @("python.exe", "python311.dll", "Lib", "DLLs")) {
+    if (-not (Test-Path -LiteralPath (Join-Path $runtimeSource $required))) {
+        throw "Managed Python root is incomplete; missing $required at $runtimeSource"
+    }
+}
+
 if (Test-Path -LiteralPath $runtimePath) {
     Remove-Item -LiteralPath $runtimePath -Recurse -Force
 }
@@ -24,9 +96,6 @@ if (Test-Path -LiteralPath $runtimePath) {
 New-Item -ItemType Directory -Path $runtimePath | Out-Null
 Copy-Item -Path (Join-Path $runtimeSource "*") -Destination $runtimePath -Recurse -Force
 
-$bundledPython = Join-Path $runtimePath "python.exe"
-if (-not (Test-Path -LiteralPath $bundledPython -PathType Leaf)) {
-    throw "Relocatable runtime is missing python.exe after copy: $bundledPython"
-}
+Assert-SelfContainedRuntime -RuntimePath $runtimePath
 
 Write-Host "Prepared relocatable Python runtime at $runtimePath"

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -30,6 +30,36 @@ function Assert-Contains {
     }
 }
 
+function Test-PathWithin {
+    param([string]$Path, [string]$Root)
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $resolvedRoot = [System.IO.Path]::GetFullPath($Root).TrimEnd([char[]]@('\', '/'))
+    return $resolvedPath.StartsWith("$resolvedRoot$([System.IO.Path]::DirectorySeparatorChar)", [System.StringComparison]::OrdinalIgnoreCase) -or
+        $resolvedPath.Equals($resolvedRoot, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Assert-SelfContainedRuntime {
+    param([string]$RuntimePath, [string]$PythonExe)
+    $probeScript = 'import json, sys; print(json.dumps({"prefix": sys.prefix, "base_prefix": sys.base_prefix, "executable": sys.executable, "path": sys.path}))'
+    $probe = & $PythonExe -I -c $probeScript
+    if ($LASTEXITCODE -ne 0) {
+        throw "Bundled Python isolation probe failed with exit code $LASTEXITCODE"
+    }
+    $runtimeProbe = $probe | ConvertFrom-Json
+    foreach ($property in @("prefix", "base_prefix", "executable")) {
+        $value = [string]$runtimeProbe.$property
+        if (-not (Test-PathWithin -Path $value -Root $RuntimePath)) {
+            throw "Bundled Python $property resolves outside the runtime: $value"
+        }
+    }
+    foreach ($entry in @($runtimeProbe.path)) {
+        $value = [string]$entry
+        if (-not [System.IO.Path]::IsPathRooted($value) -or -not (Test-PathWithin -Path $value -Root $RuntimePath)) {
+            throw "Bundled Python sys.path entry resolves outside the runtime: $value"
+        }
+    }
+}
+
 function Invoke-Native {
     param(
         [Parameter(Mandatory = $true)]
@@ -101,6 +131,7 @@ Assert-Path $pythonExe "Bundled Python"
 Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\faster_whisper") "faster-whisper package"
 Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\torch") "torch package"
 Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\nemo") "nemo package"
+Assert-SelfContainedRuntime -RuntimePath (Join-Path $serverRoot ".runtime") -PythonExe $pythonExe
 
 Write-Step "Checking installed server health/version"
 $outLog = Join-Path (Split-Path $InstallDir -Parent) "release-verify-server.out.log"

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -224,7 +224,9 @@ def test_runtime_preparation_script_uses_uv_managed_python() -> None:
     assert "Test-PathWithin -Path $pythonPath -Root $serverPath" in contents
     assert r"\.venv" in contents
     assert "Scripts" in contents
-    for required in ('"python.exe"', '"python311.dll"', '"Lib"', '"DLLs"'):
+    assert "$pythonAbi =" in contents
+    assert '"python$pythonAbi.dll"' in contents
+    for required in ('"python.exe"', '"Lib"', '"DLLs"'):
         assert required in contents
     assert "function Assert-SelfContainedRuntime" in contents
     assert "ConvertFrom-Json" in contents

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -209,13 +209,26 @@ def test_release_verify_uses_packaged_runtime_and_controlled_environment() -> No
     assert '.venv\\Lib\\site-packages' in contents
     assert "MURMUR_SETTINGS_FILE" in contents
     assert "MURMUR_WHISPER_COMPUTE_TYPE" in contents
+    assert "function Assert-SelfContainedRuntime" in contents
+    assert "ConvertFrom-Json" in contents
+    assert "sys.path entry resolves outside the runtime" in contents
+    assert "Assert-SelfContainedRuntime -RuntimePath" in contents
 
 
 def test_runtime_preparation_script_uses_uv_managed_python() -> None:
     contents = (ROOT / "scripts" / "prepare-python-runtime.ps1").read_text(encoding="utf-8")
     assert "uv python install" in contents
-    assert "uv python find --managed-python" in contents
-    assert 'Join-Path $runtimePath "python.exe"' in contents
+    assert "uv python find --managed-python --no-project --resolve-links" in contents
+    assert "Remove-Item Env:VIRTUAL_ENV" in contents
+    assert "$env:VIRTUAL_ENV = $previousVirtualEnv" in contents
+    assert "Test-PathWithin -Path $pythonPath -Root $serverPath" in contents
+    assert r"\.venv" in contents
+    assert "Scripts" in contents
+    for required in ('"python.exe"', '"python311.dll"', '"Lib"', '"DLLs"'):
+        assert required in contents
+    assert "function Assert-SelfContainedRuntime" in contents
+    assert "ConvertFrom-Json" in contents
+    assert "sys.path entry resolves outside the runtime" in contents
 
 
 def test_version_check_includes_all_release_metadata() -> None:


### PR DESCRIPTION
## Summary

Fixes the rejected v0.8 candidate's runtime-closure defect without changing product behavior or release metadata.

`prepare-python-runtime.ps1` previously let `uv python find --managed-python` resolve the project `.venv\\Scripts\\python.exe` trampoline. Copying that launcher directory produced a non-portable `.runtime` whose isolated Python resolved outside the installed tree.

This change:

- clears and restores `VIRTUAL_ENV` around the `uv` subprocess;
- resolves managed Python with `--no-project --resolve-links` from the scripts directory;
- rejects server-tree, `.venv`, and `Scripts` interpreter paths;
- requires a complete CPython root (`python.exe`, `python311.dll`, `Lib`, `DLLs`) before copying it;
- probes copied and installed runtimes with `python.exe -I`, failing when prefix, base-prefix, executable, or any `sys.path` entry resolves outside `.runtime`.

`release-verify.ps1` now performs the same containment assertion before server health launch.

## Validation

- PowerShell parser checks: both changed scripts passed.
- Neutral managed resolution returned the standalone managed CPython root, not a venv launcher.
- Focused `test_release_config.py`: 15 passed.
- Full server suite: 151 passed (one existing Transformers deprecation warning).
- `python scripts/version.py check --tag v0.8.0`: passed.

## Frozen boundaries

Version remains `0.8.0`. No app identity/GUID/profile/NSIS target/internal Murmur name/lockfile/package/install/release/publication change is included. No package, installer, or lifecycle action is part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to ensure bundled Python runtimes are self-contained and isolated.
  * Prevented project or virtual-environment interpreters from being included.
  * Strengthened release verification for runtime paths, metadata, executables, and required files.
* **Tests**
  * Expanded coverage for runtime isolation, path containment, environment restoration, and release payload validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->