### PR TITLE
fix: recover Settings from shared server status

### DIFF
--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -18,6 +18,7 @@ import {
 } from '../services/server-settings.js';
 import { startHotkeyCapture, cancelHotkeyCapture } from '../services/hotkey.js';
 import { formatHotkey } from '../services/keycodes.js';
+import { resolveServerApiUrl } from '../services/server-api-url.js';
 import { createLogger } from '../lib/logger.js';
 import {
   applyLaunchOnBoot,
@@ -27,6 +28,15 @@ import {
 const log = createLogger('IpcHandlers');
 let historyServiceRef: HistoryService | null = null;
 let serverManagerRef: ServerManager | null = null;
+
+function getServerApiUrl(): string {
+  const configuredUrl = getSetting('serverUrl');
+  return resolveServerApiUrl(
+    configuredUrl,
+    serverManagerRef?.getState(),
+    getSetting('useExternalServer'),
+  );
+}
 
 export function setupIpcHandlers(historyService?: HistoryService, serverManager?: ServerManager): void {
   // Store references to services
@@ -231,21 +241,21 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
 
   // Server settings (REST API proxy)
   ipcMain.handle(IPC_CHANNELS.GET_SERVER_SETTINGS, async () => {
-    return getServerSettings();
+    return getServerSettings(getServerApiUrl());
   });
 
   ipcMain.handle(
     IPC_CHANNELS.UPDATE_SERVER_SETTINGS,
     async (_event, patch: Record<string, unknown>) => {
-      return updateServerSettings(patch);
+      return updateServerSettings(patch, getServerApiUrl());
     }
   );
 
   ipcMain.handle(IPC_CHANNELS.GET_ENGINE_STATUS, async () => {
-    return getEngineStatus();
+    return getEngineStatus(getServerApiUrl());
   });
 
   ipcMain.handle(IPC_CHANNELS.GET_AVAILABLE_ENGINES, async () => {
-    return getAvailableEngines();
+    return getAvailableEngines(getServerApiUrl());
   });
 }

--- a/app/src/main/services/keycodes.ts
+++ b/app/src/main/services/keycodes.ts
@@ -55,14 +55,19 @@ export function getKeyName(keycode: number): string {
  * e.g., "Ctrl+Shift+F17" or just "F17"
  */
 export function formatHotkey(hotkey: Hotkey): string {
+  return formatHotkeyForPlatform(hotkey, process.platform);
+}
+
+export function formatHotkeyForPlatform(hotkey: Hotkey, platform: NodeJS.Platform): string {
   const parts: string[] = [];
+  const metaName = platform === 'win32' ? 'Win' : 'Meta';
 
   if (hotkey.ctrlKey) parts.push('Ctrl');
   if (hotkey.altKey) parts.push('Alt');
   if (hotkey.shiftKey) parts.push('Shift');
-  if (hotkey.metaKey) parts.push('Meta');
+  if (hotkey.metaKey) parts.push(metaName);
 
-  const keyName = getKeyName(hotkey.keycode);
+  const keyName = isMetaKeycode(hotkey.keycode) ? metaName : getKeyName(hotkey.keycode);
   parts.push(keyName);
 
   return parts.join('+');

--- a/app/src/main/services/server-api-url.ts
+++ b/app/src/main/services/server-api-url.ts
@@ -1,0 +1,19 @@
+import type { ServerStatePayload } from '../../shared/types.js';
+
+/**
+ * Resolve the HTTP API endpoint for server settings and engine operations.
+ *
+ * Managed production servers bind an available port and publish it through
+ * ServerManager. External-server mode must continue to use the user's saved
+ * endpoint instead.
+ */
+export function resolveServerApiUrl(
+  configuredUrl: string,
+  state: Pick<ServerStatePayload, 'status' | 'wsUrl'> | null | undefined,
+  useExternalServer: boolean,
+): string {
+  if (!useExternalServer && state?.status === 'running' && state.wsUrl) {
+    return state.wsUrl;
+  }
+  return configuredUrl;
+}

--- a/app/src/main/services/server-settings.ts
+++ b/app/src/main/services/server-settings.ts
@@ -5,11 +5,11 @@ import { createLogger } from '../lib/logger.js';
 const log = createLogger('ServerSettings');
 
 /**
- * Derive the server base URL from the WebSocket URL in settings.
+ * Derive the server base URL from a WebSocket endpoint.
  * e.g. "ws://localhost:51717/transcribe" → "http://localhost:51717"
  */
-function getBaseUrl(): string {
-  const wsUrl = getSetting('serverUrl');
+function getBaseUrl(serverUrl?: string): string {
+  const wsUrl = serverUrl ?? getSetting('serverUrl');
   const url = new URL(wsUrl);
   url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
   // Strip path (e.g. /transcribe) to get the base
@@ -17,8 +17,8 @@ function getBaseUrl(): string {
   return url.origin;
 }
 
-async function fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
-  const base = getBaseUrl();
+async function fetchJson<T>(path: string, options?: RequestInit, serverUrl?: string): Promise<T> {
+  const base = getBaseUrl(serverUrl);
   const url = `${base}${path}`;
   log.debug('Fetching', { url, method: options?.method ?? 'GET' });
 
@@ -38,24 +38,25 @@ async function fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export async function getServerSettings(): Promise<ServerSettingsResponse> {
-  return fetchJson<ServerSettingsResponse>('/settings');
+export async function getServerSettings(serverUrl?: string): Promise<ServerSettingsResponse> {
+  return fetchJson<ServerSettingsResponse>('/settings', undefined, serverUrl);
 }
 
 export async function updateServerSettings(
-  patch: Record<string, unknown>
+  patch: Record<string, unknown>,
+  serverUrl?: string,
 ): Promise<ServerSettingsResponse> {
   return fetchJson<ServerSettingsResponse>('/settings', {
     method: 'PATCH',
     body: JSON.stringify(patch),
-  });
+  }, serverUrl);
 }
 
-export async function getEngineStatus(): Promise<EngineStatus> {
-  return fetchJson<EngineStatus>('/engine/status');
+export async function getEngineStatus(serverUrl?: string): Promise<EngineStatus> {
+  return fetchJson<EngineStatus>('/engine/status', undefined, serverUrl);
 }
 
-export async function getAvailableEngines(): Promise<AvailableEngine[]> {
-  const data = await fetchJson<{ engines: AvailableEngine[] }>('/engines');
+export async function getAvailableEngines(serverUrl?: string): Promise<AvailableEngine[]> {
+  const data = await fetchJson<{ engines: AvailableEngine[] }>('/engines', undefined, serverUrl);
   return data.engines;
 }

--- a/app/src/renderer/app/server-settings-recovery.ts
+++ b/app/src/renderer/app/server-settings-recovery.ts
@@ -1,0 +1,38 @@
+import type { ServerStatePayload } from '../../shared/types';
+
+type SettingsRecoveryState = Pick<ServerStatePayload, 'status' | 'port' | 'version' | 'engineStatus' | 'modelDownload'>;
+
+/**
+ * Identify a meaningful server transition without using uptime or byte-level
+ * progress, so a failed settings request is retried once per readiness state.
+ */
+export function serverSettingsStateKey(state: SettingsRecoveryState | null | undefined): string {
+  const engine = state?.engineStatus;
+  const model = state?.modelDownload;
+  return [
+    state?.status ?? 'none',
+    state?.port ?? '',
+    state?.version ?? '',
+    engine?.current ?? '',
+    engine?.status ?? '',
+    engine?.pending?.engine ?? '',
+    engine?.pending?.status ?? '',
+    model?.model ?? '',
+    model?.status ?? '',
+    model?.phase ?? '',
+  ].join('|');
+}
+
+export function shouldRetryServerSettings(
+  state: SettingsRecoveryState | null | undefined,
+  connected: boolean,
+  loading: boolean,
+  lastAttemptKey: string | null,
+): boolean {
+  if (!state || state.status !== 'running' || connected || loading) return false;
+  return serverSettingsStateKey(state) !== lastAttemptKey;
+}
+
+export function shouldClearServerSettings(state: SettingsRecoveryState | null | undefined): boolean {
+  return state !== null && state !== undefined && state.status !== 'running';
+}

--- a/app/src/renderer/app/server-settings-recovery.ts
+++ b/app/src/renderer/app/server-settings-recovery.ts
@@ -1,6 +1,6 @@
 import type { ServerStatePayload } from '../../shared/types';
 
-type SettingsRecoveryState = Pick<ServerStatePayload, 'status' | 'port' | 'version' | 'engineStatus' | 'modelDownload'>;
+type SettingsRecoveryState = Pick<ServerStatePayload, 'status' | 'port' | 'wsUrl' | 'version' | 'engineStatus' | 'modelDownload'>;
 
 /**
  * Identify a meaningful server transition without using uptime or byte-level
@@ -12,6 +12,7 @@ export function serverSettingsStateKey(state: SettingsRecoveryState | null | und
   return [
     state?.status ?? 'none',
     state?.port ?? '',
+    state?.wsUrl ?? '',
     state?.version ?? '',
     engine?.current ?? '',
     engine?.status ?? '',
@@ -33,6 +34,9 @@ export function shouldRetryServerSettings(
   return serverSettingsStateKey(state) !== lastAttemptKey;
 }
 
-export function shouldClearServerSettings(state: SettingsRecoveryState | null | undefined): boolean {
-  return state !== null && state !== undefined && state.status !== 'running';
+export function shouldClearServerSettings(
+  state: SettingsRecoveryState | null | undefined,
+  externalMode: boolean,
+): boolean {
+  return !externalMode && state !== null && state !== undefined && state.status !== 'running';
 }

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import ModelProgressCard from '../components/ModelProgressCard.svelte';
-  import { shouldShowModelProgress } from '$shared/model-progress';
   import type { ServerStatusPhase } from '../server-status';
   import { getServerManagementMode, retryManagedServer, serverStatusState } from '../server-status';
 
@@ -18,7 +16,6 @@
   let server = $derived(snapshot.state);
   let engine = $derived(server?.engineStatus?.info);
   let model = $derived(server?.modelDownload ?? null);
-  let showModelProgress = $derived(shouldShowModelProgress(model ?? undefined));
 
   const phaseCopy: Record<ServerStatusPhase, { title: string; detail: string }> = {
     connecting: { title: 'Connecting', detail: 'Checking the local speech service.' },
@@ -124,11 +121,6 @@
         </p>
       {/if}
 
-      {#if showModelProgress}
-        <div class="mt-4 max-w-2xl">
-          <ModelProgressCard state={model ?? undefined} announce={false} />
-        </div>
-      {/if}
     </section>
 
     <section class="grid gap-4 lg:grid-cols-2" aria-label="Dictation shortcuts and guidance">

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -9,6 +9,7 @@
   import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
   import { SPEECH_MODEL_PRESETS, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../speech-model-presets';
   import { getServerManagementMode, serverStatusState } from '../server-status';
+  import { serverSettingsStateKey, shouldClearServerSettings, shouldRetryServerSettings } from '../server-settings-recovery';
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting } from '$shared/types';
   import { HOTWORDS_WARNING_THRESHOLD, formatHotwordsCsl, parseHotwordsCsl } from '$shared/hotwords';
@@ -24,15 +25,15 @@
     longHotkey: { ...DEFAULT_SETTINGS.longHotkey },
   });
 
-  // Default hotkey (Ctrl+Meta)
+  // Default hotkey (Ctrl+Win on Windows; stored as the libuiohook Meta keycode)
   const DEFAULT_HOTKEY: Hotkey = DEFAULT_SETTINGS.hotkey;
 
-  // Default long dictation hotkey (Ctrl+Shift+Meta)
+  // Default long dictation hotkey (Ctrl+Shift+Win on Windows)
   const DEFAULT_LONG_HOTKEY: Hotkey = DEFAULT_SETTINGS.longHotkey;
 
   // Hotkey display name (human-readable)
-  let hotkeyDisplayName = $state('Ctrl+Meta');
-  let longHotkeyDisplayName = $state('Ctrl+Shift+Meta');
+  let hotkeyDisplayName = $state('Ctrl+Win');
+  let longHotkeyDisplayName = $state('Ctrl+Shift+Win');
   let isHotkeyModalOpen = $state(false);
   let hotkeyCaptureTarget = $state<'quick' | 'long'>('quick');
 
@@ -74,6 +75,8 @@
   let serverSettings = $state<Record<string, ServerSetting<unknown>> | null>(null);
   let engineStatus = $state<EngineStatus | null>(null);
   let serverConnected = $state(false);
+  let serverSettingsLoading = $state(false);
+  let lastServerSettingsAttemptKey = $state<string | null>(null);
   let engineAdvancedOpen = $state(false);
   let engineApplying = $state(false);
   let availableEngines = $state<string[]>([]);
@@ -103,7 +106,7 @@
   );
 
   // Whether the current engine supports hotwords (Whisper: yes, Nemotron: no)
-  let hotwordsSupported = $derived(engineStatus?.info?.supports_hotwords ?? true);
+  let hotwordsSupported = $derived(sharedEngineStatus?.info?.supports_hotwords ?? true);
 
   // Check visibility: should a setting be shown based on visible_when?
   function isVisible(setting: ServerSetting<unknown>): boolean {
@@ -254,6 +257,8 @@
   }
 
   async function loadServerSettings() {
+    if (serverSettingsLoading) return;
+    serverSettingsLoading = true;
     try {
       const serverData = await window.murmurMain.getServerSettings();
       serverSettings = serverData.settings;
@@ -261,7 +266,12 @@
       availableEngines = serverData.available_engines ?? [];
       serverConnected = true;
     } catch {
+      serverSettings = null;
+      engineStatus = null;
+      availableEngines = [];
       serverConnected = false;
+    } finally {
+      serverSettingsLoading = false;
     }
   }
 
@@ -300,6 +310,23 @@
     void window.murmurMain.getAppVersion()
       .then((version) => (appVersion = version))
       .catch((error) => console.error('Failed to load app version:', error));
+  });
+
+  $effect(() => {
+    const state = sharedServerState;
+    if (shouldClearServerSettings(state)) {
+      serverSettings = null;
+      engineStatus = null;
+      availableEngines = [];
+      serverConnected = false;
+      lastServerSettingsAttemptKey = null;
+      return;
+    }
+
+    if (shouldRetryServerSettings(state, serverConnected, serverSettingsLoading, lastServerSettingsAttemptKey)) {
+      lastServerSettingsAttemptKey = serverSettingsStateKey(state);
+      void loadServerSettings();
+    }
   });
 
   function updateSetting<K extends keyof Settings>(key: K, value: Settings[K]) {
@@ -483,7 +510,7 @@
             <button
               onclick={resetHotkey}
               class="p-1.5 text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer"
-              title="Reset to Ctrl+Meta"
+              title="Reset to Ctrl+Win"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
@@ -506,7 +533,7 @@
             <button
               onclick={resetLongHotkey}
               class="p-1.5 text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer"
-              title="Reset to Ctrl+Shift+Meta"
+              title="Reset to Ctrl+Shift+Win"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -86,7 +86,7 @@
   let pendingEngine = $state<Record<string, unknown>>({});
   let sharedServerState = $derived($serverStatusState.state);
   let sharedEngineStatus = $derived(sharedServerState?.engineStatus ?? engineStatus);
-  let externalMode = $derived(getServerManagementMode($serverStatusState) === 'external');
+  let externalMode = $derived(settings.useExternalServer || getServerManagementMode($serverStatusState) === 'external');
 
   // Derive current values (server value overridden by pending)
   function getSettingValue<T>(key: string): T | undefined {
@@ -314,7 +314,7 @@
 
   $effect(() => {
     const state = sharedServerState;
-    if (shouldClearServerSettings(state)) {
+    if (shouldClearServerSettings(state, externalMode)) {
       serverSettings = null;
       engineStatus = null;
       availableEngines = [];

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -382,7 +382,7 @@ export const DEFAULT_SETTINGS: Settings = {
     metaKey: false,
   },
   longHotkey: {
-    keycode: 3675, // Ctrl+Shift+Meta toggles long dictation
+    keycode: 3675, // Ctrl+Shift+Win in the Windows UI; Meta in libuiohook storage
     ctrlKey: true,
     altKey: false,
     shiftKey: true,

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -212,7 +212,9 @@ describe('Home and shared server status', () => {
   });
 
   test('shares phase and progress UI while retaining factual shortcuts, privacy, actions, and restrained live announcements', () => {
-    expect(homeView).toContain('<ModelProgressCard state={model ?? undefined} announce={false} />');
+    expect(appView).toContain('<ModelProgressBanner visible />');
+    expect(homeView).not.toContain('ModelProgressCard');
+    expect(homeView).not.toContain('shouldShowModelProgress');
     expect(homeView).toContain('getHotkeyDisplayName(settings.hotkey)');
     expect(homeView).toContain('getHotkeyDisplayName(settings.longHotkey)');
     expect(homeView).toContain('does not automatically import personal data');

--- a/app/tests/keycodes.test.ts
+++ b/app/tests/keycodes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { formatHotkeyForPlatform } from '../src/main/services/keycodes';
-import { DEFAULT_SETTINGS } from '../src/shared/types';
+import { DEFAULT_SETTINGS } from '$shared/types';
 
 describe('hotkey display labels', () => {
   const ctrlWin = {

--- a/app/tests/keycodes.test.ts
+++ b/app/tests/keycodes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { formatHotkeyForPlatform } from '../src/main/services/keycodes';
+import { DEFAULT_SETTINGS } from '../src/shared/types';
+
+describe('hotkey display labels', () => {
+  const ctrlWin = {
+    keycode: 3675,
+    ctrlKey: true,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+  };
+
+  test('calls the Windows key Win without changing stored Meta keycode semantics', () => {
+    expect(formatHotkeyForPlatform(ctrlWin, 'win32')).toBe('Ctrl+Win');
+    expect(formatHotkeyForPlatform({ ...ctrlWin, shiftKey: true }, 'win32')).toBe('Ctrl+Shift+Win');
+    expect(formatHotkeyForPlatform(ctrlWin, 'darwin')).toBe('Ctrl+Meta');
+    expect(DEFAULT_SETTINGS.hotkey).toMatchObject({ keycode: 3675, ctrlKey: true, metaKey: false });
+    expect(DEFAULT_SETTINGS.longHotkey).toMatchObject({ keycode: 3675, ctrlKey: true, shiftKey: true, metaKey: false });
+  });
+});

--- a/app/tests/server-api-url.test.ts
+++ b/app/tests/server-api-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveServerApiUrl } from '../src/main/services/server-api-url';
+
+describe('server API endpoint selection', () => {
+  const configured = 'ws://localhost:51717/transcribe';
+  const dynamic = 'ws://localhost:51490/transcribe';
+
+  test('uses the manager-reported dynamic endpoint for managed running servers', () => {
+    expect(resolveServerApiUrl(configured, { status: 'running', wsUrl: dynamic }, false)).toBe(dynamic);
+    expect(resolveServerApiUrl(configured, { status: 'starting' }, false)).toBe(configured);
+  });
+
+  test('preserves the configured endpoint for external-server mode', () => {
+    expect(resolveServerApiUrl(configured, { status: 'running', wsUrl: dynamic }, true)).toBe(configured);
+  });
+});

--- a/app/tests/server-settings-recovery.test.ts
+++ b/app/tests/server-settings-recovery.test.ts
@@ -10,6 +10,7 @@ const ready = {
   status: 'running' as const,
   managed: true,
   port: 51490,
+  wsUrl: 'ws://localhost:51490/transcribe',
   version: '0.8.0',
   engineStatus: { current: 'whisper', status: 'ready' as const },
 };
@@ -29,8 +30,14 @@ describe('Settings server-state recovery', () => {
     const loading = { ...ready, engineStatus: { current: 'whisper', status: 'loading' as const } };
     expect(serverSettingsStateKey(loading)).not.toBe(readyKey);
     expect(shouldRetryServerSettings(loading, false, false, readyKey)).toBeTrue();
-    expect(shouldClearServerSettings(null)).toBeFalse();
-    expect(shouldClearServerSettings(starting)).toBeTrue();
-    expect(shouldClearServerSettings(ready)).toBeFalse();
+    expect(shouldClearServerSettings(null, false)).toBeFalse();
+    expect(shouldClearServerSettings(starting, false)).toBeTrue();
+    expect(shouldClearServerSettings(starting, true)).toBeFalse();
+    expect(shouldClearServerSettings(ready, false)).toBeFalse();
+  });
+
+  test('retries when the live endpoint changes even if its port is reused', () => {
+    const samePortDifferentEndpoint = { ...ready, wsUrl: 'ws://127.0.0.1:51490/transcribe' };
+    expect(serverSettingsStateKey(samePortDifferentEndpoint)).not.toBe(serverSettingsStateKey(ready));
   });
 });

--- a/app/tests/server-settings-recovery.test.ts
+++ b/app/tests/server-settings-recovery.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  serverSettingsStateKey,
+  shouldClearServerSettings,
+  shouldRetryServerSettings,
+} from '../src/renderer/app/server-settings-recovery';
+
+const starting = { status: 'starting' as const, managed: true };
+const ready = {
+  status: 'running' as const,
+  managed: true,
+  port: 51490,
+  version: '0.8.0',
+  engineStatus: { current: 'whisper', status: 'ready' as const },
+};
+
+describe('Settings server-state recovery', () => {
+  test('retries after a loading-to-ready transition without polling or duplicate in-flight calls', () => {
+    expect(shouldRetryServerSettings(starting, false, false, null)).toBeFalse();
+    const readyKey = serverSettingsStateKey(ready);
+    expect(shouldRetryServerSettings(ready, false, false, null)).toBeTrue();
+    expect(shouldRetryServerSettings(ready, false, true, null)).toBeFalse();
+    expect(shouldRetryServerSettings(ready, false, false, readyKey)).toBeFalse();
+    expect(shouldRetryServerSettings(ready, true, false, readyKey)).toBeFalse();
+  });
+
+  test('retries when the live endpoint or engine readiness changes and clears stale choices while stopped', () => {
+    const readyKey = serverSettingsStateKey(ready);
+    const loading = { ...ready, engineStatus: { current: 'whisper', status: 'loading' as const } };
+    expect(serverSettingsStateKey(loading)).not.toBe(readyKey);
+    expect(shouldRetryServerSettings(loading, false, false, readyKey)).toBeTrue();
+    expect(shouldClearServerSettings(null)).toBeFalse();
+    expect(shouldClearServerSettings(starting)).toBeTrue();
+    expect(shouldClearServerSettings(ready)).toBeFalse();
+  });
+});

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -33,6 +33,9 @@ describe('speech model presets', () => {
     expect(chooser).toContain('Apply and prepare model confirms the change.');
     expect(settings).toContain('Apply and prepare model');
     expect(settings).toContain('serverStatusState');
+    expect(settings).toContain('shouldRetryServerSettings');
+    expect(settings).toContain('shouldClearServerSettings');
+    expect(settings).toContain('serverSettingsLoading');
     expect(settings).not.toContain('async function pollEngineStatus');
     expect(settings).toContain('!!sharedEngineStatus?.message');
     expect(settings).toContain("sharedEngineStatus?.pending?.status === 'error'");


### PR DESCRIPTION
## Summary\n- route managed server settings/engine API calls through ServerManager's live dynamic wsUrl while preserving the saved endpoint for explicit external-server mode\n- retry Settings server metadata after shared status reaches a new running/ready state and clear stale choices when unavailable\n- keep one shared Home model-progress presentation, and label the stored Windows Meta keycode as Win on Windows\n\n## Root cause\nSettings made one /settings request while the managed server was still starting, then never recovered. The main-process proxy also used the persisted serverUrl (51717) even though the managed server publishes a dynamic port (for example 51490). Home and the global banner consumed the same state but Home rendered a second progress card. The hotkey formatter exposed libuiohook's Meta name directly.\n\n## Validation\n- focused renderer/main tests: 21 passed\n- full app matrix: 137 passed\n- renderer and main TypeScript checks passed\n- renderer and main production builds passed\n- python scripts/version.py check --tag v0.8.0 passed\n- git diff --check passed\n\nNo version, dependency/lock, identity/GUID, profile/cache, protocol, installer, runtime, or release asset changes. No package/lifecycle/publication action performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server settings now connect automatically to the active endpoint across managed and external server modes.
  * Hotkey labels use platform-appropriate terminology, including “Win” on Windows.
* **Improvements**
  * Settings recover more reliably after server readiness changes and clear stale data when the server stops.
  * Simplified model download progress messaging on the home screen.
  * Improved engine status handling for hotword support.
* **Tests**
  * Added coverage for endpoint selection, settings recovery, and platform-specific hotkey labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->