### PR TITLE
feat(settings): cohere General and Speech controls

### DIFF
--- a/app/src/renderer/app/components/SettingsGroup.svelte
+++ b/app/src/renderer/app/components/SettingsGroup.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type GroupVariant = 'rows' | 'panel';
+
+  interface Props {
+    title: string;
+    description?: string;
+    id?: string;
+    variant?: GroupVariant;
+    children: Snippet;
+  }
+
+  let { title, description, id, variant = 'rows', children }: Props = $props();
+  const componentId = $props.id();
+
+  function slugify(value: string): string {
+    return value
+      .toLowerCase()
+      .replace(/&/g, ' and ')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+
+  let headingId = $derived(id ?? `settings-group-${slugify(title) || 'group'}-${componentId}`);
+</script>
+
+<section data-settings-group class="min-w-0 space-y-2" aria-labelledby={headingId}>
+  <div class="min-w-0 px-1">
+    <h3 id={headingId} class="text-xs font-medium text-zinc-300">{title}</h3>
+    {#if description}
+      <p class="mt-1 max-w-prose text-[11px] leading-4 text-zinc-500">{description}</p>
+    {/if}
+  </div>
+
+  {#if variant === 'rows'}
+    <div data-settings-group-surface class="min-w-0 w-full divide-y divide-white/[0.08] rounded-xl border border-white/10 bg-white/[0.025]">
+      {@render children()}
+    </div>
+  {:else}
+    <div data-settings-group-surface class="min-w-0 w-full rounded-xl border border-white/10 bg-white/[0.025] p-4 sm:p-5">
+      {@render children()}
+    </div>
+  {/if}
+</section>

--- a/app/src/renderer/app/components/SpeechModelChooser.svelte
+++ b/app/src/renderer/app/components/SpeechModelChooser.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import type { EngineStatus, ModelDownloadState } from '$shared/types';
-  import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesCurrentEngine, type SpeechModelPreset } from '../speech-model-presets';
+  import { SPEECH_MODEL_PRESETS, presetMatchesCurrentEngine, type SpeechModelPreset } from '../speech-model-presets';
 
   interface Props {
     selected: SpeechModelPreset | null;
@@ -9,31 +10,150 @@
     engineStatus: EngineStatus | null;
     modelDownload?: ModelDownloadState;
     externalMode: boolean;
+    preparationFailed: boolean;
     onSelect: (preset: SpeechModelPreset) => void;
+    children?: Snippet;
   }
 
-  let { selected, availableEngines, availabilityKnown, engineStatus, modelDownload, externalMode, onSelect }: Props = $props();
+  let {
+    selected,
+    availableEngines,
+    availabilityKnown,
+    engineStatus,
+    modelDownload,
+    externalMode,
+    preparationFailed,
+    onSelect,
+    children,
+  }: Props = $props();
+
   function unavailable(preset: SpeechModelPreset): boolean {
     return availabilityKnown && !availableEngines.includes(preset.engine);
   }
+
+  function isCurrent(preset: SpeechModelPreset): boolean {
+    return presetMatchesCurrentEngine(preset, engineStatus);
+  }
+
+  function isSelected(preset: SpeechModelPreset): boolean {
+    return selected?.id === preset.id && !isCurrent(preset);
+  }
+
+  function isTargeted(preset: SpeechModelPreset): boolean {
+    return modelDownload?.model === preset.model;
+  }
+
+  function isPreparing(preset: SpeechModelPreset): boolean {
+    if (!isTargeted(preset)) return false;
+    return modelDownload?.status === 'partial'
+      || modelDownload?.status === 'downloading'
+      || modelDownload?.phase === 'checking'
+      || modelDownload?.phase === 'downloading'
+      || modelDownload?.phase === 'loading'
+      || engineStatus?.pending?.engine === preset.engine;
+  }
+
+  function isError(preset: SpeechModelPreset): boolean {
+    return isTargeted(preset) && preparationFailed;
+  }
+
+  function stateLabel(preset: SpeechModelPreset): string {
+    if (unavailable(preset)) return 'Unavailable';
+    if (isError(preset)) return isSelected(preset) ? 'Selected · Error' : 'Error';
+    if (isCurrent(preset)) return 'Current';
+    if (isSelected(preset)) return isPreparing(preset) ? 'Selected · Preparing' : 'Selected';
+    if (isPreparing(preset)) return 'Preparing';
+    return 'Available';
+  }
+
+  function stateClass(preset: SpeechModelPreset): string {
+    const label = stateLabel(preset);
+    if (label.includes('Error')) {
+      return 'text-red-300';
+    }
+    if (label.includes('Preparing')) {
+      return 'text-amber-300';
+    }
+    switch (label) {
+      case 'Current':
+        return 'text-emerald-300';
+      case 'Selected':
+        return 'text-sky-300';
+      case 'Preparing':
+        return 'text-amber-300';
+      case 'Error':
+        return 'text-red-300';
+      case 'Unavailable':
+        return 'text-zinc-500';
+      default:
+        return 'text-zinc-400';
+    }
+  }
 </script>
 
-<fieldset class="space-y-3" aria-describedby="speech-model-help">
-  <legend class="text-sm font-medium text-zinc-200">Choose a speech model</legend>
-  <p id="speech-model-help" class="text-xs text-zinc-500">Choosing a model only stages it. Apply and prepare model confirms the change.</p>
-  {#if externalMode}
-    <p class="rounded-lg border border-zinc-700 p-3 text-xs text-zinc-400">An external server controls its own model preparation. Configure it through its own endpoint.</p>
-  {:else}
-    <div class="grid gap-2 sm:grid-cols-2">
-      {#each SPEECH_MODEL_PRESETS as preset}
-        {@const disabled = unavailable(preset)}
-        <label class="rounded-xl border p-3 transition-colors focus-within:outline-hidden focus-within:ring-2 focus-within:ring-zinc-100 {disabled ? 'border-zinc-800 opacity-60 cursor-not-allowed' : 'border-white/10 hover:bg-white/[0.04] cursor-pointer'}">
-          <input class="sr-only" type="radio" name="speech-model-preset" checked={selected?.id === preset.id} disabled={disabled} onchange={() => onSelect(preset)} aria-describedby={`preset-${preset.id}-detail`} />
-          <span class="flex items-start justify-between gap-3"><span class="text-sm font-medium text-zinc-100">{preset.label}</span><span class="text-xs text-zinc-400">{presetMatchesCurrentEngine(preset, engineStatus) ? 'Current' : selected?.id === preset.id ? 'Selected' : presetDownloadLabel(modelDownload, preset)}</span></span>
-          <span id={`preset-${preset.id}-detail`} class="mt-1 block text-xs leading-5 text-zinc-400">{preset.language} · approx. {preset.sizeGb} GB. {preset.summary}</span>
-          {#if disabled}<span class="mt-2 block text-xs text-amber-300">This server does not have the required {preset.engine} runtime.</span>{/if}
-        </label>
-      {/each}
+<div data-speech-model-panel class="min-w-0 w-full rounded-xl border border-white/10 bg-white/[0.025] p-4 sm:p-5">
+  <fieldset class="m-0 min-w-0 border-0 p-0" aria-describedby="speech-model-help">
+    <legend class="text-sm font-medium text-zinc-100">Choose a speech model</legend>
+    <p id="speech-model-help" class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">
+      Select a curated model to stage. Apply and prepare model confirms the change. The current engine stays active until the selected model is ready.
+    </p>
+
+    {#if externalMode}
+      <div data-speech-model-external role="status" class="mt-4 border-t border-white/[0.08] pt-4 text-xs leading-5 text-zinc-400">
+        An external server controls model preparation. Manage its model through that server's own endpoint.
+      </div>
+    {:else}
+      <div data-speech-model-list role="radiogroup" aria-label="Curated speech models" class="mt-4 divide-y divide-white/[0.08]">
+        {#each SPEECH_MODEL_PRESETS as preset}
+          {@const disabled = unavailable(preset)}
+          {@const checked = selected?.id === preset.id}
+          {@const label = stateLabel(preset)}
+          <label
+            data-speech-model-option
+            class="flex min-w-0 items-start gap-3 py-3 first:pt-0 last:pb-0 focus-within:rounded-lg focus-within:outline-none focus-within:ring-2 focus-within:ring-zinc-100 focus-within:ring-offset-2 focus-within:ring-offset-[#08090a]
+              {disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}"
+          >
+            <input
+              class="sr-only"
+              type="radio"
+              name="speech-model-preset"
+              checked={checked}
+              disabled={disabled}
+              onchange={() => onSelect(preset)}
+              aria-label={`${preset.label}, ${label}`}
+              aria-describedby={`preset-${preset.id}-detail`}
+            />
+            <span
+              aria-hidden="true"
+              class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border {checked ? 'border-sky-300' : 'border-zinc-600'}"
+            >
+              {#if checked}
+                <span class="h-2 w-2 rounded-full bg-sky-300"></span>
+              {/if}
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-x-3 sm:gap-y-1">
+                <span class="min-w-0 text-sm font-medium text-zinc-100 [overflow-wrap:anywhere]">{preset.label}</span>
+                <span data-speech-model-state class="max-w-full text-xs [overflow-wrap:anywhere] {stateClass(preset)}">{label}</span>
+              </span>
+              <span id={`preset-${preset.id}-detail`} class="mt-1 block text-xs leading-5 text-zinc-400 [overflow-wrap:anywhere]">
+                {preset.language} · approx. {preset.sizeGb} GB. {preset.summary}
+              </span>
+              {#if disabled}
+                <span class="mt-1 block text-xs text-amber-300">This server does not have the required {preset.engine} runtime.</span>
+              {:else if isError(preset)}
+                <span class="mt-1 block text-xs text-red-300">Preparation failed. Use Retry preparation or Revert below.</span>
+              {/if}
+            </span>
+          </label>
+        {/each}
+      </div>
+    {/if}
+  </fieldset>
+
+  {#if children}
+    <div data-model-action-footer class="mt-4 border-t border-white/[0.08] pt-4">
+      {@render children()}
     </div>
   {/if}
-</fieldset>
+</div>

--- a/app/src/renderer/app/components/SpeechModelChooser.svelte
+++ b/app/src/renderer/app/components/SpeechModelChooser.svelte
@@ -117,7 +117,7 @@
             <input
               class="sr-only"
               type="radio"
-              name="speech-model-preset"
+              name={`speech-model-preset-${componentId}`}
               checked={checked}
               disabled={disabled}
               onchange={() => onSelect(preset)}

--- a/app/src/renderer/app/components/SpeechModelChooser.svelte
+++ b/app/src/renderer/app/components/SpeechModelChooser.svelte
@@ -26,6 +26,12 @@
     onSelect,
     children,
   }: Props = $props();
+  const componentId = $props.id();
+  const helpId = `speech-model-help-${componentId}`;
+
+  function detailId(presetId: SpeechModelPreset['id']): string {
+    return `speech-model-${componentId}-${presetId}-detail`;
+  }
 
   function unavailable(preset: SpeechModelPreset): boolean {
     return availabilityKnown && !availableEngines.includes(preset.engine);
@@ -66,21 +72,16 @@
     return 'Available';
   }
 
-  function stateClass(preset: SpeechModelPreset): string {
-    const label = stateLabel(preset);
-    if (label.includes('Error')) {
-      return 'text-red-300';
-    }
-    if (label.includes('Preparing')) {
-      return 'text-amber-300';
-    }
+  function stateClass(label: string): string {
     switch (label) {
       case 'Current':
         return 'text-emerald-300';
       case 'Selected':
         return 'text-sky-300';
+      case 'Selected · Preparing':
       case 'Preparing':
         return 'text-amber-300';
+      case 'Selected · Error':
       case 'Error':
         return 'text-red-300';
       case 'Unavailable':
@@ -92,9 +93,9 @@
 </script>
 
 <div data-speech-model-panel class="min-w-0 w-full rounded-xl border border-white/10 bg-white/[0.025] p-4 sm:p-5">
-  <fieldset class="m-0 min-w-0 border-0 p-0" aria-describedby="speech-model-help">
+  <fieldset class="m-0 min-w-0 border-0 p-0" aria-describedby={helpId}>
     <legend class="text-sm font-medium text-zinc-100">Choose a speech model</legend>
-    <p id="speech-model-help" class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">
+    <p id={helpId} class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">
       Select a curated model to stage. Apply and prepare model confirms the change. The current engine stays active until the selected model is ready.
     </p>
 
@@ -105,7 +106,7 @@
     {:else}
       <div data-speech-model-list role="radiogroup" aria-label="Curated speech models" class="mt-4 divide-y divide-white/[0.08]">
         {#each SPEECH_MODEL_PRESETS as preset}
-          {@const disabled = unavailable(preset)}
+          {@const disabled = externalMode || unavailable(preset)}
           {@const checked = selected?.id === preset.id}
           {@const label = stateLabel(preset)}
           <label
@@ -121,7 +122,7 @@
               disabled={disabled}
               onchange={() => onSelect(preset)}
               aria-label={`${preset.label}, ${label}`}
-              aria-describedby={`preset-${preset.id}-detail`}
+              aria-describedby={detailId(preset.id)}
             />
             <span
               aria-hidden="true"
@@ -134,9 +135,9 @@
             <span class="min-w-0 flex-1">
               <span class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-x-3 sm:gap-y-1">
                 <span class="min-w-0 text-sm font-medium text-zinc-100 [overflow-wrap:anywhere]">{preset.label}</span>
-                <span data-speech-model-state class="max-w-full text-xs [overflow-wrap:anywhere] {stateClass(preset)}">{label}</span>
+                <span data-speech-model-state class="max-w-full text-xs [overflow-wrap:anywhere] {stateClass(label)}">{label}</span>
               </span>
-              <span id={`preset-${preset.id}-detail`} class="mt-1 block text-xs leading-5 text-zinc-400 [overflow-wrap:anywhere]">
+              <span id={detailId(preset.id)} class="mt-1 block text-xs leading-5 text-zinc-400 [overflow-wrap:anywhere]">
                 {preset.language} · approx. {preset.sizeGb} GB. {preset.summary}
               </span>
               {#if disabled}

--- a/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
@@ -201,15 +201,13 @@
                     {compatibilityOpen ? 'Hide controls' : 'Show controls'}
                   </button>
                 </div>
-                {#if compatibilityOpen}
-                  <div id="fixture-compatibility-controls" data-fixture-compatibility-controls class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2">
+                <div id="fixture-compatibility-controls" data-fixture-compatibility-controls hidden={!compatibilityOpen} class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2">
                     <SettingsRow label="Whisper model" description="Raw compatibility model"><select aria-label="Whisper model" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>large-v3-turbo</option><option>large-v3</option></select></SettingsRow>
                     <SettingsRow label="Compute type" description="Precision used by Faster-Whisper"><select aria-label="Compute type" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>int8</option><option>float16</option></select></SettingsRow>
                     <SettingsRow label="Language" description="Language hint for compatibility"><input aria-label="Whisper language" value="auto" class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-28" /></SettingsRow>
                     <SettingsRow label="Device" description="Hardware device for inference"><select aria-label="Whisper device" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>cuda</option><option>cpu</option></select></SettingsRow>
                     <SettingsRow label="Unload before swap" description="Free VRAM before loading a new engine"><Toggle enabled label="Unload before swap" /></SettingsRow>
-                  </div>
-                {/if}
+                </div>
                 <div data-fixture-compatibility-footer class="mt-4 border-t border-white/[0.08] pt-4">
                   <div class="flex flex-wrap items-center justify-between gap-3">
                     <p class="text-xs text-amber-300">Compatibility changes require an engine reload.</p>

--- a/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+  import type { EngineStatus, ModelDownloadState } from '$shared/types';
+  import { SPEECH_MODEL_PRESETS, type SpeechModelPreset } from '../speech-model-presets';
+  import SettingsGroup from '../components/SettingsGroup.svelte';
+  import SettingsRow from '../components/SettingsRow.svelte';
+  import SettingsSection from '../components/SettingsSection.svelte';
+  import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
+  import Toggle from '../components/Toggle.svelte';
+
+  type FixtureState = 'ready' | 'preparing' | 'error' | 'external';
+
+  const params = new URLSearchParams(globalThis.location.search);
+  const fixtureState = (params.get('state') ?? 'ready') as FixtureState;
+  const fixtureView = params.get('view') ?? 'all';
+  let compatibilityOpen = $state(params.get('compatibility') === 'expanded');
+  let selectedPreset = $state<SpeechModelPreset>(
+    fixtureState === 'ready' || fixtureState === 'external'
+      ? SPEECH_MODEL_PRESETS[1]!
+      : SPEECH_MODEL_PRESETS[2]!,
+  );
+
+  const currentPreset = SPEECH_MODEL_PRESETS[1]!;
+  const targetPreset = SPEECH_MODEL_PRESETS[2]!;
+  const currentEngineStatus: EngineStatus = {
+    current: currentPreset.engine,
+    status: 'ready',
+    info: {
+      id: currentPreset.engine,
+      name: 'Faster-Whisper',
+      model: currentPreset.model,
+      supports_hotwords: true,
+      languages: ['en', 'fr', 'de'],
+      model_size_gb: currentPreset.sizeGb,
+      gpu_name: 'Fixture GPU',
+      gpu_vram_gb: 16,
+    },
+  };
+
+  const engineStatus: EngineStatus = fixtureState === 'preparing'
+    ? { ...currentEngineStatus, pending: { engine: targetPreset.engine, status: 'loading', message: 'Loading selected model' } }
+    : fixtureState === 'error'
+      ? { ...currentEngineStatus, pending: { engine: targetPreset.engine, status: 'error', message: 'Selected model could not be prepared' } }
+      : currentEngineStatus;
+
+  const modelDownload: ModelDownloadState = fixtureState === 'preparing'
+    ? {
+        model: targetPreset.model,
+        size_gb: targetPreset.sizeGb,
+        status: 'downloading',
+        phase: 'downloading',
+        progress_percent: 62,
+        downloaded_bytes: 1000000000,
+        total_bytes: 1600000000,
+        bytes_per_second: 3000000,
+        eta_seconds: 120,
+        current_file: 'model weights',
+      }
+    : fixtureState === 'error'
+      ? {
+          model: targetPreset.model,
+          size_gb: targetPreset.sizeGb,
+          status: 'error',
+          phase: 'error',
+          detail: 'The fixture selected-model preparation failed.',
+        }
+      : {
+          model: currentPreset.model,
+          size_gb: currentPreset.sizeGb,
+          status: 'ready',
+          phase: 'ready',
+          cached: true,
+        };
+
+  function selectPreset(preset: SpeechModelPreset): void {
+    selectedPreset = preset;
+  }
+</script>
+
+<div class="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[#08090a] text-zinc-100">
+  <header class="flex h-12 shrink-0 items-center justify-between gap-3 px-4 sm:px-6">
+    <h1 class="text-sm font-semibold text-zinc-100">Phase 2 Settings fixture</h1>
+    <span data-fixture-state class="rounded-full border border-white/10 px-2.5 py-1 text-[11px] text-zinc-400">{fixtureState}</span>
+  </header>
+
+  <main data-fixture-main class="min-h-0 min-w-0 flex-1 overflow-hidden">
+    <div class="flex h-full min-h-0 min-w-0 w-full justify-center px-4 sm:px-6">
+      <div data-fixture-scroll-owner class="min-h-0 min-w-0 w-full max-w-[640px] overflow-y-auto overscroll-contain pr-2">
+        <div class="space-y-7 pb-8">
+          {#if fixtureView === 'general' || fixtureView === 'all'}
+            <SettingsSection title="General" description="Shortcuts, audio, dictation, vocabulary, and app behavior." variant="content">
+              <div data-fixture-general class="space-y-6">
+                <SettingsGroup title="Shortcuts &amp; activation">
+                  <SettingsRow label="Fast dictation hotkey" description="Start or stop fast dictation">
+                    <button type="button" class="min-h-9 cursor-pointer rounded-lg bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Ctrl+Win</button>
+                  </SettingsRow>
+                  <SettingsRow label="Activation mode" description="Hold-to-talk or toggle on/off">
+                    <div class="grid min-h-9 w-full max-w-full grid-cols-2 rounded-lg bg-zinc-800 p-1 sm:w-[120px]">
+                      <button type="button" aria-pressed="true" class="cursor-pointer rounded-md text-xs text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Hold</button>
+                      <button type="button" aria-pressed="false" class="cursor-pointer rounded-md text-xs text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Toggle</button>
+                    </div>
+                  </SettingsRow>
+                </SettingsGroup>
+
+                <SettingsGroup title="Audio">
+                  <SettingsRow label="Input device" description="Select microphone for recording">
+                    <select aria-label="Input device" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto">
+                      <option>Default</option>
+                    </select>
+                  </SettingsRow>
+                </SettingsGroup>
+
+                <SettingsGroup title="Dictation/output">
+                  <SettingsRow label="Append period" description="Add a period at the end of transcriptions">
+                    <Toggle enabled={false} label="Append period" />
+                  </SettingsRow>
+                  <SettingsRow label="Dictation mode" description="Local rule-based cleanup before copy or paste">
+                    <select aria-label="Dictation mode" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 sm:w-auto">
+                      <option>Clean Prompt</option>
+                    </select>
+                  </SettingsRow>
+                </SettingsGroup>
+
+                <SettingsGroup title="Hotwords" description="Keep important names and terms recognizable.">
+                  <SettingsRow label="Enable hotwords" description="Bias transcription toward your custom terms">
+                    <Toggle enabled label="Enable hotwords" />
+                  </SettingsRow>
+                  <div data-fixture-hotwords-editor class="p-4">
+                    <label for="fixture-hotwords" class="block text-sm text-zinc-200">Custom hotwords (comma-separated)</label>
+                    <p id="fixture-hotwords-help" class="mt-1 text-xs leading-5 text-zinc-500">Add product names, acronyms, and proper nouns that are often transcribed incorrectly.</p>
+                    <textarea id="fixture-hotwords" aria-describedby="fixture-hotwords-help" class="mt-3 min-h-24 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 p-3 text-sm text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100" rows="3">Eve, Murmur, Svelte, Nemotron</textarea>
+                    <div class="mt-3 flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <p class="min-w-0 text-xs text-amber-300">4 terms · Recognition quality may degrade with very long lists.</p>
+                      <div class="flex min-w-0 flex-wrap gap-2">
+                        <button type="button" class="min-h-9 cursor-pointer rounded-lg bg-zinc-800 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Import</button>
+                        <button type="button" class="min-h-9 cursor-pointer rounded-lg bg-zinc-800 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Export</button>
+                      </div>
+                    </div>
+                  </div>
+                </SettingsGroup>
+
+                <SettingsGroup title="App behavior">
+                  <SettingsRow label="Auto-copy" description="Copy transcription to clipboard automatically"><Toggle enabled label="Auto-copy" /></SettingsRow>
+                  <SettingsRow label="Auto-paste" description="Paste transcription into active window"><Toggle enabled label="Auto-paste" /></SettingsRow>
+                  <SettingsRow label="Start minimized" description="Hide main window on application launch"><Toggle enabled={false} label="Start minimized" /></SettingsRow>
+                </SettingsGroup>
+              </div>
+            </SettingsSection>
+          {/if}
+
+          {#if fixtureView === 'speech' || fixtureView === 'all'}
+            <SettingsSection title="Speech model" variant="content">
+              <SpeechModelChooser
+                selected={selectedPreset}
+                availableEngines={['nemotron', 'whisper']}
+                availabilityKnown
+                engineStatus={engineStatus}
+                modelDownload={modelDownload}
+                externalMode={fixtureState === 'external'}
+                preparationFailed={fixtureState === 'error'}
+                onSelect={selectPreset}
+              >
+                {#snippet children()}
+                  {#if fixtureState === 'ready'}
+                    <p data-fixture-preparation-status class="text-xs leading-5 text-emerald-300">Current model is ready. No preparation is pending.</p>
+                  {:else if fixtureState === 'preparing'}
+                    <p data-fixture-preparation-status class="text-xs leading-5 text-amber-300">Selected model is preparing; the current engine remains active until the selected model is ready.</p>
+                    <div class="mt-3 flex flex-wrap items-center gap-2">
+                      <button type="button" class="min-h-9 cursor-pointer rounded-lg bg-emerald-600 px-3 py-2 text-xs font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Preparing…</button>
+                      <button type="button" class="min-h-9 cursor-pointer rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Revert</button>
+                    </div>
+                  {:else if fixtureState === 'error'}
+                    <p data-fixture-preparation-status class="text-xs leading-5 text-red-300">Preparation failed. Retry or revert your selected model.</p>
+                    <div class="mt-3 flex flex-wrap items-center gap-2">
+                      <button type="button" class="min-h-9 cursor-pointer rounded-lg bg-emerald-600 px-3 py-2 text-xs font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Retry preparation</button>
+                      <button type="button" class="min-h-9 cursor-pointer rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Revert</button>
+                    </div>
+                  {/if}
+                {/snippet}
+              </SpeechModelChooser>
+            </SettingsSection>
+
+            <section data-fixture-compatibility class="min-w-0 space-y-2" aria-labelledby="fixture-compatibility-heading">
+              <div class="px-1">
+                <h2 id="fixture-compatibility-heading" class="text-sm font-semibold text-zinc-400">Advanced</h2>
+                <p class="mt-1 text-xs leading-5 text-zinc-500">Engine compatibility controls remain explicit and local to this fixture.</p>
+              </div>
+              <div class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4 sm:p-5">
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h3 class="text-sm font-medium text-zinc-100">Compatibility controls</h3>
+                    <p class="mt-1 text-xs leading-5 text-zinc-500">Raw model, precision, language, device, and unload-before-swap settings.</p>
+                  </div>
+                  <button
+                    type="button"
+                    data-fixture-compatibility-toggle
+                    aria-expanded={compatibilityOpen}
+                    aria-controls="fixture-compatibility-controls"
+                    onclick={() => compatibilityOpen = !compatibilityOpen}
+                    class="min-h-9 cursor-pointer rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+                  >
+                    {compatibilityOpen ? 'Hide controls' : 'Show controls'}
+                  </button>
+                </div>
+                {#if compatibilityOpen}
+                  <div id="fixture-compatibility-controls" data-fixture-compatibility-controls class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2">
+                    <SettingsRow label="Whisper model" description="Raw compatibility model"><select aria-label="Whisper model" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>large-v3-turbo</option><option>large-v3</option></select></SettingsRow>
+                    <SettingsRow label="Compute type" description="Precision used by Faster-Whisper"><select aria-label="Compute type" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>int8</option><option>float16</option></select></SettingsRow>
+                    <SettingsRow label="Language" description="Language hint for compatibility"><input aria-label="Whisper language" value="auto" class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-28" /></SettingsRow>
+                    <SettingsRow label="Device" description="Hardware device for inference"><select aria-label="Whisper device" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>cuda</option><option>cpu</option></select></SettingsRow>
+                    <SettingsRow label="Unload before swap" description="Free VRAM before loading a new engine"><Toggle enabled label="Unload before swap" /></SettingsRow>
+                  </div>
+                {/if}
+                <div data-fixture-compatibility-footer class="mt-4 border-t border-white/[0.08] pt-4">
+                  <div class="flex flex-wrap items-center justify-between gap-3">
+                    <p class="text-xs text-amber-300">Compatibility changes require an engine reload.</p>
+                    <button type="button" class="min-h-9 cursor-pointer rounded-lg bg-emerald-600 px-3 py-2 text-xs font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100">Apply compatibility changes</button>
+                  </div>
+                  <p class="mt-2 text-xs text-zinc-500">Engine status: Ready · Faster-Whisper · 16 GB fixture GPU</p>
+                </div>
+              </div>
+            </section>
+          {/if}
+        </div>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/src/renderer/app/fixtures/settings-speech-fixture.html
+++ b/app/src/renderer/app/fixtures/settings-speech-fixture.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-[#08090a]">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Settings Speech cohesion fixture</title>
+  </head>
+  <body class="h-full bg-[#08090a]">
+    <div id="fixture-root" class="h-full min-h-0 bg-[#08090a]"></div>
+    <script type="module" src="./settings-speech-fixture.ts"></script>
+  </body>
+</html>

--- a/app/src/renderer/app/fixtures/settings-speech-fixture.ts
+++ b/app/src/renderer/app/fixtures/settings-speech-fixture.ts
@@ -1,0 +1,8 @@
+import { mount } from 'svelte';
+import SettingsSpeechFixture from './SettingsSpeechFixture.svelte';
+import '../app.css';
+
+const target = document.querySelector('#fixture-root');
+if (!target) throw new Error('Settings Speech fixture target is missing');
+
+mount(SettingsSpeechFixture, { target });

--- a/app/src/renderer/app/speech-model-presets.ts
+++ b/app/src/renderer/app/speech-model-presets.ts
@@ -22,6 +22,16 @@ export function presetPatch(preset: SpeechModelPreset): Record<string, string> {
   return { engine: preset.engine, [preset.setting]: preset.model };
 }
 
+export function hasPendingCompatibilityChanges(
+  pending: Record<string, unknown>,
+  stagedPreset: SpeechModelPreset | null,
+): boolean {
+  const stagedPatch = stagedPreset ? presetPatch(stagedPreset) : {};
+  return Object.entries(pending).some(([key, value]) => {
+    return !Object.prototype.hasOwnProperty.call(stagedPatch, key) || stagedPatch[key] !== value;
+  });
+}
+
 export function stagedPresetFromPending(pending: Record<string, unknown>): SpeechModelPreset | null {
   return SPEECH_MODEL_PRESETS.find((preset) =>
     pending.engine === preset.engine && pending[preset.setting] === preset.model

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -8,7 +8,7 @@
   import SettingsSkeleton from '../components/SettingsSkeleton.svelte';
   import ServerView from './ServerView.svelte';
   import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
-  import { SPEECH_MODEL_PRESETS, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../speech-model-presets';
+  import { SPEECH_MODEL_PRESETS, hasPendingCompatibilityChanges, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../speech-model-presets';
   import { getServerManagementMode, serverStatusState } from '../server-status';
   import { serverSettingsStateKey, shouldClearServerSettings, shouldRetryServerSettings } from '../server-settings-recovery';
   import { toast } from '$lib/toast.svelte';
@@ -124,12 +124,6 @@
       const setting = serverSettings![key];
       return setting?.requires_reload && setting.value !== value;
     });
-  }
-
-  function hasPendingCompatibilityChanges(): boolean {
-    return Object.keys(pendingEngine).some((key) =>
-      key !== 'engine' && !SPEECH_MODEL_PRESETS.some((preset) => preset.setting === key)
-    );
   }
 
   // Convenience: get options for a select setting
@@ -951,7 +945,7 @@
         {/if}
         </div>
 
-        {#if hasPendingCompatibilityChanges()}
+        {#if hasPendingCompatibilityChanges(pendingEngine, stagedPreset)}
           <div data-compatibility-footer class="mt-4 border-t border-white/[0.08] pt-4">
             <div class="flex flex-wrap items-center justify-between gap-3">
               <p class="text-xs text-amber-300">Compatibility changes require an engine reload.</p>

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -126,6 +126,12 @@
     });
   }
 
+  function hasPendingCompatibilityChanges(): boolean {
+    return Object.keys(pendingEngine).some((key) =>
+      key !== 'engine' && !SPEECH_MODEL_PRESETS.some((preset) => preset.setting === key)
+    );
+  }
+
   // Convenience: get options for a select setting
   function getOptions(key: string): Array<{ value: unknown; label: string; description?: string }> {
     return (serverSettings?.[key]?.options as Array<{ value: unknown; label: string; description?: string }>) ?? [];
@@ -849,8 +855,7 @@
           </p>
         </div>
       {:else if serverSettings}
-        {#if compatibilityControlsOpen}
-          <div id="compatibility-controls" class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2 {externalMode ? 'opacity-60' : ''}">
+        <div id="compatibility-controls" hidden={!compatibilityControlsOpen} class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2 {externalMode ? 'opacity-60' : ''}">
         {#if serverSettings.whisper_model}
           <SettingsRow label={serverSettings.whisper_model.label} description="Raw Whisper compatibility model, including Medium and Tiny">
             <select
@@ -944,28 +949,29 @@
             />
           </SettingsRow>
         {/if}
-          </div>
-        {/if}
+        </div>
 
-        {#if Object.keys(pendingEngine).length > 0 && !stagedPreset}
+        {#if hasPendingCompatibilityChanges()}
           <div data-compatibility-footer class="mt-4 border-t border-white/[0.08] pt-4">
             <div class="flex flex-wrap items-center justify-between gap-3">
               <p class="text-xs text-amber-300">Compatibility changes require an engine reload.</p>
-              <button
-                type="button"
-                onclick={applyEngineSettings}
-                disabled={engineApplying || externalMode}
-                class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
-                  {engineApplying || externalMode
-                    ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed'
-                    : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}"
-              >
-                {#if engineApplying}
-                  Preparing…
-                {:else}
-                  Apply compatibility changes
-                {/if}
-              </button>
+              {#if !stagedPreset}
+                <button
+                  type="button"
+                  onclick={applyEngineSettings}
+                  disabled={engineApplying || externalMode}
+                  class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
+                    {engineApplying || externalMode
+                      ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed'
+                      : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}"
+                >
+                  {#if engineApplying}
+                    Preparing…
+                  {:else}
+                    Apply compatibility changes
+                  {/if}
+                </button>
+              {/if}
             </div>
             {#if engineApplyError}
               <p class="mt-2 text-xs text-red-300">{engineApplyError}</p>

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import Toggle from '../components/Toggle.svelte';
   import SettingsRow from '../components/SettingsRow.svelte';
+  import SettingsGroup from '../components/SettingsGroup.svelte';
   import SettingsSection from '../components/SettingsSection.svelte';
   import HotkeyCaptureModal from '../components/HotkeyCaptureModal.svelte';
   import SettingsSkeleton from '../components/SettingsSkeleton.svelte';
@@ -77,7 +78,7 @@
   let serverConnected = $state(false);
   let serverSettingsLoading = $state(false);
   let lastServerSettingsAttemptKey = $state<string | null>(null);
-  let engineAdvancedOpen = $state(false);
+  let compatibilityControlsOpen = $state(false);
   let engineApplying = $state(false);
   let availableEngines = $state<string[]>([]);
   let engineApplyError = $state('');
@@ -498,226 +499,279 @@
 
     <h1 class="sr-only">Settings</h1>
 
-    <!-- Shortcuts & activation -->
-    <SettingsSection title="Shortcuts &amp; activation">
-      <SettingsRow label="Fast dictation hotkey" description="Start or stop fast dictation">
-        <div class="flex items-center gap-2">
-          <button
-            type="button"
-            onclick={() => openHotkeyCapture('quick')}
-            class="max-w-full rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-mono text-zinc-300 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+    <SettingsSection title="General" description="Shortcuts, audio, dictation, vocabulary, and app behavior." variant="content">
+      <div data-settings-general class="space-y-6">
+        <SettingsGroup title="Shortcuts &amp; activation">
+          <SettingsRow label="Fast dictation hotkey" description="Start or stop fast dictation">
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                onclick={() => openHotkeyCapture('quick')}
+                class="min-h-9 max-w-full rounded-lg bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-300 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+              >
+                {hotkeyDisplayName}
+              </button>
+              {#if isHotkeyChanged}
+                <button
+                  type="button"
+                  onclick={resetHotkey}
+                  class="min-h-8 rounded-md p-1.5 text-zinc-500 transition-colors hover:text-zinc-300 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+                  aria-label="Reset fast dictation hotkey to Ctrl+Win"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+                    <path d="M3 3v5h5"/>
+                  </svg>
+                </button>
+              {/if}
+            </div>
+          </SettingsRow>
+
+          <SettingsRow label="Long dictation hotkey" description="Start or stop hands-free long dictation">
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                onclick={() => openHotkeyCapture('long')}
+                class="min-h-9 max-w-full rounded-lg bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-300 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+              >
+                {longHotkeyDisplayName}
+              </button>
+              {#if isLongHotkeyChanged}
+                <button
+                  type="button"
+                  onclick={resetLongHotkey}
+                  class="min-h-8 rounded-md p-1.5 text-zinc-500 transition-colors hover:text-zinc-300 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+                  aria-label="Reset long dictation hotkey to Ctrl+Shift+Win"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+                    <path d="M3 3v5h5"/>
+                  </svg>
+                </button>
+              {/if}
+            </div>
+          </SettingsRow>
+
+          <SettingsRow label="Activation mode" description="Hold-to-talk or toggle on/off">
+            <div class="relative grid min-h-9 w-full max-w-full grid-cols-2 rounded-lg bg-zinc-800 p-1 sm:w-[120px]">
+              <div
+                class="absolute top-1 left-1 h-[calc(100%-8px)] w-[calc(50%-4px)] rounded-md bg-zinc-700 transition-all duration-150 ease-out
+                  {!settings.holdToTalk ? 'translate-x-full' : ''}"
+              ></div>
+              <button
+                type="button"
+                onclick={() => updateSetting('holdToTalk', true)}
+                aria-pressed={settings.holdToTalk}
+                class="relative z-10 rounded-md py-1 text-center text-xs transition-colors duration-150
+                  cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
+                  {settings.holdToTalk ? 'text-zinc-200' : 'text-zinc-400 hover:text-zinc-300'}"
+              >
+                Hold
+              </button>
+              <button
+                type="button"
+                onclick={() => updateSetting('holdToTalk', false)}
+                aria-pressed={!settings.holdToTalk}
+                class="relative z-10 rounded-md py-1 text-center text-xs transition-colors duration-150
+                  cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
+                  {!settings.holdToTalk ? 'text-zinc-200' : 'text-zinc-400 hover:text-zinc-300'}"
+              >
+                Toggle
+              </button>
+            </div>
+          </SettingsRow>
+        </SettingsGroup>
+
+        <SettingsGroup title="Audio">
+          <SettingsRow
+            label="Input device"
+            description={audioDeviceError || 'Select microphone for recording'}
           >
-            {hotkeyDisplayName}
-          </button>
-          {#if isHotkeyChanged}
-            <button
-              type="button"
-              onclick={resetHotkey}
-              class="rounded-md p-1.5 text-zinc-500 transition-colors hover:text-zinc-300 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
-              aria-label="Reset fast dictation hotkey to Ctrl+Win"
+            <select
+              aria-label="Input device"
+              value={settings.selectedDeviceId}
+              onchange={(e) => updateSetting('selectedDeviceId', e.currentTarget.value)}
+              disabled={isLoadingDevices}
+              title={inputDevices.find(d => d.id === settings.selectedDeviceId)?.label ?? 'Default'}
+              class="min-h-9 w-full max-w-full truncate rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:max-w-[280px]"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
-                <path d="M3 3v5h5"/>
-              </svg>
-            </button>
-          {/if}
-        </div>
-      </SettingsRow>
+              {#each inputDevices as device}
+                <option value={device.id}>{device.label}</option>
+              {/each}
+            </select>
+          </SettingsRow>
+        </SettingsGroup>
 
-      <SettingsRow label="Long dictation hotkey" description="Start or stop hands-free long dictation">
-        <div class="flex items-center gap-2">
-          <button
-            type="button"
-            onclick={() => openHotkeyCapture('long')}
-            class="max-w-full rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-mono text-zinc-300 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
-          >
-            {longHotkeyDisplayName}
-          </button>
-          {#if isLongHotkeyChanged}
-            <button
-              type="button"
-              onclick={resetLongHotkey}
-              class="rounded-md p-1.5 text-zinc-500 transition-colors hover:text-zinc-300 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
-              aria-label="Reset long dictation hotkey to Ctrl+Shift+Win"
+        <SettingsGroup title="Dictation/output">
+          <SettingsRow label="Append period" description="Add a period at the end of transcriptions">
+            <Toggle
+              enabled={settings.appendPeriod}
+              onchange={(v) => updateSetting('appendPeriod', v)}
+              label="Append period"
+            />
+          </SettingsRow>
+
+          <SettingsRow label="Append space" description="Add a trailing space after transcriptions">
+            <Toggle
+              enabled={settings.appendSpace}
+              onchange={(v) => updateSetting('appendSpace', v)}
+              label="Append space"
+            />
+          </SettingsRow>
+
+          <SettingsRow label="Dictation mode" description="Local rule-based cleanup before copy or paste">
+            <select
+              aria-label="Dictation mode"
+              value={settings.dictationMode}
+              onchange={(e) => updateSetting('dictationMode', e.currentTarget.value as Settings['dictationMode'])}
+              class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
-                <path d="M3 3v5h5"/>
+              <option value="raw">Raw Dictation</option>
+              <option value="clean_prompt">Clean Prompt</option>
+              <option value="codex_prompt">Codex Prompt</option>
+              <option value="message_rewrite">Message Rewrite</option>
+              <option value="command">Command Mode</option>
+            </select>
+          </SettingsRow>
+        </SettingsGroup>
+
+        <SettingsGroup title="Hotwords" description="Keep important names and terms recognizable.">
+          {#if !hotwordsSupported}
+            <div role="status" class="flex items-start gap-3 p-4 text-sm">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 shrink-0 text-zinc-400">
+                <circle cx="12" cy="12" r="10"/>
+                <path d="M12 16v-4"/>
+                <path d="M12 8h.01"/>
               </svg>
-            </button>
+              <div>
+                <p class="text-zinc-300">Hotwords are not supported with the Nemotron engine.</p>
+                <p class="mt-1 text-xs text-zinc-500">Switch to Faster-Whisper to use hotwords.</p>
+              </div>
+            </div>
           {/if}
-        </div>
-      </SettingsRow>
 
-      <SettingsRow label="Activation Mode" description="Hold-to-talk or toggle on/off">
-        <div class="relative grid w-full max-w-full grid-cols-2 rounded-lg bg-zinc-800 p-1 sm:w-[120px]">
-          <!-- Sliding indicator -->
-          <div
-            class="absolute top-1 left-1 w-[calc(50%-4px)] h-[calc(100%-8px)] bg-zinc-700 rounded-md transition-all duration-150 ease-out
-              {!settings.holdToTalk ? 'translate-x-full' : ''}"
-          ></div>
-          <!-- Buttons -->
-          <button
-            type="button"
-            onclick={() => updateSetting('holdToTalk', true)}
-            aria-pressed={settings.holdToTalk}
-            class="relative z-10 rounded-md py-1 text-center text-xs transition-colors duration-150
-              cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
-              {settings.holdToTalk ? 'text-zinc-200' : 'text-zinc-400 hover:text-zinc-300'}"
-          >
-            Hold
-          </button>
-          <button
-            type="button"
-            onclick={() => updateSetting('holdToTalk', false)}
-            aria-pressed={!settings.holdToTalk}
-            class="relative z-10 rounded-md py-1 text-center text-xs transition-colors duration-150
-              cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
-              {!settings.holdToTalk ? 'text-zinc-200' : 'text-zinc-400 hover:text-zinc-300'}"
-          >
-            Toggle
-          </button>
-        </div>
-      </SettingsRow>
-    </SettingsSection>
+          <SettingsRow label="Enable hotwords" description="Bias transcription toward your custom terms">
+            <Toggle
+              enabled={settings.hotwordsEnabled && hotwordsSupported}
+              onchange={(v) => updateSetting('hotwordsEnabled', v)}
+              label="Enable hotwords"
+              disabled={!hotwordsSupported}
+            />
+          </SettingsRow>
 
-    <!-- Audio -->
-    <SettingsSection title="Audio">
-      <SettingsRow
-        label="Input Device"
-        description={audioDeviceError || 'Select microphone for recording'}
-      >
-        <select
-          aria-label="Input Device"
-          value={settings.selectedDeviceId}
-          onchange={(e) => updateSetting('selectedDeviceId', e.currentTarget.value)}
-          disabled={isLoadingDevices}
-          title={inputDevices.find(d => d.id === settings.selectedDeviceId)?.label ?? 'Default'}
-          class="w-full max-w-full truncate rounded-lg bg-zinc-800 py-1.5 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 border border-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:opacity-50 disabled:cursor-not-allowed sm:w-auto sm:max-w-[280px]"
-        >
-          {#each inputDevices as device}
-            <option value={device.id}>{device.label}</option>
-          {/each}
-        </select>
-      </SettingsRow>
+          <div data-hotwords-editor class="p-4 transition-colors {!hotwordsSupported ? 'bg-zinc-900/40 opacity-60' : hasHotwordOverflowWarning ? 'bg-amber-950/10' : ''}">
+            <label for="hotwords-csl" class="block text-sm text-zinc-200">Custom hotwords (comma-separated)</label>
+            <p id="hotwords-help" class="mt-1 text-xs leading-5 text-zinc-500">
+              Add terms that are often transcribed incorrectly, such as product names, acronyms, and proper nouns.
+              Avoid very long lists; large lists can reduce quality.
+            </p>
+            <textarea
+              id="hotwords-csl"
+              value={settings.hotwordsCsl}
+              oninput={(e) => updateHotwordsCsl(e.currentTarget.value)}
+              rows="4"
+              disabled={!hotwordsSupported}
+              aria-describedby="hotwords-help"
+              class="mt-3 min-h-24 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder="Svelte, IPC, Claude"
+            ></textarea>
 
-    </SettingsSection>
+            <div class="mt-3 flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p id="hotwords-count" class="min-w-0 text-xs {hasHotwordOverflowWarning ? 'text-amber-300' : 'text-zinc-500'}">
+                {hotwordCount} {hotwordCount === 1 ? 'term' : 'terms'}
+                {#if hasHotwordOverflowWarning}
+                  - You have a lot of entries. Recognition quality may degrade.
+                {/if}
+              </p>
+              <div class="flex min-w-0 flex-wrap gap-2">
+                <button
+                  type="button"
+                  onclick={importHotwords}
+                  disabled={!hotwordsSupported}
+                  class="min-h-9 rounded-lg bg-zinc-800 px-3 py-2 text-xs text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
+                    {hotwordsSupported ? 'cursor-pointer hover:bg-zinc-700' : 'cursor-not-allowed opacity-50'}"
+                >
+                  Import
+                </button>
+                <button
+                  type="button"
+                  onclick={exportHotwords}
+                  disabled={!hotwordsSupported}
+                  class="min-h-9 rounded-lg bg-zinc-800 px-3 py-2 text-xs text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
+                    {hotwordsSupported ? 'cursor-pointer hover:bg-zinc-700' : 'cursor-not-allowed opacity-50'}"
+                >
+                  Export
+                </button>
+              </div>
+            </div>
 
-    <!-- Dictation/output -->
-    <SettingsSection title="Dictation/output">
-      <SettingsRow label="Append period" description="Add a period at the end of transcriptions">
-        <Toggle
-          enabled={settings.appendPeriod}
-          onchange={(v) => updateSetting('appendPeriod', v)}
-          label="Append period"
-        />
-      </SettingsRow>
-
-      <SettingsRow label="Append space" description="Add a trailing space after transcriptions">
-        <Toggle
-          enabled={settings.appendSpace}
-          onchange={(v) => updateSetting('appendSpace', v)}
-          label="Append space"
-        />
-      </SettingsRow>
-
-      <SettingsRow label="Dictation mode" description="Local rule-based cleanup before copy or paste">
-        <select
-          aria-label="Dictation mode"
-          value={settings.dictationMode}
-          onchange={(e) => updateSetting('dictationMode', e.currentTarget.value as Settings['dictationMode'])}
-          class="w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
-        >
-          <option value="raw">Raw Dictation</option>
-          <option value="clean_prompt">Clean Prompt</option>
-          <option value="codex_prompt">Codex Prompt</option>
-          <option value="message_rewrite">Message Rewrite</option>
-          <option value="command">Command Mode</option>
-        </select>
-      </SettingsRow>
-    </SettingsSection>
-
-    <SettingsSection title="Hotwords" variant="panel">
-      {#if !hotwordsSupported}
-        <div role="status" class="mb-4 flex items-start gap-3 rounded-lg bg-zinc-900/70 p-3">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-zinc-400 shrink-0 mt-0.5">
-            <circle cx="12" cy="12" r="10"/>
-            <path d="M12 16v-4"/>
-            <path d="M12 8h.01"/>
-          </svg>
-          <div>
-            <p class="text-sm text-zinc-300">Hotwords are not supported with the Nemotron engine.</p>
-            <p class="text-xs text-zinc-500 mt-1">Switch to Faster-Whisper to use hotwords.</p>
-          </div>
-        </div>
-      {/if}
-
-      <SettingsRow label="Enable hotwords" description="Bias transcription toward your custom terms">
-        <Toggle
-          enabled={settings.hotwordsEnabled && hotwordsSupported}
-          onchange={(v) => updateSetting('hotwordsEnabled', v)}
-          label="Enable hotwords"
-          disabled={!hotwordsSupported}
-        />
-      </SettingsRow>
-
-      <div class="mt-4 w-full min-w-0 border transition-colors
-        {!hotwordsSupported ? 'border-zinc-700 bg-zinc-900/50 opacity-50' : hasHotwordOverflowWarning ? 'border-amber-500/70 bg-amber-950/10' : 'border-zinc-700 bg-zinc-900/50'}">
-        <label for="hotwords-csl" class="block text-sm text-zinc-200">Custom hotwords (comma-separated)</label>
-        <p id="hotwords-help" class="mt-1 text-xs text-zinc-500">
-          Add terms that are often transcribed incorrectly, such as product names, acronyms, and proper nouns.
-          Avoid very long lists; large lists can reduce quality.
-        </p>
-        <textarea
-          id="hotwords-csl"
-          value={settings.hotwordsCsl}
-          oninput={(e) => updateHotwordsCsl(e.currentTarget.value)}
-          rows="4"
-          disabled={!hotwordsSupported}
-          aria-describedby="hotwords-help"
-          class="mt-3 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:opacity-50 disabled:cursor-not-allowed"
-          placeholder="Svelte, IPC, Claude"
-        ></textarea>
-
-        <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
-          <p id="hotwords-count" class="text-xs {hasHotwordOverflowWarning ? 'text-amber-300' : 'text-zinc-500'}">
-            {hotwordCount} {hotwordCount === 1 ? 'term' : 'terms'}
-            {#if hasHotwordOverflowWarning}
-              - You have a lot of entries. Recognition quality may degrade.
+            {#if hotwordsFileMessage}
+              <p class="mt-2 text-xs text-zinc-500" role="status">{hotwordsFileMessage}</p>
             {/if}
-          </p>
-          <div class="flex items-center gap-2">
-            <button
-              type="button"
-              onclick={importHotwords}
-              disabled={!hotwordsSupported}
-              class="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
-                {hotwordsSupported ? 'hover:bg-zinc-700 cursor-pointer' : 'opacity-50 cursor-not-allowed'}"
-            >
-              Import
-            </button>
-            <button
-              type="button"
-              onclick={exportHotwords}
-              disabled={!hotwordsSupported}
-              class="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
-                {hotwordsSupported ? 'hover:bg-zinc-700 cursor-pointer' : 'opacity-50 cursor-not-allowed'}"
-            >
-              Export
-            </button>
           </div>
-        </div>
+        </SettingsGroup>
 
-        {#if hotwordsFileMessage}
-          <p class="mt-2 text-xs text-zinc-500" role="status">{hotwordsFileMessage}</p>
-        {/if}
+        <SettingsGroup title="App behavior">
+          <SettingsRow label="Auto-copy" description="Copy transcription to clipboard automatically">
+            <Toggle
+              enabled={settings.autoCopy}
+              onchange={(v) => updateSetting('autoCopy', v)}
+              label="Auto-copy"
+            />
+          </SettingsRow>
+
+          <SettingsRow label="Auto-paste" description="Paste transcription into active window">
+            <Toggle
+              enabled={settings.autoPaste}
+              onchange={(v) => updateSetting('autoPaste', v)}
+              label="Auto-paste"
+            />
+          </SettingsRow>
+
+          <SettingsRow label="Restore clipboard" description="Put your previous clipboard text back after auto-paste">
+            <Toggle
+              enabled={settings.restoreClipboardAfterPaste}
+              onchange={(v) => updateSetting('restoreClipboardAfterPaste', v)}
+              label="Restore clipboard"
+            />
+          </SettingsRow>
+
+          <SettingsRow label="Paste method" description="Use native SendInput first, or force VBScript fallback">
+            <select
+              aria-label="Paste method"
+              value={settings.pasteMethod}
+              onchange={(e) => updateSetting('pasteMethod', e.currentTarget.value as Settings['pasteMethod'])}
+              class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
+            >
+              <option value="sendinput">SendInput</option>
+              <option value="vbscript">VBScript</option>
+            </select>
+          </SettingsRow>
+
+          <SettingsRow label="Launch on boot" description="Start application when system starts">
+            <Toggle
+              enabled={settings.launchOnBoot}
+              onchange={(v) => void updateLaunchOnBoot(v)}
+              label="Launch on boot"
+            />
+          </SettingsRow>
+
+          <SettingsRow label="Start minimized" description="Hide main window on application launch">
+            <Toggle
+              enabled={settings.startMinimized}
+              onchange={(v) => updateSetting('startMinimized', v)}
+              label="Start minimized"
+            />
+          </SettingsRow>
+        </SettingsGroup>
       </div>
     </SettingsSection>
 
     <SettingsSection title="Speech model" variant="content">
       {#if !serverConnected || !serverSettings}
-        <p class="text-xs text-zinc-500">Speech model choices are available when the server reports its settings.</p>
+        <div data-speech-model-panel class="min-w-0 w-full rounded-xl border border-white/10 bg-white/[0.025] p-4 sm:p-5">
+          <p class="text-xs leading-5 text-zinc-500">Speech model choices are available when the server reports its settings.</p>
+        </div>
       {:else}
         <SpeechModelChooser
           selected={selectedPreset}
@@ -726,100 +780,85 @@
           engineStatus={sharedEngineStatus}
           modelDownload={sharedServerState?.modelDownload}
           externalMode={externalMode}
+          preparationFailed={preparationFailed}
           onSelect={selectPreset}
-        />
-        {#if stagedPreset && !presetMatchesReadyEngine(stagedPreset, sharedEngineStatus)}
-          <p class="mt-3 text-xs {preparationFailed ? 'text-red-300' : 'text-amber-300'}">{preparationFailed ? 'Preparation failed. Retry or revert your selected model.' : 'Selected model is pending preparation; the current engine remains active until the selected model is ready.'}</p>
-        {/if}
-        {#if stagedPreset && !externalMode}
-          <div class="mt-3 flex flex-wrap items-center gap-2">
-            <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
-            <button type="button" onclick={revertPreset} disabled={engineApplying} class="rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
-          </div>
-          {#if engineApplyError}<p class="mt-2 text-xs text-red-300">{engineApplyError}</p>{/if}
-        {/if}
+        >
+          {#snippet children()}
+            {#if stagedPreset && !presetMatchesReadyEngine(stagedPreset, sharedEngineStatus)}
+              <p data-model-preparation-status class="text-xs leading-5 {preparationFailed ? 'text-red-300' : 'text-amber-300'}">
+                {preparationFailed ? 'Preparation failed. Retry or revert your selected model.' : 'Selected model is pending preparation; the current engine remains active until the selected model is ready.'}
+              </p>
+            {/if}
+            {#if stagedPreset && !externalMode}
+              <div class="mt-3 flex flex-wrap items-center gap-2">
+                <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
+                <button type="button" onclick={revertPreset} disabled={engineApplying} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
+              </div>
+              {#if engineApplyError}<p class="mt-2 text-xs text-red-300">{engineApplyError}</p>{/if}
+            {/if}
+          {/snippet}
+        </SpeechModelChooser>
       {/if}
     </SettingsSection>
 
-    <!-- App behavior -->
-    <SettingsSection title="App behavior">
-      <SettingsRow label="Auto-copy" description="Copy transcription to clipboard automatically">
-        <Toggle
-          enabled={settings.autoCopy}
-          onchange={(v) => updateSetting('autoCopy', v)}
-          label="Auto-copy"
-        />
-      </SettingsRow>
+    <SettingsSection
+      title="Advanced"
+      id="advanced-settings-heading"
+      description="Engine, connection, diagnostics, and local server controls."
+      variant="content"
+    >
+      <div data-advanced-settings class="min-w-0">
+        <div data-compatibility-panel class="min-w-0 w-full rounded-xl border border-white/10 bg-white/[0.025] p-4 sm:p-5">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0">
+              <h3 class="text-sm font-medium text-zinc-100">Compatibility controls</h3>
+              <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Raw model, precision, language, device, and unload-before-swap settings.</p>
+            </div>
+            {#if serverConnected && serverSettings}
+              <button
+                type="button"
+                aria-expanded={compatibilityControlsOpen}
+                aria-controls="compatibility-controls"
+                onclick={() => compatibilityControlsOpen = !compatibilityControlsOpen}
+                class="inline-flex min-h-9 shrink-0 items-center gap-2 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"
+                  fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                  class="transition-transform duration-150 {compatibilityControlsOpen ? 'rotate-90' : ''}"
+                  aria-hidden="true"
+                >
+                  <path d="m9 18 6-6-6-6"/>
+                </svg>
+                {compatibilityControlsOpen ? 'Hide controls' : 'Show controls'}
+              </button>
+            {/if}
+          </div>
 
-      <SettingsRow label="Auto-paste" description="Paste transcription into active window">
-        <Toggle
-          enabled={settings.autoPaste}
-          onchange={(v) => updateSetting('autoPaste', v)}
-          label="Auto-paste"
-        />
-      </SettingsRow>
+          {#if externalMode}
+            <div data-compatibility-external class="mt-4 flex items-start gap-3 border-t border-white/[0.08] pt-4 text-xs leading-5 text-zinc-400">
+              <span class="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-amber-300"></span>
+              <p>Compatibility controls are read-only while an external server is active. Configure the external server through its own endpoint.</p>
+            </div>
+          {/if}
 
-      <SettingsRow label="Restore clipboard" description="Put your previous clipboard text back after auto-paste">
-        <Toggle
-          enabled={settings.restoreClipboardAfterPaste}
-          onchange={(v) => updateSetting('restoreClipboardAfterPaste', v)}
-          label="Restore clipboard"
-        />
-      </SettingsRow>
-
-      <SettingsRow label="Paste method" description="Use native SendInput first, or force VBScript fallback">
-        <select
-          aria-label="Paste method"
-          value={settings.pasteMethod}
-          onchange={(e) => updateSetting('pasteMethod', e.currentTarget.value as Settings['pasteMethod'])}
-          class="w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
-        >
-          <option value="sendinput">SendInput</option>
-          <option value="vbscript">VBScript</option>
-        </select>
-      </SettingsRow>
-
-      <SettingsRow label="Launch on boot" description="Start application when system starts">
-        <Toggle
-          enabled={settings.launchOnBoot}
-          onchange={(v) => void updateLaunchOnBoot(v)}
-          label="Launch on boot"
-        />
-      </SettingsRow>
-
-      <SettingsRow label="Start minimized" description="Hide main window on application launch">
-        <Toggle
-          enabled={settings.startMinimized}
-          onchange={(v) => updateSetting('startMinimized', v)}
-          label="Start minimized"
-        />
-      </SettingsRow>
-    </SettingsSection>
-
-    <section aria-labelledby="advanced-settings-heading" class="min-w-0 space-y-4">
-      <div>
-        <h2 id="advanced-settings-heading" class="text-base font-semibold text-zinc-100">Advanced</h2>
-        <p class="mt-1 text-xs text-zinc-400">
-          Engine, connection, diagnostics, and local server controls.
-        </p>
-      </div>
-      <div class="min-w-0 space-y-6">
-
-    <SettingsSection title="Model compatibility">
       {#if !serverConnected}
-        <div class="p-4 bg-zinc-900/50 rounded-xl w-full">
-          <p class="text-xs text-zinc-500 text-center">
+        <div class="mt-4 border-t border-white/[0.08] pt-4">
+          <p class="text-xs leading-5 text-zinc-500">
             Server not connected. Start the server to configure engine settings.
           </p>
         </div>
       {:else if serverSettings}
+        {#if compatibilityControlsOpen}
+          <div id="compatibility-controls" class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2 {externalMode ? 'opacity-60' : ''}">
         {#if serverSettings.whisper_model}
           <SettingsRow label={serverSettings.whisper_model.label} description="Raw Whisper compatibility model, including Medium and Tiny">
             <select
               aria-label={serverSettings.whisper_model.label}
               value={getSettingValue('whisper_model') ?? serverSettings.whisper_model.value}
               onchange={(e) => updateEngineSetting('whisper_model', e.currentTarget.value)}
-              class="w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-1.5 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
+              disabled={externalMode}
+              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
               {#each getOptions('whisper_model') as option}
                 <option value={option.value}>{option.label}</option>
@@ -833,7 +872,8 @@
               aria-label={serverSettings.whisper_compute_type.label}
               value={getSettingValue('whisper_compute_type') ?? serverSettings.whisper_compute_type.value}
               onchange={(e) => updateEngineSetting('whisper_compute_type', e.currentTarget.value)}
-              class="w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-1.5 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
+              disabled={externalMode}
+              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
               {#each getOptions('whisper_compute_type') as option}
                 <option value={option.value}>{option.label}</option>
@@ -842,153 +882,132 @@
           </SettingsRow>
         {/if}
 
-        <!-- Advanced (collapsible) -->
-        <div class="w-full">
-          <button
-            type="button"
-            aria-expanded={engineAdvancedOpen}
-            aria-controls="engine-advanced-options"
-            onclick={() => engineAdvancedOpen = !engineAdvancedOpen}
-            class="flex items-center gap-2 py-1 text-xs text-zinc-500 transition-colors hover:text-zinc-300 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"
-              fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-              class="transition-transform duration-150 {engineAdvancedOpen ? 'rotate-90' : ''}"
+        {#if serverSettings.nemotron_model && isVisible(serverSettings.nemotron_model)}
+          <SettingsRow label={serverSettings.nemotron_model.label} description="Raw Nemotron model name or path">
+            <input
+              aria-label={serverSettings.nemotron_model.label}
+              value={getSettingValue<string>('nemotron_model') ?? String(serverSettings.nemotron_model.value)}
+              oninput={(e) => updateEngineSetting('nemotron_model', e.currentTarget.value)}
+              disabled={externalMode}
+              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-56"
+            />
+          </SettingsRow>
+        {/if}
+        {#if serverSettings.whisper_language && isVisible(serverSettings.whisper_language)}
+          <SettingsRow label={serverSettings.whisper_language.label} description={serverSettings.whisper_language.description}>
+            <input
+              aria-label={serverSettings.whisper_language.label}
+              value={getSettingValue<string>('whisper_language') ?? String(serverSettings.whisper_language.value ?? '')}
+              oninput={(e) => updateEngineSetting('whisper_language', e.currentTarget.value)}
+              disabled={externalMode}
+              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-28"
+            />
+          </SettingsRow>
+        {/if}
+        {#if serverSettings.nemotron_device && isVisible(serverSettings.nemotron_device)}
+          <SettingsRow label="Device" description="Hardware device for inference">
+            <select
+              aria-label="Nemotron device"
+              value={getSettingValue('nemotron_device') ?? serverSettings.nemotron_device.value}
+              onchange={(e) => updateEngineSetting('nemotron_device', e.currentTarget.value)}
+              disabled={externalMode}
+              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
-              <path d="m9 18 6-6-6-6"/>
-            </svg>
-            Advanced
-          </button>
+              {#each getOptions('nemotron_device') as option}
+                <option value={option.value}>{option.label}</option>
+              {/each}
+            </select>
+          </SettingsRow>
+        {/if}
+        {#if serverSettings.whisper_device && isVisible(serverSettings.whisper_device)}
+          <SettingsRow label="Device" description="Hardware device for inference">
+            <select
+              aria-label="Whisper device"
+              value={getSettingValue('whisper_device') ?? serverSettings.whisper_device.value}
+              onchange={(e) => updateEngineSetting('whisper_device', e.currentTarget.value)}
+              disabled={externalMode}
+              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+            >
+              {#each getOptions('whisper_device') as option}
+                <option value={option.value}>{option.label}</option>
+              {/each}
+            </select>
+          </SettingsRow>
+        {/if}
+        {#if serverSettings.unload_before_swap}
+          <SettingsRow label="Unload before swap" description="Free VRAM before loading a new engine on low-VRAM GPUs">
+            <Toggle
+              enabled={!!getSettingValue('unload_before_swap')}
+              onchange={(v) => updateEngineSetting('unload_before_swap', v)}
+              label="Unload before swap"
+              disabled={externalMode}
+            />
+          </SettingsRow>
+        {/if}
+          </div>
+        {/if}
 
-           {#if engineAdvancedOpen}
-             <div id="engine-advanced-options" class="mt-2 space-y-2">
-               {#if serverSettings.nemotron_model && isVisible(serverSettings.nemotron_model)}
-                 <SettingsRow label={serverSettings.nemotron_model.label} description="Raw Nemotron model name or path">
-                   <input aria-label={serverSettings.nemotron_model.label} value={getSettingValue<string>('nemotron_model') ?? String(serverSettings.nemotron_model.value)} oninput={(e) => updateEngineSetting('nemotron_model', e.currentTarget.value)} class="w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-56" />
-                 </SettingsRow>
-               {/if}
-               {#if serverSettings.whisper_language && isVisible(serverSettings.whisper_language)}
-                 <SettingsRow label={serverSettings.whisper_language.label} description={serverSettings.whisper_language.description}>
-                   <input aria-label={serverSettings.whisper_language.label} value={getSettingValue<string>('whisper_language') ?? String(serverSettings.whisper_language.value ?? '')} oninput={(e) => updateEngineSetting('whisper_language', e.currentTarget.value)} class="w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-28" />
-                 </SettingsRow>
-               {/if}
-               <!-- Device setting (show whichever is visible) -->
-              {#if serverSettings.nemotron_device && isVisible(serverSettings.nemotron_device)}
-                <SettingsRow label="Device" description="Hardware device for inference">
-                  <select
-                    aria-label="Nemotron device"
-                    value={getSettingValue('nemotron_device') ?? serverSettings.nemotron_device.value}
-                    onchange={(e) => updateEngineSetting('nemotron_device', e.currentTarget.value)}
-                    class="w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-1.5 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
-                  >
-                    {#each getOptions('nemotron_device') as option}
-                      <option value={option.value}>{option.label}</option>
-                    {/each}
-                  </select>
-                </SettingsRow>
-              {/if}
-
-              {#if serverSettings.whisper_device && isVisible(serverSettings.whisper_device)}
-                <SettingsRow label="Device" description="Hardware device for inference">
-                  <select
-                    aria-label="Whisper device"
-                    value={getSettingValue('whisper_device') ?? serverSettings.whisper_device.value}
-                    onchange={(e) => updateEngineSetting('whisper_device', e.currentTarget.value)}
-                    class="w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-1.5 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
-                  >
-                    {#each getOptions('whisper_device') as option}
-                      <option value={option.value}>{option.label}</option>
-                    {/each}
-                  </select>
-                </SettingsRow>
-              {/if}
-
-              <!-- Unload before swap toggle -->
-              {#if serverSettings.unload_before_swap}
-                <SettingsRow label="Unload before swap" description="Free VRAM before loading new engine (for low-VRAM GPUs)">
-                  <Toggle
-                    enabled={!!getSettingValue('unload_before_swap')}
-                    onchange={(v) => updateEngineSetting('unload_before_swap', v)}
-                    label="Unload before swap"
-                  />
-                </SettingsRow>
-              {/if}
-            </div>
-          {/if}
-        </div>
-
-        <!-- Advanced compatibility changes remain explicit. -->
         {#if Object.keys(pendingEngine).length > 0 && !stagedPreset}
-          <div class="w-full rounded-xl border border-zinc-700 bg-zinc-900/50 p-4">
-            <div class="flex items-center gap-2 mb-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400">
-                <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/>
-              </svg>
-              <p class="text-xs text-amber-300">Changes require engine reload</p>
+          <div data-compatibility-footer class="mt-4 border-t border-white/[0.08] pt-4">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <p class="text-xs text-amber-300">Compatibility changes require an engine reload.</p>
+              <button
+                type="button"
+                onclick={applyEngineSettings}
+                disabled={engineApplying || externalMode}
+                class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
+                  {engineApplying || externalMode
+                    ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed'
+                    : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}"
+              >
+                {#if engineApplying}
+                  Preparing…
+                {:else}
+                  Apply compatibility changes
+                {/if}
+              </button>
             </div>
-            <button
-              onclick={applyEngineSettings}
-              disabled={engineApplying}
-              class="px-4 py-2 rounded-lg text-xs font-medium transition-colors
-                {engineApplying
-                  ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed'
-                  : 'bg-emerald-600 hover:bg-emerald-500 text-white cursor-pointer'}"
-            >
-              {#if engineApplying}
-                <span class="flex items-center gap-2">
-                  <svg class="animate-spin h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
-                  Applying...
-                </span>
-              {:else}
-                Apply advanced changes
-              {/if}
-            </button>
             {#if engineApplyError}
-              <p class="mt-2 text-xs text-red-400">{engineApplyError}</p>
+              <p class="mt-2 text-xs text-red-300">{engineApplyError}</p>
             {/if}
           </div>
         {/if}
 
-        <!-- Engine status -->
-        {#if engineStatus}
-          <div class="flex items-center justify-between p-4 bg-zinc-900/50 rounded-xl w-full">
+        {#if sharedEngineStatus}
+          <div data-engine-status class="mt-4 flex flex-wrap items-start justify-between gap-3 border-t border-white/[0.08] pt-4">
             <div class="flex items-center gap-2">
-              <span class="text-xs text-zinc-500">Status:</span>
-              {#if engineStatus.status === 'ready' && !engineStatus.pending}
-                <span class="flex items-center gap-1.5 text-xs text-emerald-400">
-                  <span class="w-1.5 h-1.5 rounded-full bg-emerald-400"></span>
+              <span class="text-xs text-zinc-500">Engine status:</span>
+              {#if sharedEngineStatus.status === 'ready' && !sharedEngineStatus.pending}
+                <span class="flex items-center gap-1.5 text-xs text-emerald-300">
+                  <span class="h-1.5 w-1.5 rounded-full bg-emerald-300"></span>
                   Ready
                 </span>
-              {:else if engineStatus.status === 'loading' || engineStatus.pending}
-                <span class="flex items-center gap-1.5 text-xs text-amber-400">
-                  <span class="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse"></span>
-                  Loading{engineStatus.pending?.message ? `: ${engineStatus.pending.message}` : '...'}
+              {:else if sharedEngineStatus.status === 'loading' || sharedEngineStatus.pending}
+                <span class="flex items-center gap-1.5 text-xs text-amber-300">
+                  <span class="h-1.5 w-1.5 rounded-full bg-amber-300"></span>
+                  Preparing{sharedEngineStatus.pending?.message ? `: ${sharedEngineStatus.pending.message}` : '...'}
                 </span>
-              {:else if engineStatus.status === 'error'}
-                <span class="flex items-center gap-1.5 text-xs text-red-400">
-                  <span class="w-1.5 h-1.5 rounded-full bg-red-400"></span>
-                  Error{engineStatus.message ? `: ${engineStatus.message}` : ''}
+              {:else if sharedEngineStatus.status === 'error'}
+                <span class="flex items-center gap-1.5 text-xs text-red-300">
+                  <span class="h-1.5 w-1.5 rounded-full bg-red-300"></span>
+                  Error{sharedEngineStatus.message ? `: ${sharedEngineStatus.message}` : ''}
                 </span>
               {/if}
             </div>
-            {#if engineStatus.info}
-              <div class="flex flex-col items-end gap-0.5">
-                <span class="text-xs text-zinc-500">~{engineStatus.info.model_size_gb} GB model</span>
-                {#if engineStatus.info.gpu_vram_gb != null}
-                  <span class="max-w-[260px] truncate text-xs text-zinc-500" title={engineStatus.info.gpu_name ?? 'GPU'}>
-                    {engineStatus.info.gpu_name ?? 'GPU'} • {engineStatus.info.gpu_vram_gb.toFixed(1)} GB VRAM
+            {#if sharedEngineStatus.info}
+              <div class="flex min-w-0 flex-col items-start gap-0.5 sm:items-end">
+                <span class="text-xs text-zinc-500">~{sharedEngineStatus.info.model_size_gb} GB model</span>
+                {#if sharedEngineStatus.info.gpu_vram_gb != null}
+                  <span class="max-w-full truncate text-xs text-zinc-500" title={sharedEngineStatus.info.gpu_name ?? 'GPU'}>
+                    {sharedEngineStatus.info.gpu_name ?? 'GPU'} • {sharedEngineStatus.info.gpu_vram_gb.toFixed(1)} GB VRAM
                   </span>
                 {/if}
-                {#if engineStatus.info.estimated_max_duration_s != null}
+                {#if sharedEngineStatus.info.estimated_max_duration_s != null}
                   <span
                     class="text-xs text-zinc-400 cursor-help border-b border-dotted border-zinc-600"
-                    title={estimatedDurationTooltip(engineStatus.info)}
+                    title={estimatedDurationTooltip(sharedEngineStatus.info)}
                   >
-                    Est. max per recording: {formatEstimatedDuration(engineStatus.info.estimated_max_duration_s)}
+                    Est. max per recording: {formatEstimatedDuration(sharedEngineStatus.info.estimated_max_duration_s)}
                   </span>
                 {/if}
               </div>
@@ -996,8 +1015,8 @@
           </div>
         {/if}
       {/if}
-    </SettingsSection>
-
+        </div>
+      </div>
     <SettingsSection title="Server">
       <SettingsRow
         label="Use external server"
@@ -1083,8 +1102,7 @@
 
     <ServerView embedded />
 
-      </div>
-    </section>
+    </SettingsSection>
 
     <SettingsSection title="About">
       <SettingsRow label="Version" description="Installed Eve build version">

--- a/app/tests/fixtures/settings-speech-electron.cjs
+++ b/app/tests/fixtures/settings-speech-electron.cjs
@@ -1,0 +1,138 @@
+const { app, BrowserWindow } = require('electron');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const baseUrl = process.argv[2];
+const screenshotDir = path.resolve(process.env.EVE_PHASE2_SCREENSHOT_DIR || path.join(os.tmpdir(), 'eve-phase2-settings-screenshots'));
+if (!baseUrl) throw new Error('fixture URL is required');
+
+const tempRoot = path.resolve(os.tmpdir());
+const userData = path.resolve(tempRoot, `eve-settings-speech-${process.pid}`);
+const electronScreenshots = [
+  ['general', 'ready', false, 'general-hotwords.png'],
+  ['speech', 'ready', false, 'speech-ready.png'],
+  ['speech', 'preparing', false, 'speech-preparing.png'],
+  ['speech', 'error', false, 'speech-error.png'],
+  ['speech', 'external', false, null],
+  ['speech', 'ready', true, 'compatibility-expanded.png'],
+];
+
+app.setPath('userData', userData);
+app.commandLine.appendSwitch('disable-gpu');
+app.commandLine.appendSwitch('force-device-scale-factor', '1');
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function fixtureUrl(view, state, compatibility) {
+  const params = new URLSearchParams({ view, state });
+  if (compatibility) params.set('compatibility', 'expanded');
+  return `${baseUrl}?${params}`;
+}
+
+async function loadFixture(window, view, state, compatibility) {
+  await window.loadURL(fixtureUrl(view, state, compatibility));
+  await wait(250);
+}
+
+async function measure(window, view, state, compatibility, zoom) {
+  await window.webContents.setZoomFactor(zoom);
+  await wait(80);
+  const serialized = JSON.stringify({ view, state, compatibility, zoom });
+  return window.webContents.executeJavaScript(`(() => {
+    const meta = ${serialized};
+    const owner = document.querySelector('[data-fixture-scroll-owner]');
+    const main = document.querySelector('[data-fixture-main]');
+    const panel = document.querySelector('[data-speech-model-panel]');
+    const options = [...document.querySelectorAll('[data-speech-model-option]')];
+    const radios = [...document.querySelectorAll('input[type="radio"]')];
+    const states = [...document.querySelectorAll('[data-speech-model-state]')].map((node) => node.textContent?.trim() ?? '');
+    const focusTarget = radios[0] ?? document.querySelector('[data-fixture-compatibility-toggle]');
+    focusTarget?.focus({ preventScroll: true, focusVisible: true });
+    const focusLabel = focusTarget?.closest('label');
+    const focusStyle = focusLabel ? getComputedStyle(focusLabel) : focusTarget ? getComputedStyle(focusTarget) : null;
+    const rect = (element) => element ? (() => { const box = element.getBoundingClientRect(); return { top: box.top, bottom: box.bottom, left: box.left, right: box.right, width: box.width, height: box.height }; })() : null;
+    const ownerRect = rect(owner);
+    const optionRects = options.map(rect);
+    const compatibilityButton = document.querySelector('[data-fixture-compatibility-toggle]');
+    const compatibilityControls = document.querySelector('[data-fixture-compatibility-controls]');
+    return {
+      ...meta,
+      viewport: { width: innerWidth, height: innerHeight },
+      owner: owner ? { overflowY: getComputedStyle(owner).overflowY, clientHeight: owner.clientHeight, scrollHeight: owner.scrollHeight, scrollWidth: owner.scrollWidth, clientWidth: owner.clientWidth, rect: ownerRect } : null,
+      main: rect(main),
+      panel: rect(panel),
+      optionCount: options.length,
+      checkedCount: radios.filter((radio) => radio.checked).length,
+      states,
+      optionContained: !!ownerRect && optionRects.every((option) => option && option.left >= ownerRect.left && option.right <= ownerRect.right),
+      focus: focusStyle ? { focusWithin: !!focusLabel?.matches(':focus-within'), outlineWidth: focusStyle.outlineWidth, boxShadow: focusStyle.boxShadow } : null,
+      document: { scrollWidth: document.documentElement.scrollWidth, clientWidth: document.documentElement.clientWidth },
+      external: !!document.querySelector('[data-speech-model-external]'),
+      compatibilityExpanded: compatibilityButton?.getAttribute('aria-expanded') === 'true' && !!compatibilityControls,
+      compatibilityAssociation: !!compatibilityButton && compatibilityButton.getAttribute('aria-controls') === compatibilityControls?.id,
+    };
+  })()`);
+}
+
+async function capture(window, view, state, compatibility, filename) {
+  await window.webContents.setZoomFactor(1);
+  await window.setContentSize(960, 900);
+  await wait(120);
+  fs.mkdirSync(screenshotDir, { recursive: true });
+  const image = await window.webContents.capturePage();
+  const target = path.resolve(screenshotDir, filename);
+  fs.writeFileSync(target, image.toPNG());
+  return target;
+}
+
+async function main() {
+  let window = null;
+  const measurements = [];
+  const screenshots = [];
+  await app.whenReady();
+  try {
+    window = new BrowserWindow({
+      width: 960,
+      height: 900,
+      show: false,
+      frame: false,
+      resizable: false,
+      backgroundColor: '#08090a',
+      webPreferences: { contextIsolation: true, nodeIntegration: false },
+    });
+    window.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+      process.stderr.write(`renderer console ${level} ${sourceId}:${line}: ${message}\n`);
+    });
+    window.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+      process.stderr.write(`renderer load failed ${errorCode} ${errorDescription} ${validatedURL}\n`);
+    });
+    window.show();
+    window.focus();
+    window.webContents.focus();
+    await wait(500);
+
+    for (const [view, state, compatibility, filename] of electronScreenshots) {
+      await loadFixture(window, view, state, compatibility);
+      if (filename) screenshots.push(await capture(window, view, state, compatibility, filename));
+
+      for (const [width, height] of [[960, 900], [320, 700]]) {
+        await window.setContentSize(width, height);
+        await wait(100);
+        for (const zoom of [1, 1.5, 2]) {
+          measurements.push(await measure(window, view, state, compatibility, zoom));
+        }
+      }
+    }
+  } finally {
+    if (window && !window.isDestroyed()) await window.close();
+  }
+
+  process.stdout.write(JSON.stringify({ measurements, screenshots, userDataPath: userData }));
+  app.quit();
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  app.exit(1);
+});

--- a/app/tests/settings-layout.test.ts
+++ b/app/tests/settings-layout.test.ts
@@ -9,6 +9,7 @@ const appView = source('../src/renderer/app/App.svelte');
 const appCss = source('../src/renderer/app/app.css');
 const appHtml = source('../src/renderer/app/index.html');
 const settingsView = source('../src/renderer/app/views/SettingsView.svelte');
+const settingsGroup = source('../src/renderer/app/components/SettingsGroup.svelte');
 const settingsSection = source('../src/renderer/app/components/SettingsSection.svelte');
 const settingsRow = source('../src/renderer/app/components/SettingsRow.svelte');
 const statusBanner = source('../src/renderer/app/components/ModelProgressBanner.svelte');
@@ -62,12 +63,12 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(settingsSection).toContain('aria-labelledby={headingId}');
     expect(settingsSection).toContain('<h2 id={headingId}');
     expect(settingsView).toContain('<h1 class="sr-only">Settings</h1>');
-    expect(settingsView).toContain('aria-label="Input Device"');
+    expect(settingsView).toContain('aria-label="Input device"');
     expect(settingsView).toContain('aria-label="Dictation mode"');
     expect(settingsView).toContain('aria-label="Paste method"');
     expect(settingsView).toContain('aria-describedby="hotwords-help"');
-    expect(settingsView).toContain('aria-expanded={engineAdvancedOpen}');
-    expect(settingsView).toContain('aria-controls="engine-advanced-options"');
+    expect(settingsView).toContain('aria-expanded={compatibilityControlsOpen}');
+    expect(settingsView).toContain('aria-controls="compatibility-controls"');
   });
 
   test('keeps generated section heading IDs unique and non-empty while preserving explicit IDs', () => {
@@ -82,8 +83,21 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(appView).toContain('<p class="sr-only" aria-live="polite" aria-atomic="true">{$serverStatusState.announcement}</p>');
     expect(settingsView).toContain('aria-pressed={settings.holdToTalk}');
     expect(settingsView).toContain('aria-pressed={!settings.holdToTalk}');
-    expect(settingsView).toContain('mt-4 w-full min-w-0 border transition-colors');
+    expect(settingsView).toContain('data-hotwords-editor');
     expect(settingsView.match(/<select[\s\S]*?cursor-pointer/g)?.length).toBe(7);
+  });
+
+  test('keeps the Phase 2 General subgroup foundation aligned with the row primitive', () => {
+    expect(settingsGroup).toContain('<h3 id={headingId}');
+    expect(settingsGroup).toContain('data-settings-group-surface');
+    expect(settingsView).toContain('<SettingsSection title="General"');
+    expect(settingsView).toContain('<SettingsGroup title="Shortcuts &amp; activation">');
+    expect(settingsView).toContain('<SettingsGroup title="Audio">');
+    expect(settingsView).toContain('<SettingsGroup title="Dictation/output">');
+    expect(settingsView).toContain('<SettingsGroup title="Hotwords"');
+    expect(settingsView).toContain('<SettingsGroup title="App behavior">');
+    expect(settingsView).not.toContain('<SettingsSection title="Shortcuts &amp; activation">');
+    expect(settingsView).not.toContain('<SettingsSection title="Model compatibility">');
   });
 
   test('keeps shared focus, forced-colors, and reduced-motion fallbacks intact', () => {

--- a/app/tests/settings-speech-cohesion.test.ts
+++ b/app/tests/settings-speech-cohesion.test.ts
@@ -63,6 +63,9 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(settingsView).toContain('aria-expanded={compatibilityControlsOpen}');
     expect(settingsView).toContain('aria-controls="compatibility-controls"');
     expect(settingsView).toContain('id="compatibility-controls"');
+    expect(settingsView).toContain('hidden={!compatibilityControlsOpen}');
+    expect(settingsView).toContain('hasPendingCompatibilityChanges()');
+    expect(chooser).toContain('externalMode || unavailable(preset)');
     expect(settingsView).toContain("'whisper_compute_type'");
     expect(settingsView).toContain("'whisper_language'");
     expect(settingsView).toContain("'nemotron_device'");

--- a/app/tests/settings-speech-cohesion.test.ts
+++ b/app/tests/settings-speech-cohesion.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+const settingsView = source('../src/renderer/app/views/SettingsView.svelte');
+const chooser = source('../src/renderer/app/components/SpeechModelChooser.svelte');
+const settingsGroup = source('../src/renderer/app/components/SettingsGroup.svelte');
+
+describe('Phase 2 General and Speech cohesion contracts', () => {
+  test('keeps General flat while removing the Hotwords card-within-card collision', () => {
+    expect(settingsView).toContain('<SettingsSection title="General"');
+    expect(settingsView).toContain('data-settings-general');
+    expect(settingsView).toContain('data-hotwords-editor');
+    expect(settingsView).toContain('HOTWORDS_WARNING_THRESHOLD');
+    expect(settingsView).toContain('importHotwords');
+    expect(settingsView).toContain('exportHotwords');
+    expect(settingsView).not.toContain('<SettingsSection title="Hotwords"');
+    expect(settingsView).not.toContain('data-hotwords-editor class="mt-4 w-full min-w-0 border');
+    expect(settingsGroup).toContain('rounded-xl border border-white/10 bg-white/[0.025]');
+  });
+
+  test('renders one padded single-column accessible speech model panel', () => {
+    expect(chooser).toContain('data-speech-model-panel');
+    expect(chooser).toContain('<fieldset class="m-0 min-w-0 border-0 p-0"');
+    expect(chooser).toContain('data-speech-model-list role="radiogroup"');
+    expect(chooser).toContain('type="radio"');
+    expect(chooser).toContain('data-speech-model-option');
+    expect(chooser).toContain('focus-within:ring-2');
+    expect(chooser).not.toContain('sm:grid-cols-2');
+    expect(chooser).not.toContain('rounded-xl border p-3 transition-colors');
+  });
+
+  test('distinguishes current, selected, available, preparing, error, and external states', () => {
+    expect(chooser).toContain("if (isError(preset)) return isSelected(preset) ? 'Selected · Error' : 'Error'");
+    expect(chooser).toContain("if (isPreparing(preset)) return 'Preparing'");
+    expect(chooser).toContain("if (isCurrent(preset)) return 'Current'");
+    expect(chooser).toContain('if (isSelected(preset)) return isPreparing(preset)');
+    expect(chooser).toContain("'Selected'");
+    expect(chooser).toContain("return 'Available'");
+    expect(chooser).toContain("return 'Unavailable'");
+    expect(chooser).toContain('data-speech-model-external');
+    expect(chooser).toContain('preparationFailed: boolean');
+    expect(settingsView).toContain('preparationFailed={preparationFailed}');
+  });
+
+  test('keeps explicit prepare/retry/revert semantics and current-until-ready copy', () => {
+    expect(chooser).toContain('Apply and prepare model confirms the change');
+    expect(settingsView).toContain('Apply and prepare model');
+    expect(settingsView).toContain("'Retry preparation'");
+    expect(settingsView).toContain('>Revert</button>');
+    expect(settingsView).toContain('current engine remains active until the selected model is ready');
+    expect(settingsView).toContain('selectPreset');
+    expect(settingsView).toContain('if (externalMode || !isEngineAvailable(preset.engine)) return;');
+    expect(settingsView).not.toContain('async function pollEngineStatus');
+    expect(settingsView).toContain('void loadServerSettings()');
+  });
+
+  test('puts raw compatibility controls behind one accessible disclosure and footer', () => {
+    expect(settingsView).toContain('<h3 class="text-sm font-medium text-zinc-100">Compatibility controls</h3>');
+    expect(settingsView).toContain('aria-expanded={compatibilityControlsOpen}');
+    expect(settingsView).toContain('aria-controls="compatibility-controls"');
+    expect(settingsView).toContain('id="compatibility-controls"');
+    expect(settingsView).toContain("'whisper_compute_type'");
+    expect(settingsView).toContain("'whisper_language'");
+    expect(settingsView).toContain("'nemotron_device'");
+    expect(settingsView).toContain("'whisper_device'");
+    expect(settingsView).toContain("'unload_before_swap'");
+    expect(settingsView).toContain('data-compatibility-footer');
+    expect(settingsView).toContain('Apply compatibility changes');
+    expect(settingsView).toContain('data-engine-status');
+    expect(settingsView).toContain('disabled={externalMode}');
+    expect(settingsView).not.toContain('engineAdvancedOpen');
+    expect(settingsView).not.toContain('engine-advanced-options');
+  });
+});

--- a/app/tests/settings-speech-cohesion.test.ts
+++ b/app/tests/settings-speech-cohesion.test.ts
@@ -28,6 +28,7 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(chooser).toContain('data-speech-model-list role="radiogroup"');
     expect(chooser).toContain('type="radio"');
     expect(chooser).toContain('data-speech-model-option');
+    expect(chooser).toContain('name={`speech-model-preset-${componentId}`}');
     expect(chooser).toContain('focus-within:ring-2');
     expect(chooser).not.toContain('sm:grid-cols-2');
     expect(chooser).not.toContain('rounded-xl border p-3 transition-colors');
@@ -64,7 +65,7 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(settingsView).toContain('aria-controls="compatibility-controls"');
     expect(settingsView).toContain('id="compatibility-controls"');
     expect(settingsView).toContain('hidden={!compatibilityControlsOpen}');
-    expect(settingsView).toContain('hasPendingCompatibilityChanges()');
+    expect(settingsView).toContain('hasPendingCompatibilityChanges(pendingEngine, stagedPreset)');
     expect(chooser).toContain('externalMode || unavailable(preset)');
     expect(settingsView).toContain("'whisper_compute_type'");
     expect(settingsView).toContain("'whisper_language'");

--- a/app/tests/settings-speech-rendered.test.mjs
+++ b/app/tests/settings-speech-rendered.test.mjs
@@ -1,0 +1,144 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, isAbsolute, relative, resolve } from 'node:path';
+
+const appRoot = resolve(import.meta.dir, '..');
+const fixtureTempRoot = resolve(tmpdir());
+const screenshotDir = resolve(fixtureTempRoot, 'eve-phase2-settings-screenshots');
+const vitePort = 52000 + (process.pid % 100);
+const viteProcess = Bun.spawn([
+  'node',
+  resolve(appRoot, 'node_modules/vite/bin/vite.js'),
+  '--host',
+  '127.0.0.1',
+], {
+  cwd: appRoot,
+  env: { ...process.env, MURMUR_DEV_PORT: String(vitePort) },
+  stdout: 'ignore',
+  stderr: 'pipe',
+  windowsHide: true,
+});
+const fixtureUrl = `http://127.0.0.1:${vitePort}/app/fixtures/settings-speech-fixture.html`;
+const electronPath = resolve(appRoot, 'node_modules/electron/dist/electron.exe');
+const runnerPath = resolve(appRoot, 'tests/fixtures/settings-speech-electron.cjs');
+
+function assertSafeUserDataPath(target) {
+  const resolvedTarget = resolve(target);
+  const relativeTarget = relative(fixtureTempRoot, resolvedTarget);
+  if (!relativeTarget || relativeTarget.startsWith('..') || isAbsolute(relativeTarget) || !basename(resolvedTarget).startsWith('eve-settings-speech-')) {
+    throw new Error(`Refusing to remove unexpected fixture path: ${resolvedTarget}`);
+  }
+  return resolvedTarget;
+}
+
+async function cleanupUserData(target) {
+  const resolvedTarget = assertSafeUserDataPath(target);
+  await fs.rm(resolvedTarget, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+  return existsSync(resolvedTarget);
+}
+
+async function waitForFixtureServer() {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      const response = await fetch(fixtureUrl);
+      if (response.ok) return;
+    } catch {
+      // Vite is still starting.
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  viteProcess.kill();
+  const stderr = await new Response(viteProcess.stderr).text();
+  throw new Error(`Vite fixture server did not start on port ${vitePort}: ${stderr}`);
+}
+
+function runElectron() {
+  const child = Bun.spawn([electronPath, runnerPath, fixtureUrl], {
+    cwd: appRoot,
+    env: { ...process.env, EVE_PHASE2_SCREENSHOT_DIR: screenshotDir },
+    stdout: 'pipe',
+    stderr: 'pipe',
+    windowsHide: true,
+  });
+  return Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]).then(([stdout, stderr, code]) => {
+    let result = null;
+    let parseError = null;
+    try {
+      result = JSON.parse(stdout);
+    } catch (error) {
+      parseError = error;
+    }
+    const userDataPath = result?.userDataPath ?? resolve(fixtureTempRoot, `eve-settings-speech-${child.pid}`);
+    return cleanupUserData(userDataPath).then((userDataExists) => {
+      if (code !== 0) throw new Error(`Electron Speech fixture exited with ${code}: ${stderr || stdout}`);
+      if (!result) throw new Error(`Electron Speech fixture returned invalid JSON: ${parseError}\n${stderr}\n${stdout}`);
+      return { ...result, userDataExists };
+    });
+  });
+}
+
+afterAll(async () => {
+  viteProcess.kill();
+  await viteProcess.exited;
+});
+
+await waitForFixtureServer();
+const result = await runElectron();
+const { measurements } = result;
+
+describe('rendered Phase 2 Settings/Speech fixture', () => {
+  test('keeps the General and Speech fixture inside one page scroll owner at all zooms', () => {
+    expect(measurements.length).toBe(36);
+    for (const measurement of measurements) {
+      expect(measurement.owner.overflowY).toBe('auto');
+      expect(measurement.owner.scrollHeight).toBeGreaterThanOrEqual(measurement.owner.clientHeight);
+      expect(measurement.owner.scrollWidth).toBeLessThanOrEqual(measurement.owner.clientWidth);
+      expect(measurement.document.scrollWidth).toBeLessThanOrEqual(measurement.document.clientWidth);
+    }
+  });
+
+  test('renders radio/current/selected states and visible keyboard focus across ready/loading/error', () => {
+    for (const state of ['ready', 'preparing', 'error']) {
+      const stateMeasurements = measurements.filter((measurement) => measurement.view === 'speech' && measurement.state === state && !measurement.compatibility);
+      expect(stateMeasurements.length).toBe(6);
+      for (const measurement of stateMeasurements) {
+        expect(measurement.optionCount).toBe(4);
+        expect(measurement.checkedCount).toBe(1);
+        expect(measurement.optionContained).toBeTrue();
+        expect(measurement.focus.focusWithin).toBeTrue();
+      }
+    }
+
+    const ready = measurements.find((measurement) => measurement.view === 'speech' && measurement.state === 'ready' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const preparing = measurements.find((measurement) => measurement.view === 'speech' && measurement.state === 'preparing' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const error = measurements.find((measurement) => measurement.view === 'speech' && measurement.state === 'error' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    expect(ready.states).toContain('Current');
+    expect(ready.states).toContain('Available');
+    expect(preparing.states.some((label) => label.includes('Selected') && label.includes('Preparing'))).toBeTrue();
+    expect(error.states.some((label) => label.includes('Selected') && label.includes('Error'))).toBeTrue();
+  });
+
+  test('preserves external restrictions and the compatibility disclosure association', () => {
+    const external = measurements.find((measurement) => measurement.view === 'speech' && measurement.state === 'external' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    expect(external.external).toBeTrue();
+    expect(external.optionCount).toBe(0);
+    expect(external.focus.focusWithin).toBeFalse();
+
+    const expanded = measurements.find((measurement) => measurement.compatibility);
+    expect(expanded.compatibilityExpanded).toBeTrue();
+    expect(expanded.compatibilityAssociation).toBeTrue();
+  });
+
+  test('writes deterministic isolated screenshots and cleans Electron userData', () => {
+    expect(result.screenshots).toHaveLength(5);
+    for (const screenshot of result.screenshots) {
+      expect(existsSync(screenshot)).toBeTrue();
+    }
+    expect(result.userDataExists).toBeFalse();
+  });
+});

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
-import { SPEECH_MODEL_PRESETS, presetDownloadLabel, presetMatchesCurrentEngine, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../src/renderer/app/speech-model-presets';
+import { SPEECH_MODEL_PRESETS, hasPendingCompatibilityChanges, presetDownloadLabel, presetMatchesCurrentEngine, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../src/renderer/app/speech-model-presets';
 
 describe('speech model presets', () => {
   test('keeps the four exact supported mappings and factual established sizes', () => {
@@ -12,6 +12,19 @@ describe('speech model presets', () => {
     ]);
     expect(presetPatch(SPEECH_MODEL_PRESETS[0])).toEqual({ engine: 'nemotron', nemotron_model: 'nvidia/nemotron-speech-streaming-en-0.6b' });
     expect(presetPatch(SPEECH_MODEL_PRESETS[1])).toEqual({ engine: 'whisper', whisper_model: 'large-v3-turbo' });
+  });
+
+  test('does not warn for a pure staged preset patch but warns for an additional pending model', () => {
+    const preset = SPEECH_MODEL_PRESETS[0];
+    const patch = presetPatch(preset);
+    expect(hasPendingCompatibilityChanges(patch, preset)).toBeFalse();
+    expect(hasPendingCompatibilityChanges({ ...patch, whisper_model: 'medium' }, preset)).toBeTrue();
+  });
+
+  test('warns when a staged preset model has a different pending value', () => {
+    const preset = SPEECH_MODEL_PRESETS[1];
+    expect(hasPendingCompatibilityChanges(presetPatch(preset), preset)).toBeFalse();
+    expect(hasPendingCompatibilityChanges({ ...presetPatch(preset), whisper_model: 'medium' }, preset)).toBeTrue();
   });
 
   test('promotes a selected preset only when its actual engine status is ready', () => {
@@ -30,6 +43,7 @@ describe('speech model presets', () => {
     const settings = readFileSync(new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url), 'utf8');
     const chooser = readFileSync(new URL('../src/renderer/app/components/SpeechModelChooser.svelte', import.meta.url), 'utf8');
     expect(chooser).toContain('type="radio"');
+    expect(chooser).toContain('name={`speech-model-preset-${componentId}`}');
     expect(chooser).toContain('Apply and prepare model confirms the change.');
     expect(settings).toContain('Apply and prepare model');
     expect(settings).toContain('serverStatusState');


### PR DESCRIPTION
Phase 2 Settings/Speech cohesion from canonical trunk 7959e386. Consolidates General into flat SettingsGroup surfaces and removes the Hotwords nested-card collision. Rebuilds Speech selection as a padded accessible single-column radio list with Current, Selected, Available, Preparing, Error, and external states. Preserves curated mappings, pending/apply/retry/revert semantics, current-until-ready behavior, external restrictions, and no mount/focus download. Moves raw compatibility fields behind one accessible disclosure with status/action footer. Adds isolated rendered fixtures, 100/150/200% zoom geometry checks, keyboard focus checks, and deterministic screenshots. Verification: 160 app tests passed; history/insights passed; main and renderer TypeScript checks passed; production build passed; svelte-check has the same six pre-existing diagnostics in HistoryView, InsightsView, and App.svelte, with no new Settings/Speech diagnostics or warnings. Screenshots: E:\Temp\eve-phase2-settings-screenshots\general-hotwords.png, speech-ready.png, speech-preparing.png, speech-error.png, compatibility-expanded.png. No package, install, release, draft, server/IPC, persistence, or Phase 3 changes. Please review; do not merge as part of this task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorganized Settings into clear General, Speech, Advanced, Server, and About groups.
  * Added improved speech model selection with preparation, retry, error, and external-mode states.
  * Added hotword import/export controls and engine support messaging.
  * Consolidated compatibility settings into an expandable panel with clearer status and controls.
  * Improved accessibility, responsive layouts, focus states, and descriptive labels.

* **Bug Fixes**
  * Improved handling and presentation of speech model preparation failures and compatibility restrictions.
  * Added clearer warnings for pending compatibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->