### PR TITLE
feat(settings): cohere server and diagnostics

### DIFF
--- a/app/src/renderer/app/components/ModelProgressBanner.svelte
+++ b/app/src/renderer/app/components/ModelProgressBanner.svelte
@@ -21,7 +21,7 @@
       <div class="rounded-lg border border-red-500/30 bg-red-950/25 p-3" role="status" aria-live="off">
         <p class="text-sm font-medium text-red-200 text-pretty">Speech model setup failed</p>
         <p class="mt-1 text-xs text-red-200/80 text-pretty [overflow-wrap:anywhere]">
-          {modelDownload.detail ?? 'Check your connection.'} Open Settings &gt; Advanced for details.
+          {modelDownload.detail ?? 'Check your connection.'} Open Settings &gt; Server &amp; diagnostics for details.
           {#if managementMode === 'managed'}
             You can restart the managed server there.
           {:else if managementMode === 'external'}

--- a/app/src/renderer/app/components/SettingsGroup.svelte
+++ b/app/src/renderer/app/components/SettingsGroup.svelte
@@ -23,13 +23,14 @@
   }
 
   let headingId = $derived(id ?? `settings-group-${slugify(title) || 'group'}-${componentId}`);
+  let descriptionId = $derived(description ? `${headingId}-description` : undefined);
 </script>
 
-<section data-settings-group class="min-w-0 space-y-2" aria-labelledby={headingId}>
+<section data-settings-group class="min-w-0 space-y-2" aria-labelledby={headingId} aria-describedby={descriptionId}>
   <div class="min-w-0 px-1">
     <h3 id={headingId} class="text-xs font-medium text-zinc-300">{title}</h3>
     {#if description}
-      <p class="mt-1 max-w-prose text-[11px] leading-4 text-zinc-500">{description}</p>
+      <p id={descriptionId} class="mt-1 max-w-prose text-[11px] leading-4 text-zinc-500">{description}</p>
     {/if}
   </div>
 

--- a/app/src/renderer/app/components/SettingsSection.svelte
+++ b/app/src/renderer/app/components/SettingsSection.svelte
@@ -23,15 +23,16 @@
   }
 
   let headingId = $derived(id ?? `settings-section-${slugify(title) || 'section'}-${componentId}`);
+  let descriptionId = $derived(description ? `${headingId}-description` : undefined);
 </script>
 
-<section class="w-full min-w-0" aria-labelledby={headingId}>
+<section class="w-full min-w-0" aria-labelledby={headingId} aria-describedby={descriptionId}>
   <div class="mb-3 min-w-0">
     <h2 id={headingId} class="text-sm font-semibold text-zinc-400">
       {title}
     </h2>
     {#if description}
-      <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">{description}</p>
+      <p id={descriptionId} class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">{description}</p>
     {/if}
   </div>
 

--- a/app/src/renderer/app/fixtures/SettingsServerFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsServerFixture.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import SettingsRow from '../components/SettingsRow.svelte';
+  import SettingsSection from '../components/SettingsSection.svelte';
+  import ServerView from '../views/ServerView.svelte';
+  import Toggle from '../components/Toggle.svelte';
+
+  type FixtureState = 'managed-ready' | 'managed-error' | 'external-ready' | 'managed-long';
+
+  const params = new URLSearchParams(globalThis.location.search);
+  const fixtureState = (params.get('state') ?? 'managed-ready') as FixtureState;
+  const externalMode = fixtureState === 'external-ready';
+  const longStrings = fixtureState === 'managed-long';
+  const endpoint = longStrings
+    ? 'ws://fixture-server-with-a-deliberately-long-hostname.example.internal:51717/transcribe'
+    : externalMode
+      ? 'ws://external-fixture.example:51717/transcribe'
+      : 'ws://localhost:51717/transcribe';
+  let externalEnabled = $state(externalMode);
+</script>
+
+<div class="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[#08090a] text-zinc-100">
+  <header class="flex h-12 shrink-0 items-center justify-between gap-3 px-4 sm:px-6">
+    <h1 class="min-w-0 text-sm font-semibold text-zinc-100 [overflow-wrap:anywhere]">Phase 3 Server &amp; diagnostics fixture</h1>
+    <span data-fixture-state class="shrink-0 rounded-full border border-white/10 px-2.5 py-1 text-[11px] text-zinc-400">{fixtureState}</span>
+  </header>
+
+  <main data-server-fixture-main class="min-h-0 min-w-0 flex-1 overflow-hidden">
+    <div class="flex h-full min-h-0 min-w-0 w-full justify-center px-4 sm:px-6">
+      <div data-server-fixture-scroll-owner class="min-h-0 min-w-0 w-full max-w-[720px] overflow-y-auto overscroll-contain pr-2">
+        <div class="space-y-7 pb-8">
+          <SettingsSection
+            title="Server &amp; diagnostics"
+            description="Management mode, endpoint, health, diagnostics, and recent logs."
+            variant="content"
+          >
+            <div data-server-diagnostics class="min-w-0 space-y-6">
+              <section data-server-management class="min-w-0 space-y-2" aria-labelledby="fixture-server-management-heading">
+                <div class="min-w-0 px-1">
+                  <h3 id="fixture-server-management-heading" class="text-sm font-semibold text-zinc-200">Management mode &amp; endpoint</h3>
+                  <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Choose Eve-managed processing or connect to an external endpoint.</p>
+                </div>
+                <div data-server-mode-surface class="min-w-0 overflow-hidden rounded-xl border border-white/10 bg-white/[0.025]">
+                  <SettingsRow label="Use external server" description="Connect to your own server and disable built-in server management">
+                    <Toggle enabled={externalEnabled} label="Use external server" onchange={(enabled) => externalEnabled = enabled} />
+                  </SettingsRow>
+                  <div data-external-server-panel class="min-w-0 border-t border-white/[0.08] p-4">
+                    <p class="text-sm text-zinc-200">Custom server endpoint</p>
+                    <p class="mt-1 text-xs leading-5 text-zinc-500 [overflow-wrap:anywhere]">Eve connects to <span class="font-mono">/transcribe</span> at the configured endpoint.</p>
+                    <label for="fixture-server-url" class="mt-3 block text-xs text-zinc-500">Endpoint</label>
+                    <input id="fixture-server-url" aria-label="External server endpoint" value={endpoint} readonly class="mt-1 min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100" />
+                  </div>
+                </div>
+              </section>
+
+              <ServerView embedded externalMode={externalMode} />
+            </div>
+          </SettingsSection>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/src/renderer/app/fixtures/SettingsServerFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsServerFixture.svelte
@@ -43,11 +43,15 @@
                   <SettingsRow label="Use external server" description="Connect to your own server and disable built-in server management">
                     <Toggle enabled={externalEnabled} label="Use external server" onchange={(enabled) => externalEnabled = enabled} />
                   </SettingsRow>
-                  <div data-external-server-panel class="min-w-0 border-t border-white/[0.08] p-4">
-                    <p class="text-sm text-zinc-200">Custom server endpoint</p>
-                    <p class="mt-1 text-xs leading-5 text-zinc-500 [overflow-wrap:anywhere]">Eve connects to <span class="font-mono">/transcribe</span> at the configured endpoint.</p>
-                    <label for="fixture-server-url" class="mt-3 block text-xs text-zinc-500">Endpoint</label>
-                    <input id="fixture-server-url" aria-label="External server endpoint" value={endpoint} readonly class="mt-1 min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100" />
+                  <div class="overflow-hidden border-t border-white/[0.08]">
+                    {#if externalEnabled}
+                      <div data-external-server-panel class="min-w-0 p-4">
+                        <p class="text-sm text-zinc-200">Custom server endpoint</p>
+                        <p class="mt-1 text-xs leading-5 text-zinc-500 [overflow-wrap:anywhere]">Eve connects to <span class="font-mono">/transcribe</span> at the configured endpoint.</p>
+                        <label for="fixture-server-url" class="mt-3 block text-xs text-zinc-500">Endpoint</label>
+                        <input id="fixture-server-url" aria-label="External server endpoint" value={endpoint} readonly class="mt-1 min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100" />
+                      </div>
+                    {/if}
                   </div>
                 </div>
               </section>

--- a/app/src/renderer/app/fixtures/settings-server-fixture.html
+++ b/app/src/renderer/app/fixtures/settings-server-fixture.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-[#08090a]">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Settings Server diagnostics cohesion fixture</title>
+  </head>
+  <body class="h-full bg-[#08090a]">
+    <div id="fixture-root" class="h-full min-h-0 bg-[#08090a]"></div>
+    <script type="module" src="./settings-server-fixture.ts"></script>
+  </body>
+</html>

--- a/app/src/renderer/app/fixtures/settings-server-fixture.ts
+++ b/app/src/renderer/app/fixtures/settings-server-fixture.ts
@@ -1,0 +1,104 @@
+import { mount } from 'svelte';
+import type { ServerLogEntry, ServerStatePayload } from '$shared/types';
+import { DEFAULT_SETTINGS } from '$shared/types';
+import { serverStatusState } from '../server-status';
+import SettingsServerFixture from './SettingsServerFixture.svelte';
+import '../app.css';
+
+type FixtureState = 'managed-ready' | 'managed-error' | 'external-ready' | 'managed-long';
+
+const params = new URLSearchParams(globalThis.location.search);
+const fixtureState = (params.get('state') ?? 'managed-ready') as FixtureState;
+const externalMode = fixtureState === 'external-ready';
+const longStrings = fixtureState === 'managed-long';
+const hasError = fixtureState === 'managed-error';
+
+const longWarning = 'The fixture warning deliberately contains a long diagnostic explanation with a host, a compatibility hint, and a recovery action so responsive wrapping can be measured without accessing personal data.';
+const engineStatus = {
+  current: 'whisper',
+  status: hasError ? 'error' as const : 'ready' as const,
+  message: hasError ? 'The fixture engine could not load because the selected compatibility configuration needs attention.' : undefined,
+  info: {
+    id: 'whisper',
+    name: longStrings ? 'Faster-Whisper fixture engine with a deliberately long descriptive name' : 'Faster-Whisper',
+    model: 'large-v3-turbo',
+    supports_hotwords: true,
+    languages: ['en', 'fr', 'de'],
+    model_size_gb: 1.5,
+    gpu_name: longStrings ? 'Fixture GPU with an intentionally long hardware label for wrapping' : 'Fixture GPU',
+    gpu_vram_gb: 16,
+  },
+};
+
+const serverState: ServerStatePayload = {
+  status: hasError ? 'error' : 'running',
+  managed: !externalMode,
+  pid: externalMode ? undefined : 4242,
+  port: 51717,
+  version: longStrings ? '0.8.0-fixture-build-with-a-long-version-label' : '0.8.0',
+  uptime: 3725000,
+  error: hasError ? 'The managed server reported a recoverable fixture failure with a deliberately long message for wrapping.' : undefined,
+  engineStatus,
+  diagnostics: {
+    generated_at: '2026-08-03T00:00:00.000Z',
+    cuda: { available: true, device: 'cuda' },
+    cuda_dlls: { available: true },
+    nvidia_driver: { available: true, version: 'fixture' },
+    vc_redist: { required: false },
+    warnings: longStrings || hasError
+      ? [{
+          code: hasError ? 'fixture-engine-error' : 'fixture-long-warning',
+          message: hasError ? longWarning : longWarning,
+          action: 'Review the compatibility controls before retrying.',
+          severity: hasError ? 'error' as const : 'warning' as const,
+        }]
+      : [],
+  },
+};
+
+const logs: ServerLogEntry[] = Array.from({ length: 42 }, (_, index) => ({
+  timestamp: Date.UTC(2026, 7, 3, 12, 0, index),
+  level: index % 11 === 0 ? 'stderr' : 'stdout',
+  message: longStrings
+    ? `Fixture log ${index + 1}: a deliberately long, privacy-safe diagnostic line that wraps at narrow widths without exposing a real path, transcript, or profile value.`
+    : `Fixture server log entry ${index + 1}: readiness check complete.`,
+}));
+
+const fixtureSettings = {
+  ...DEFAULT_SETTINGS,
+  useExternalServer: externalMode,
+  serverUrl: longStrings
+    ? 'ws://fixture-server-with-a-deliberately-long-hostname.example.internal:51717/transcribe'
+    : externalMode
+      ? 'ws://external-fixture.example:51717/transcribe'
+      : DEFAULT_SETTINGS.serverUrl,
+};
+
+serverStatusState.set({
+  state: serverState,
+  phase: hasError ? 'error' : 'ready',
+  announcement: '',
+  configuredExternalServer: externalMode,
+});
+
+const fixtureMain = {
+  getServerLogs: async () => logs,
+  getSettings: async () => fixtureSettings,
+  onServerLog: (_callback: (entry: ServerLogEntry) => void) => () => {},
+  copyDiagnostics: async () => {},
+  copyToClipboard: (_text: string) => {},
+  startServer: async () => serverState,
+  stopServer: async () => serverState,
+  restartServer: async () => serverState,
+  updateSetting: async (_key: string, _value: unknown) => {},
+};
+
+Object.defineProperty(window, 'murmurMain', {
+  configurable: true,
+  value: fixtureMain,
+});
+
+const target = document.querySelector('#fixture-root');
+if (!target) throw new Error('Settings Server fixture target is missing');
+
+mount(SettingsServerFixture, { target });

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -87,7 +87,7 @@
           </button>
         {:else if managementMode === 'unknown' && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
           <p class="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
-            Management mode cannot be confirmed. Open Settings &gt; Advanced.
+            Management mode cannot be confirmed. Open Settings &gt; Server &amp; diagnostics.
           </p>
         {/if}
       </div>

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -5,7 +5,7 @@
   import ModelProgressCard from '../components/ModelProgressCard.svelte';
   import type { ServerStatePayload, ServerLogEntry } from '$shared/types';
   import { shouldShowModelProgress } from '$shared/model-progress';
-  import { serverStatusState } from '../server-status';
+  import { getServerManagementMode, serverStatusState } from '../server-status';
 
   interface Props {
     embedded?: boolean;
@@ -40,9 +40,12 @@
   let scrollAfterLogBatch = false;
   let removeLogListener: (() => void) | null = null;
 
-  let externalMode = $derived(externalModeProp ?? configuredExternalServer);
+  let externalMode = $derived(
+    externalModeProp ?? getServerManagementMode({ ...$serverStatusState, configuredExternalServer }) === 'external'
+  );
   const logOutputId = `server-log-output-${componentId}`;
   const privacyWarningId = `server-logs-privacy-${componentId}`;
+  const diagnosticsStatusId = `server-diagnostics-status-${componentId}`;
 
   const statusConfig: Record<
     ServerStatePayload['status'],
@@ -235,7 +238,12 @@
       <div class="min-w-0">
         <p class="text-sm text-amber-200">External server mode is enabled</p>
         <p class="mt-1 text-xs leading-5 text-amber-300/80 [overflow-wrap:anywhere]">
-          Built-in server controls are disabled. Configure the external endpoint in Settings &gt; Server &amp; diagnostics.
+          Built-in server controls are disabled.
+          {#if embedded}
+            Configure the external endpoint in the Management mode &amp; endpoint section above.
+          {:else}
+            Configure the external endpoint in Settings &gt; Server &amp; diagnostics.
+          {/if}
         </p>
       </div>
       {#if serverState.managed && serverState.status === 'running'}
@@ -262,14 +270,18 @@
       <button
         type="button"
         onclick={copyDiagnostics}
+        aria-describedby={diagnosticsStatusId}
         class="inline-flex min-h-9 shrink-0 items-center justify-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
       >
-        {diagnosticsCopyState === 'copied'
-          ? 'Copied diagnostics'
-          : diagnosticsCopyState === 'error'
-            ? 'Copy failed'
-            : 'Copy diagnostics'}
+        Copy diagnostics
       </button>
+      <span id={diagnosticsStatusId} class="sr-only">
+        {diagnosticsCopyState === 'copied'
+          ? 'Diagnostics copied.'
+          : diagnosticsCopyState === 'error'
+            ? 'Diagnostics copy failed.'
+            : ''}
+      </span>
     </div>
   </section>
 
@@ -297,7 +309,7 @@
     </div>
     <div data-server-health-surface class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4">
       <div data-server-health-status class="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div class="flex min-w-0 items-center gap-3" aria-label={`Server status: ${statusDisplay.label}`}>
+        <div class="flex min-w-0 items-center gap-3">
           <span class="relative flex h-3 w-3 shrink-0 items-center justify-center" aria-hidden="true">
             {#if serverState.status === 'running' && engineReady}
               <span class="absolute h-3 w-3 motion-safe:animate-ping rounded-full bg-emerald-400 opacity-75"></span>
@@ -401,7 +413,7 @@
         </div>
       {/if}
 
-      {#if serverState.status === 'running' && (serverState.pid || serverState.port || serverState.uptime)}
+      {#if serverState.status === 'running' && (serverState.pid !== undefined || serverState.port !== undefined || serverState.version !== undefined || serverState.uptime !== undefined)}
         <div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/[0.08] pt-4 sm:grid-cols-2">
           {#if serverState.port}
             <div class="min-w-0"><p class="text-xs text-zinc-500">Port</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">{serverState.port}</p></div>
@@ -463,7 +475,10 @@
           data-server-log-output
           id={`${logOutputId}-scroll`}
           bind:this={logsContainer}
-          class="mt-2 max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain rounded-lg border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs"
+          tabindex="0"
+          role="group"
+          aria-label="Server log output"
+          class="mt-2 max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain rounded-lg border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
         >
           {#if logs.length === 0}
             <p class="py-8 text-center text-zinc-500">No logs yet</p>

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -1,29 +1,35 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import Toggle from '../components/Toggle.svelte';
   import SettingsRow from '../components/SettingsRow.svelte';
-  import SettingsSection from '../components/SettingsSection.svelte';
   import ModelProgressCard from '../components/ModelProgressCard.svelte';
-  import type { ServerStatePayload, ServerLogEntry, Settings } from '$shared/types';
+  import type { ServerStatePayload, ServerLogEntry } from '$shared/types';
   import { shouldShowModelProgress } from '$shared/model-progress';
   import { serverStatusState } from '../server-status';
 
   interface Props {
     embedded?: boolean;
+    externalMode?: boolean;
   }
 
-  let { embedded = false }: Props = $props();
+  let { embedded = false, externalMode: externalModeProp }: Props = $props();
+  const componentId = $props.id();
+  const headingTag = $derived(embedded ? 'h3' : 'h2');
 
-  // Server state
+  function headingId(slug: string): string {
+    return `server-${slug}-${componentId}`;
+  }
+
   const unavailableState: ServerStatePayload = {
     status: 'idle',
     managed: false,
   };
+
   let serverState = $derived($serverStatusState.state ?? unavailableState);
   let logs = $state<ServerLogEntry[]>([]);
   let showLogs = $state(false);
   let autoStart = $state(true);
-  let useExternalServer = $state(false);
+  let configuredExternalServer = $state(false);
   let isLoading = $state(false);
   let logsContainer: HTMLDivElement | null = $state(null);
   let logsCopied = $state(false);
@@ -34,7 +40,10 @@
   let scrollAfterLogBatch = false;
   let removeLogListener: (() => void) | null = null;
 
-  // Status badge colors and labels
+  let externalMode = $derived(externalModeProp ?? configuredExternalServer);
+  const logOutputId = `server-log-output-${componentId}`;
+  const privacyWarningId = `server-logs-privacy-${componentId}`;
+
   const statusConfig: Record<
     ServerStatePayload['status'],
     { color: string; bgColor: string; label: string }
@@ -60,7 +69,6 @@
   let showModelProgress = $derived(shouldShowModelProgress(modelDownload));
   let modelDownloadError = $derived(modelDownload?.status === 'error');
 
-  // Format uptime as human-readable string
   function formatUptime(ms: number): string {
     const seconds = Math.floor(ms / 1000);
     const minutes = Math.floor(seconds / 60);
@@ -73,24 +81,22 @@
     return `${seconds}s`;
   }
 
-  // Format timestamp for logs
   function formatLogTime(timestamp: number): string {
     const date = new Date(timestamp);
     return date.toLocaleTimeString('en-US', { hour12: false });
   }
 
-  // Can start/stop based on status and management mode
   let canStart = $derived(
-    !useExternalServer &&
+    !externalMode &&
     !isLoading &&
     (serverState.status === 'stopped' || serverState.status === 'idle' || serverState.status === 'error')
   );
   let canStop = $derived(
-    !useExternalServer &&
+    !externalMode &&
     !isLoading && serverState.managed && serverState.status === 'running'
   );
   let canRestart = $derived(
-    !useExternalServer &&
+    !externalMode &&
     !isLoading && serverState.managed && serverState.status === 'running'
   );
   let canShutdownManaged = $derived(
@@ -140,19 +146,17 @@
 
   function isScrolledToBottom(): boolean {
     if (!logsContainer) return true;
-    const threshold = 40; // px from bottom to consider "at bottom"
+    const threshold = 40;
     return logsContainer.scrollHeight - logsContainer.scrollTop - logsContainer.clientHeight < threshold;
   }
 
   function scrollLogsToBottom() {
-    if (logsContainer) {
-      logsContainer.scrollTop = logsContainer.scrollHeight;
-    }
+    if (logsContainer) logsContainer.scrollTop = logsContainer.scrollHeight;
   }
 
   function copyLogs() {
     const text = logs
-      .map((l) => `${formatLogTime(l.timestamp)} ${l.message}`)
+      .map((log) => `${formatLogTime(log.timestamp)} ${log.message}`)
       .join('\n');
     window.murmurMain.copyToClipboard(text);
     logsCopied = true;
@@ -203,7 +207,7 @@
       const settings = await window.murmurMain.getSettings();
       if (!active) return;
       autoStart = settings.serverAutoStart;
-      useExternalServer = settings.useExternalServer;
+      configuredExternalServer = settings.useExternalServer;
 
       if (!active) return;
       removeLogListener = window.murmurMain.onServerLog((entry) => {
@@ -225,301 +229,254 @@
   });
 </script>
 
-<div class={embedded ? 'min-w-0 space-y-4' : 'h-full min-h-0 min-w-0 space-y-6 overflow-y-auto overscroll-contain p-4 pr-3'}>
-
-    {#if useExternalServer}
-      <div class="rounded-xl border border-amber-800/70 bg-amber-950/20 px-4 py-3">
-        <div class="flex items-center justify-between gap-3">
-          <div>
-            <p class="text-sm text-amber-200">External server mode is enabled</p>
-            <p class="mt-1 text-xs text-amber-300/80">
-              Managed server controls are disabled. Configure host and port in Settings > Advanced.
-            </p>
-          </div>
-          {#if serverState.managed && serverState.status === 'running'}
-            <button
-              onclick={handleStop}
-              disabled={!canShutdownManaged}
-              class="shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors
-                {canShutdownManaged
-                  ? 'bg-red-900/60 hover:bg-red-900 text-red-100 cursor-pointer'
-                  : 'bg-zinc-800 text-zinc-500 cursor-not-allowed'}"
-            >
-              Shut down server
-            </button>
-          {/if}
-        </div>
-      </div>
-    {/if}
-
-    <SettingsSection title="Diagnostics">
-      <div class="flex w-full items-center justify-between gap-4 rounded-xl bg-zinc-900/50 p-4">
-        <p class="text-xs text-zinc-500">
-          Copies an allowlisted system summary without logs, paths, history, or transcription text.
+<div data-server-view class={embedded ? 'min-w-0 space-y-6' : 'h-full min-h-0 min-w-0 space-y-6 overflow-y-auto overscroll-contain p-4 pr-3'}>
+  {#if externalMode}
+    <div data-server-external-notice class="flex min-w-0 flex-col gap-3 rounded-xl border border-amber-800/70 bg-amber-950/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div class="min-w-0">
+        <p class="text-sm text-amber-200">External server mode is enabled</p>
+        <p class="mt-1 text-xs leading-5 text-amber-300/80 [overflow-wrap:anywhere]">
+          Built-in server controls are disabled. Configure the external endpoint in Settings &gt; Server &amp; diagnostics.
         </p>
+      </div>
+      {#if serverState.managed && serverState.status === 'running'}
         <button
-          onclick={copyDiagnostics}
-          class="shrink-0 rounded-lg bg-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-600 cursor-pointer"
+          type="button"
+          onclick={handleStop}
+          disabled={!canShutdownManaged}
+          class="inline-flex min-h-9 shrink-0 items-center justify-center rounded-lg border border-red-800/70 bg-red-900/60 px-3 py-2 text-xs font-medium text-red-100 transition-colors
+            {canShutdownManaged ? 'cursor-pointer hover:bg-red-900' : 'cursor-not-allowed opacity-60'}"
         >
-          {diagnosticsCopyState === 'copied'
-            ? 'Copied diagnostics'
-            : diagnosticsCopyState === 'error'
-              ? 'Copy failed'
-              : 'Copy diagnostics'}
+          Shut down built-in server
         </button>
-      </div>
-    </SettingsSection>
+      {/if}
+    </div>
+  {/if}
 
-    <div class="space-y-5 {useExternalServer ? 'opacity-45 pointer-events-none select-none' : ''}">
+  <section data-server-section="diagnostics" class="min-w-0 space-y-2" aria-labelledby={headingId('diagnostics')}>
+    <div class="min-w-0 px-1">
+      <svelte:element this={headingTag} id={headingId('diagnostics')} class="text-sm font-semibold text-zinc-200">Diagnostics</svelte:element>
+      <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Copy an allowlisted system summary without logs, paths, history, or transcription text.</p>
+    </div>
+    <div data-server-diagnostics-surface class="flex min-w-0 flex-col gap-3 rounded-xl border border-white/10 bg-white/[0.025] p-4 sm:flex-row sm:items-center sm:justify-between">
+      <p class="min-w-0 text-xs leading-5 text-zinc-400 [overflow-wrap:anywhere]">Diagnostics include only the information Eve needs to explain server readiness and compatibility.</p>
+      <button
+        type="button"
+        onclick={copyDiagnostics}
+        class="inline-flex min-h-9 shrink-0 items-center justify-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+      >
+        {diagnosticsCopyState === 'copied'
+          ? 'Copied diagnostics'
+          : diagnosticsCopyState === 'error'
+            ? 'Copy failed'
+            : 'Copy diagnostics'}
+      </button>
+    </div>
+  </section>
 
-    <!-- Status Card -->
-    <SettingsSection title="Status">
-      <div class="p-4 bg-zinc-900/50 rounded-xl w-full">
-        <div class="flex items-center justify-between mb-4">
-          <!-- Status Badge -->
-          <div class="flex items-center gap-3">
-            <div class="relative flex items-center justify-center">
-              {#if serverState.status === 'running' && engineReady}
-                <!-- Pulse animation for running state -->
-                <span class="absolute w-3 h-3 rounded-full bg-emerald-400 animate-ping opacity-75"></span>
-              {/if}
-              <span class="relative w-3 h-3 rounded-full {statusDisplay.bgColor}"></span>
-            </div>
-            <span class="text-lg font-medium {statusDisplay.color}">
-              {statusDisplay.label}
-            </span>
-            {#if !serverState.managed && serverState.status === 'running'}
-              <span class="text-xs text-zinc-500 bg-zinc-800 px-2 py-0.5 rounded">
-                External
-              </span>
-            {/if}
-          </div>
-
-          <!-- Control Buttons -->
-          <div class="flex items-center gap-2">
-            {#if serverState.status === 'running'}
-              <button
-                onclick={handleRestart}
-                disabled={!canRestart}
-                class="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors
-                  {canRestart
-                    ? 'bg-zinc-700 hover:bg-zinc-600 text-zinc-200 cursor-pointer'
-                    : 'bg-zinc-800 text-zinc-500 cursor-not-allowed'}"
-              >
-                Restart
-              </button>
-              <button
-                onclick={handleStop}
-                disabled={!canStop}
-                class="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors
-                  {canStop
-                    ? 'bg-red-900/50 hover:bg-red-900 text-red-200 cursor-pointer'
-                    : 'bg-zinc-800 text-zinc-500 cursor-not-allowed'}"
-              >
-                Stop
-              </button>
-            {:else}
-              <button
-                onclick={handleStart}
-                disabled={!canStart}
-                class="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors
-                  {canStart
-                    ? 'bg-emerald-900/50 hover:bg-emerald-900 text-emerald-200 cursor-pointer'
-                    : 'bg-zinc-800 text-zinc-500 cursor-not-allowed'}"
-              >
-                {isLoading ? 'Starting...' : 'Start'}
-              </button>
-            {/if}
-          </div>
-        </div>
-
-        <!-- Error Message -->
-        {#if serverState.error}
-          <div class="mb-4 p-3 bg-red-950/50 border border-red-900/50 rounded-lg">
-            <p class="text-sm text-red-300">{serverState.error}</p>
-          </div>
-        {/if}
-
-        {#if serverState.engineStatus?.status === 'error'}
-          <div class="mb-4 rounded-lg border border-red-900/60 bg-red-950/30 p-3">
-            <p class="text-sm text-red-300">Transcription engine failed to load</p>
-            <p class="mt-1 text-xs text-red-300/80">
-              {serverState.engineStatus.message ?? 'Restart the server or select a CPU-compatible engine configuration.'}
-            </p>
-          </div>
-        {/if}
-
-        {#if modelDownload && showModelProgress}
-          <div class="mx-auto mb-4 max-w-2xl">
-            <ModelProgressCard state={modelDownload} announce={false} />
-          </div>
-        {/if}
-
-        {#if modelDownloadError}
-          <div class="mb-4 rounded-lg border border-red-900/60 bg-red-950/30 p-3">
-            <p class="text-sm text-red-300">
-              Model download failed
-              {#if modelDownload?.model}
-                <span class="text-red-300/80">({modelDownload.model})</span>
-              {/if}
-            </p>
-            <p class="mt-1 text-xs text-red-300/80">
-              {modelDownload?.detail ?? 'Check your connection and restart the server to retry.'}
-            </p>
-          </div>
-        {/if}
-
-        {#if diagnosticWarnings.length > 0}
-          <div class="mb-4 space-y-2">
-            {#each diagnosticWarnings as warning}
-              <div class="rounded-lg border border-amber-900/60 bg-amber-950/30 p-3">
-                <p class="text-sm text-amber-200">{warning.message}</p>
-                {#if warning.action || warning.url}
-                  <div class="mt-2 text-xs text-amber-300/80 flex flex-wrap items-center gap-2">
-                    {#if warning.action}
-                      <span>{warning.action}</span>
-                    {/if}
-                    {#if warning.url}
-                      <a
-                        href={warning.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        class="underline underline-offset-2 hover:text-amber-200 cursor-pointer"
-                      >
-                        Open link
-                      </a>
-                    {/if}
-                  </div>
-                {/if}
-              </div>
-            {/each}
-          </div>
-        {/if}
-
-        <!-- Details Grid (when running) -->
-        {#if serverState.status === 'running' && (serverState.pid || serverState.port || serverState.uptime)}
-          <div class="grid grid-cols-2 gap-4 pt-4 border-t border-zinc-800">
-            {#if serverState.port}
-              <div>
-                <p class="text-xs text-zinc-500 mb-1">Port</p>
-                <p class="text-sm font-mono text-zinc-300">{serverState.port}</p>
-              </div>
-            {/if}
-            {#if serverState.version}
-              <div>
-                <p class="text-xs text-zinc-500 mb-1">Version</p>
-                <p class="text-sm font-mono text-zinc-300">v{serverState.version}</p>
-              </div>
-            {/if}
-            {#if serverState.pid}
-              <div>
-                <p class="text-xs text-zinc-500 mb-1">PID</p>
-                <p class="text-sm font-mono text-zinc-300">{serverState.pid}</p>
-              </div>
-            {/if}
-            {#if serverState.uptime !== undefined}
-              <div>
-                <p class="text-xs text-zinc-500 mb-1">Uptime</p>
-                <p class="text-sm font-mono text-zinc-300">{formatUptime(serverState.uptime)}</p>
-              </div>
-            {/if}
-          </div>
-        {/if}
-
-      </div>
-    </SettingsSection>
-
-    <!-- Settings -->
-    <SettingsSection title="Settings">
-      <SettingsRow label="Auto-start server" description="Automatically start the server when the app launches">
+  <section data-server-section="management" class="min-w-0 space-y-2" aria-labelledby={headingId('management')}>
+    <div class="min-w-0 px-1">
+      <svelte:element this={headingTag} id={headingId('management')} class="text-sm font-semibold text-zinc-200">Server management</svelte:element>
+      <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Control the built-in server lifecycle and startup behavior.</p>
+    </div>
+    <div data-server-management-surface class="min-w-0 overflow-hidden rounded-xl border border-white/10 bg-white/[0.025]">
+      <SettingsRow label="Auto-start server" description="Automatically start the built-in server when Eve launches">
         <Toggle
           enabled={autoStart}
           onchange={updateAutoStart}
           label="Auto-start server"
+          disabled={externalMode}
         />
       </SettingsRow>
-    </SettingsSection>
+    </div>
+  </section>
 
-    <!-- Logs -->
-    <SettingsSection title="Logs">
-      <div class="w-full">
-        <button
-          type="button"
-          onclick={() => {
-            showLogs = !showLogs;
-            if (showLogs) {
-              setTimeout(scrollLogsToBottom, 0);
-            }
-          }}
-          aria-expanded={showLogs}
-          aria-controls="server-log-output"
-          class="w-full flex items-center justify-between p-4 bg-zinc-900/50 rounded-xl hover:bg-zinc-900 transition-colors cursor-pointer"
-        >
-          <div class="flex items-center gap-2">
-            <span class="text-sm text-zinc-200">Server Logs</span>
-            <span class="text-xs text-zinc-500 bg-zinc-800 px-2 py-0.5 rounded">
-              {logs.length}
-            </span>
-          </div>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="text-zinc-400 transition-transform duration-200 {showLogs ? 'rotate-180' : ''}"
-          >
-            <polyline points="6 9 12 15 18 9"></polyline>
-          </svg>
-        </button>
-
-        {#if showLogs}
-          <div class="mt-2 flex items-center justify-between gap-3 px-1">
-            <p class="text-xs text-amber-300/70">Raw logs may contain local paths. Review before sharing.</p>
-            <button
-              onclick={(e: MouseEvent) => { e.stopPropagation(); copyLogs(); }}
-              disabled={logs.length === 0}
-              class="flex items-center gap-1 px-2 py-1 text-xs rounded-md transition-colors
-                {logs.length === 0
-                  ? 'text-zinc-600 cursor-not-allowed'
-                  : logsCopied
-                    ? 'text-emerald-400 cursor-default'
-                    : 'text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 cursor-pointer'}"
-            >
-              {#if logsCopied}
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                Copied
-              {:else}
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
-                Copy raw logs
-              {/if}
-            </button>
-          </div>
-          <div
-            id="server-log-output"
-            bind:this={logsContainer}
-            class="mt-1 h-64 overflow-y-auto overscroll-contain bg-zinc-950 rounded-lg border border-zinc-800 p-3 font-mono text-xs"
-          >
-            {#if logs.length === 0}
-              <p class="text-zinc-500 text-center py-8">No logs yet</p>
-            {:else}
-              {#each logs as log}
-                <div class="flex gap-2 py-0.5 hover:bg-zinc-900/50">
-                  <span class="text-zinc-600 shrink-0">{formatLogTime(log.timestamp)}</span>
-                  <span class="{log.level === 'stderr' ? 'text-red-400' : 'text-zinc-300'} break-all">
-                    {log.message}
-                  </span>
-                </div>
-              {/each}
+  <section data-server-section="health" class="min-w-0 space-y-2" aria-labelledby={headingId('health')}>
+    <div class="min-w-0 px-1">
+      <svelte:element this={headingTag} id={headingId('health')} class="text-sm font-semibold text-zinc-200">Health &amp; actions</svelte:element>
+      <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Live status from the shared server controller; lifecycle actions apply only to the managed server.</p>
+    </div>
+    <div data-server-health-surface class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4">
+      <div data-server-health-status class="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-w-0 items-center gap-3" aria-label={`Server status: ${statusDisplay.label}`}>
+          <span class="relative flex h-3 w-3 shrink-0 items-center justify-center" aria-hidden="true">
+            {#if serverState.status === 'running' && engineReady}
+              <span class="absolute h-3 w-3 motion-safe:animate-ping rounded-full bg-emerald-400 opacity-75"></span>
             {/if}
-          </div>
-        {/if}
-      </div>
-    </SettingsSection>
+            <span class="relative h-3 w-3 rounded-full {statusDisplay.bgColor}"></span>
+          </span>
+          <span data-server-status class="min-w-0 text-lg font-medium {statusDisplay.color} [overflow-wrap:anywhere]">{statusDisplay.label}</span>
+          {#if !serverState.managed && serverState.status === 'running'}
+            <span class="shrink-0 rounded-full border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300">External</span>
+          {/if}
+        </div>
 
-</div>
+        <div class="flex min-w-0 flex-wrap items-center gap-2">
+          {#if serverState.status === 'running'}
+            <button
+              type="button"
+              onclick={handleRestart}
+              disabled={!canRestart}
+              class="inline-flex min-h-9 items-center justify-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors
+                {canRestart ? 'cursor-pointer hover:bg-zinc-700' : 'cursor-not-allowed opacity-60'}"
+            >
+              Restart
+            </button>
+            <button
+              type="button"
+              onclick={handleStop}
+              disabled={!canStop}
+              class="inline-flex min-h-9 items-center justify-center rounded-lg border border-red-800/70 bg-red-900/50 px-3 py-2 text-xs font-medium text-red-200 transition-colors
+                {canStop ? 'cursor-pointer hover:bg-red-900' : 'cursor-not-allowed opacity-60'}"
+            >
+              Stop
+            </button>
+          {:else}
+            <button
+              type="button"
+              onclick={handleStart}
+              disabled={!canStart}
+              class="inline-flex min-h-9 items-center justify-center rounded-lg border border-emerald-800/70 bg-emerald-900/50 px-3 py-2 text-xs font-medium text-emerald-200 transition-colors
+                {canStart ? 'cursor-pointer hover:bg-emerald-900' : 'cursor-not-allowed opacity-60'}"
+            >
+              {isLoading ? 'Starting…' : 'Start'}
+            </button>
+          {/if}
+        </div>
+      </div>
+
+      {#if externalMode}
+        <p data-server-action-restriction class="mt-3 border-t border-white/[0.08] pt-3 text-xs leading-5 text-zinc-500">Start, restart, and stop are unavailable while an external endpoint is active.</p>
+      {/if}
+
+      {#if serverState.error}
+        <div class="mt-4 rounded-lg border border-red-900/60 bg-red-950/30 p-3">
+          <p class="text-sm text-red-300 [overflow-wrap:anywhere]">{serverState.error}</p>
+        </div>
+      {/if}
+
+      {#if serverState.engineStatus?.status === 'error'}
+        <div class="mt-4 rounded-lg border border-red-900/60 bg-red-950/30 p-3">
+          <p class="text-sm text-red-300">Transcription engine failed to load</p>
+          <p class="mt-1 text-xs leading-5 text-red-300/80 [overflow-wrap:anywhere]">
+            {serverState.engineStatus.message ?? 'Restart the server or select a CPU-compatible engine configuration.'}
+          </p>
+        </div>
+      {/if}
+
+      {#if modelDownload && showModelProgress}
+        <div class="mx-auto mt-4 max-w-2xl">
+          <ModelProgressCard state={modelDownload} announce={false} />
+        </div>
+      {/if}
+
+      {#if modelDownloadError}
+        <div class="mt-4 rounded-lg border border-red-900/60 bg-red-950/30 p-3">
+          <p class="text-sm text-red-300">
+            Model download failed
+            {#if modelDownload?.model}
+              <span class="text-red-300/80 [overflow-wrap:anywhere]">({modelDownload.model})</span>
+            {/if}
+          </p>
+          <p class="mt-1 text-xs leading-5 text-red-300/80 [overflow-wrap:anywhere]">
+            {modelDownload?.detail ?? 'Check your connection and restart the server to retry.'}
+          </p>
+        </div>
+      {/if}
+
+      {#if diagnosticWarnings.length > 0}
+        <div data-server-diagnostic-warnings class="mt-4 space-y-2">
+          {#each diagnosticWarnings as warning}
+            <div class="rounded-lg border border-amber-900/60 bg-amber-950/30 p-3">
+              <p class="text-sm text-amber-200 [overflow-wrap:anywhere]">{warning.message}</p>
+              {#if warning.action || warning.url}
+                <div class="mt-2 flex min-w-0 flex-wrap items-center gap-2 text-xs text-amber-300/80">
+                  {#if warning.action}<span class="[overflow-wrap:anywhere]">{warning.action}</span>{/if}
+                  {#if warning.url}
+                    <a href={warning.url} target="_blank" rel="noreferrer" class="cursor-pointer break-all underline underline-offset-2 hover:text-amber-200">Open link</a>
+                  {/if}
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      {#if serverState.status === 'running' && (serverState.pid || serverState.port || serverState.uptime)}
+        <div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/[0.08] pt-4 sm:grid-cols-2">
+          {#if serverState.port}
+            <div class="min-w-0"><p class="text-xs text-zinc-500">Port</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">{serverState.port}</p></div>
+          {/if}
+          {#if serverState.version}
+            <div class="min-w-0"><p class="text-xs text-zinc-500">Version</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">v{serverState.version}</p></div>
+          {/if}
+          {#if serverState.pid}
+            <div class="min-w-0"><p class="text-xs text-zinc-500">PID</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">{serverState.pid}</p></div>
+          {/if}
+          {#if serverState.uptime !== undefined}
+            <div class="min-w-0"><p class="text-xs text-zinc-500">Uptime</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">{formatUptime(serverState.uptime)}</p></div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </section>
+
+  <section data-server-section="logs" class="min-w-0 space-y-2" aria-labelledby={headingId('logs')}>
+    <div class="min-w-0 px-1">
+      <svelte:element this={headingTag} id={headingId('logs')} class="text-sm font-semibold text-zinc-200">Logs</svelte:element>
+      <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Inspect recent server output only when needed for troubleshooting.</p>
+    </div>
+    <div data-server-logs-surface class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4 focus-within:ring-2 focus-within:ring-zinc-100 focus-within:ring-offset-2 focus-within:ring-offset-[#08090a]">
+      <button
+        type="button"
+        data-server-logs-toggle
+        onclick={() => {
+          showLogs = !showLogs;
+          if (showLogs) setTimeout(scrollLogsToBottom, 0);
+        }}
+        aria-expanded={showLogs}
+        aria-controls={logOutputId}
+        aria-describedby={privacyWarningId}
+        class="flex min-h-12 w-full min-w-0 items-center justify-between gap-3 rounded-lg border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-left transition-colors hover:bg-zinc-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+      >
+        <span class="min-w-0 text-sm text-zinc-200 [overflow-wrap:anywhere]">Server logs</span>
+        <span class="shrink-0 rounded-full border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs tabular-nums text-zinc-400">{logs.length}</span>
+      </button>
+      <p id={privacyWarningId} data-server-logs-privacy class="mt-3 text-xs leading-5 text-amber-300/80 [overflow-wrap:anywhere]">Raw logs may contain local paths. Review them before sharing.</p>
+
+      <div id={logOutputId} hidden={!showLogs} class="mt-3 min-w-0">
+        <div class="flex min-w-0 flex-wrap items-center justify-end gap-2">
+          <button
+            type="button"
+            onclick={copyLogs}
+            disabled={logs.length === 0}
+            class="inline-flex min-h-9 items-center justify-center gap-1 rounded-lg border border-zinc-700 px-3 py-2 text-xs transition-colors
+              {logs.length === 0
+                ? 'cursor-not-allowed text-zinc-600'
+                : logsCopied
+                  ? 'cursor-default text-emerald-400'
+                  : 'cursor-pointer text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200'}"
+          >
+            {#if logsCopied}Copied{:else}Copy raw logs{/if}
+          </button>
+        </div>
+        <div
+          data-server-log-output
+          id={`${logOutputId}-scroll`}
+          bind:this={logsContainer}
+          class="mt-2 max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain rounded-lg border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs"
+        >
+          {#if logs.length === 0}
+            <p class="py-8 text-center text-zinc-500">No logs yet</p>
+          {:else}
+            {#each logs as log}
+              <div class="flex min-w-0 gap-2 py-0.5">
+                <span class="shrink-0 text-zinc-500">{formatLogTime(log.timestamp)}</span>
+                <span class="min-w-0 break-all {log.level === 'stderr' ? 'text-red-300' : 'text-zinc-300'}">{log.message}</span>
+              </div>
+            {/each}
+          {/if}
+        </div>
+      </div>
+    </div>
+  </section>
 </div>

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -804,7 +804,7 @@
     <SettingsSection
       title="Advanced"
       id="advanced-settings-heading"
-      description="Engine, connection, diagnostics, and local server controls."
+      description="Raw engine compatibility controls for advanced setups."
       variant="content"
     >
       <div data-advanced-settings class="min-w-0">
@@ -1017,91 +1017,102 @@
       {/if}
         </div>
       </div>
-    <SettingsSection title="Server">
-      <SettingsRow
-        label="Use external server"
-        description="Connect to your own server and disable built-in server management"
-      >
-        <Toggle
-          enabled={settings.useExternalServer}
-          onchange={updateUseExternalServer}
-          label="Use external server"
-        />
-      </SettingsRow>
-
-      <div class="overflow-hidden [view-transition-name:external-server-panel]">
-        {#if settings.useExternalServer}
-          <div bind:this={externalServerCard} class="mt-2 p-4 bg-zinc-900/50 rounded-xl border border-zinc-800 w-full">
-            <p class="text-sm text-zinc-200 mb-1">Custom server endpoint</p>
-            <p class="text-xs text-zinc-500 mb-3">
-              Set the host and port for your transcription server. Eve connects to <span class="font-mono">/transcribe</span>.
-            </p>
-
-            {#if externalServerError}
-              <p class="mb-3 text-xs text-red-300">{externalServerError}</p>
-            {:else}
-              <p class="mb-3 text-xs text-zinc-500">
-                Using endpoint <span class="font-mono text-zinc-300">{settings.serverUrl}</span>
-              </p>
-            {/if}
-
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div>
-                <label for="external-server-host" class="text-xs text-zinc-500 block mb-1">Host</label>
-                <input
-                  id="external-server-host"
-                  type="text"
-                  value={externalServerHost}
-                  onpaste={(e) => {
-                    const pasted = e.clipboardData?.getData('text') ?? '';
-                    if (!pasted) {
-                      return;
-                    }
-                    const parsed = parseHostPaste(pasted);
-                    if (parsed.host) {
-                      e.preventDefault();
-                      externalServerHost = parsed.host;
-                      if (parsed.port) {
-                        externalServerPort = parsed.port;
-                      }
-                      updateExternalServerUrl();
-                    }
-                  }}
-                  oninput={(e) => {
-                    externalServerHost = e.currentTarget.value;
-                    updateExternalServerUrl();
-                  }}
-                  class="w-full bg-zinc-800 border border-zinc-700 rounded-lg
-                    px-3 py-2 text-sm text-zinc-300 font-mono
-                    focus:outline-none focus:border-zinc-600 focus:ring-1 focus:ring-zinc-600"
-                  placeholder="localhost"
-                />
-              </div>
-
-              <div>
-                <label for="external-server-port" class="text-xs text-zinc-500 block mb-1">Port</label>
-                <input
-                  id="external-server-port"
-                  type="text"
-                  value={externalServerPort}
-                  oninput={(e) => {
-                    externalServerPort = e.currentTarget.value;
-                    updateExternalServerUrl();
-                  }}
-                  class="w-full bg-zinc-800 border border-zinc-700 rounded-lg
-                    px-3 py-2 text-sm text-zinc-300 font-mono
-                    focus:outline-none focus:border-zinc-600 focus:ring-1 focus:ring-zinc-600"
-                  placeholder="51717"
-                />
-              </div>
-            </div>
-          </div>
-        {/if}
-      </div>
     </SettingsSection>
 
-    <ServerView embedded />
+    <SettingsSection
+      title="Server &amp; diagnostics"
+      description="Management mode, endpoint, health, diagnostics, and recent logs."
+      variant="content"
+    >
+      <div data-server-diagnostics class="min-w-0 space-y-6">
+        <section data-server-management class="min-w-0 space-y-2" aria-labelledby="settings-server-management-heading">
+          <div class="min-w-0 px-1">
+            <h3 id="settings-server-management-heading" class="text-sm font-semibold text-zinc-200">Management mode &amp; endpoint</h3>
+            <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Choose Eve-managed processing or connect to an external endpoint.</p>
+          </div>
 
+          <div data-server-mode-surface class="min-w-0 overflow-hidden rounded-xl border border-white/10 bg-white/[0.025]">
+            <SettingsRow
+              label="Use external server"
+              description="Connect to your own server and disable built-in server management"
+            >
+              <Toggle
+                enabled={settings.useExternalServer}
+                onchange={updateUseExternalServer}
+                label="Use external server"
+              />
+            </SettingsRow>
+
+            <div class="overflow-hidden border-t border-white/[0.08] [view-transition-name:external-server-panel]">
+              {#if settings.useExternalServer}
+                <div bind:this={externalServerCard} data-external-server-panel class="min-w-0 p-4">
+                  <p class="text-sm text-zinc-200">Custom server endpoint</p>
+                  <p class="mt-1 text-xs leading-5 text-zinc-500">
+                    Set the host and port for your transcription server. Eve connects to <span class="font-mono">/transcribe</span>.
+                  </p>
+
+                  {#if externalServerError}
+                    <p class="mt-3 text-xs leading-5 text-red-300 [overflow-wrap:anywhere]">{externalServerError}</p>
+                  {:else}
+                    <p class="mt-3 text-xs leading-5 text-zinc-500 [overflow-wrap:anywhere]">
+                      Using endpoint <span class="font-mono text-zinc-300">{settings.serverUrl}</span>
+                    </p>
+                  {/if}
+
+                  <div class="mt-4 grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div class="min-w-0">
+                      <label for="external-server-host" class="mb-1 block text-xs text-zinc-500">Host</label>
+                      <input
+                        id="external-server-host"
+                        type="text"
+                        value={externalServerHost}
+                        onpaste={(e) => {
+                          const pasted = e.clipboardData?.getData('text') ?? '';
+                          if (!pasted) {
+                            return;
+                          }
+                          const parsed = parseHostPaste(pasted);
+                          if (parsed.host) {
+                            e.preventDefault();
+                            externalServerHost = parsed.host;
+                            if (parsed.port) {
+                              externalServerPort = parsed.port;
+                            }
+                            updateExternalServerUrl();
+                          }
+                        }}
+                        oninput={(e) => {
+                          externalServerHost = e.currentTarget.value;
+                          updateExternalServerUrl();
+                        }}
+                        class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+                        placeholder="localhost"
+                      />
+                    </div>
+
+                    <div class="min-w-0">
+                      <label for="external-server-port" class="mb-1 block text-xs text-zinc-500">Port</label>
+                      <input
+                        id="external-server-port"
+                        type="text"
+                        value={externalServerPort}
+                        oninput={(e) => {
+                          externalServerPort = e.currentTarget.value;
+                          updateExternalServerUrl();
+                        }}
+                        class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+                        placeholder="51717"
+                      />
+                    </div>
+                  </div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        </section>
+
+        <ServerView embedded externalMode={externalMode} />
+      </div>
     </SettingsSection>
 
     <SettingsSection title="About">
@@ -1110,7 +1121,7 @@
           type="button"
           onclick={copyVersionToClipboard}
           title="Click to copy version"
-          class="rounded-lg bg-zinc-800 px-3 py-1.5 font-mono text-xs text-zinc-300 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+          class="inline-flex min-h-9 items-center justify-center rounded-lg bg-zinc-800 px-3 py-2 font-mono text-xs text-zinc-300 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
         >
           v{appVersion}
         </button>

--- a/app/tests/fixtures/settings-server-electron.cjs
+++ b/app/tests/fixtures/settings-server-electron.cjs
@@ -1,0 +1,166 @@
+const { app, BrowserWindow } = require('electron');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const baseUrl = process.argv[2];
+const screenshotDir = path.resolve(process.env.EVE_PHASE3_SCREENSHOT_DIR || path.join(os.tmpdir(), 'eve-phase3-settings-server-screenshots'));
+if (!baseUrl) throw new Error('fixture URL is required');
+
+const tempRoot = path.resolve(os.tmpdir());
+const userData = path.resolve(tempRoot, `eve-settings-server-${process.pid}`);
+const cases = [
+  ['managed-ready', false, 'managed-ready.png'],
+  ['managed-error', false, 'managed-error.png'],
+  ['external-ready', false, 'external-ready.png'],
+  ['managed-ready', true, 'logs-expanded.png'],
+  ['managed-long', false, 'long-strings.png'],
+];
+
+app.setPath('userData', userData);
+app.commandLine.appendSwitch('disable-gpu');
+app.commandLine.appendSwitch('force-device-scale-factor', '1');
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function fixtureUrl(state) {
+  return `${baseUrl}?${new URLSearchParams({ state })}`;
+}
+
+async function loadFixture(window, state, logsExpanded) {
+  await window.loadURL(fixtureUrl(state));
+  await wait(300);
+  if (logsExpanded) {
+    await window.webContents.executeJavaScript(`document.querySelector('[data-server-logs-toggle]')?.click()`);
+    await wait(120);
+  }
+}
+
+async function measure(window, state, logsExpanded, zoom) {
+  await window.webContents.setZoomFactor(zoom);
+  await wait(80);
+  const serialized = JSON.stringify({ state, logsExpanded, zoom });
+  return window.webContents.executeJavaScript(`(() => {
+    const meta = ${serialized};
+    const owner = document.querySelector('[data-server-fixture-scroll-owner]');
+    const main = document.querySelector('[data-server-fixture-main]');
+    const serverView = document.querySelector('[data-server-view]');
+    const sections = [...document.querySelectorAll('section[aria-labelledby]')];
+    const headingIds = sections.map((section) => section.getAttribute('aria-labelledby'));
+    const headings = headingIds.map((headingId) => headingId ? document.getElementById(headingId) : null);
+    const logsToggle = document.querySelector('[data-server-logs-toggle]');
+    const logPanelId = logsToggle?.getAttribute('aria-controls');
+    const logPanel = logPanelId ? document.getElementById(logPanelId) : null;
+    const logOutput = document.querySelector('[data-server-log-output]');
+    const controls = [...document.querySelectorAll('[data-server-mode-surface] button, [data-server-mode-surface] input, [data-server-health-surface] button, [data-server-diagnostics-surface] button, [data-server-logs-surface] button')].filter((control) => control.offsetParent !== null);
+    const focusTarget = logsToggle ?? controls[0];
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    focusTarget?.focus({ preventScroll: true, focusVisible: true });
+    const focusStyle = focusTarget ? getComputedStyle(focusTarget) : null;
+    const focusContainer = focusTarget?.closest('[data-server-logs-surface]');
+    const focusContainerStyle = focusContainer ? getComputedStyle(focusContainer) : null;
+    const rect = (element) => element ? (() => { const box = element.getBoundingClientRect(); return { top: box.top, bottom: box.bottom, left: box.left, right: box.right, width: box.width, height: box.height }; })() : null;
+    const ownerRect = rect(owner);
+    const ownerBox = owner?.getBoundingClientRect();
+    const controlBounds = controls.map((control) => {
+      const box = control.getBoundingClientRect();
+      return { tag: control.tagName, text: control.textContent?.trim().slice(0, 30), left: box.left, right: box.right };
+    });
+    const controlsContained = ownerBox ? controlBounds.every((box) => box.left >= ownerBox.left - 1 && box.right <= ownerBox.right + 1) : false;
+    const scrollersOutsideLogs = [...document.querySelectorAll('*')].filter((element) => {
+      return getComputedStyle(element).overflowY === 'auto' && !element.matches('[data-server-log-output]');
+    });
+    return {
+      ...meta,
+      viewport: { width: innerWidth, height: innerHeight },
+      owner: owner ? { overflowY: getComputedStyle(owner).overflowY, clientHeight: owner.clientHeight, scrollHeight: owner.scrollHeight, scrollWidth: owner.scrollWidth, clientWidth: owner.clientWidth, rect: ownerRect } : null,
+      main: rect(main),
+      serverView: rect(serverView),
+      document: { scrollWidth: document.documentElement.scrollWidth, clientWidth: document.documentElement.clientWidth },
+      controlsContained,
+      controlBounds,
+      controlCount: controls.length,
+      focus: focusStyle ? { focused: document.activeElement === focusTarget, focusVisible: focusTarget.matches(':focus-visible'), outlineWidth: focusStyle.outlineWidth, boxShadow: focusStyle.boxShadow, containerBoxShadow: focusContainerStyle?.boxShadow ?? 'none' } : null,
+      headingAssociation: sections.length > 0 && headings.every((heading, index) => !!heading && heading.id === headingIds[index]),
+      headingIdsUnique: headingIds.every(Boolean) && new Set(headingIds).size === headingIds.length,
+      headingLevels: [...document.querySelectorAll('h1, h2, h3')].map((heading) => Number(heading.tagName.slice(1))),
+      serverSubsectionCount: serverView?.querySelectorAll('[data-server-section]').length ?? 0,
+      external: !!document.querySelector('[data-server-external-notice]'),
+      restriction: !!document.querySelector('[data-server-action-restriction]'),
+      status: document.querySelector('[data-server-status]')?.textContent?.trim() ?? '',
+      healthButtonsDisabled: [...document.querySelectorAll('[data-server-health-surface] button')].map((button) => button.disabled),
+      autoStartDisabled: document.querySelector('[data-server-management-surface] [role="switch"]')?.disabled ?? false,
+      logsAssociation: !!logsToggle && !!logPanel && logsToggle.getAttribute('aria-controls') === logPanel.id,
+      logsExpanded: logPanel ? !logPanel.hidden : false,
+      logsScroller: logOutput ? { overflowY: getComputedStyle(logOutput).overflowY, overscrollBehaviorY: getComputedStyle(logOutput).overscrollBehaviorY, clientHeight: logOutput.clientHeight, scrollHeight: logOutput.scrollHeight } : null,
+      privacyWarning: !!document.querySelector('[data-server-logs-privacy]'),
+      scrollersOutsideLogs: scrollersOutsideLogs.length,
+    };
+  })()`);
+}
+
+async function capture(window, state, logsExpanded, filename) {
+  await window.webContents.setZoomFactor(1);
+  await window.setContentSize(960, 900);
+  await wait(120);
+  if (logsExpanded) {
+    await window.webContents.executeJavaScript(`document.querySelector('[data-server-logs-surface]')?.scrollIntoView({ block: 'start' })`);
+    await wait(120);
+  }
+  fs.mkdirSync(screenshotDir, { recursive: true });
+  const image = await window.webContents.capturePage();
+  const target = path.resolve(screenshotDir, filename);
+  fs.writeFileSync(target, image.toPNG());
+  return target;
+}
+
+async function main() {
+  let window = null;
+  const measurements = [];
+  const screenshots = [];
+  await app.whenReady();
+  try {
+    window = new BrowserWindow({
+      width: 960,
+      height: 900,
+      show: false,
+      frame: false,
+      resizable: false,
+      backgroundColor: '#08090a',
+      webPreferences: { contextIsolation: true, nodeIntegration: false },
+    });
+    window.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+      process.stderr.write(`renderer console ${level} ${sourceId}:${line}: ${message}\n`);
+    });
+    window.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+      process.stderr.write(`renderer load failed ${errorCode} ${errorDescription} ${validatedURL}\n`);
+    });
+    window.show();
+    window.focus();
+    window.webContents.focus();
+    await wait(500);
+
+    for (const [state, logsExpanded, filename] of cases) {
+      await loadFixture(window, state, logsExpanded);
+      if (filename) screenshots.push(await capture(window, state, logsExpanded, filename));
+
+      for (const [width, height] of [[960, 900], [320, 700]]) {
+        await window.setContentSize(width, height);
+        await wait(100);
+        for (const zoom of [1, 1.5, 2]) {
+          measurements.push(await measure(window, state, logsExpanded, zoom));
+        }
+      }
+    }
+  } finally {
+    if (window && !window.isDestroyed()) await window.close();
+  }
+
+  process.stdout.write(JSON.stringify({ measurements, screenshots, userDataPath: userData }));
+  app.quit();
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  app.exit(1);
+});

--- a/app/tests/fixtures/settings-server-electron.cjs
+++ b/app/tests/fixtures/settings-server-electron.cjs
@@ -53,7 +53,7 @@ async function measure(window, state, logsExpanded, zoom) {
     const logPanel = logPanelId ? document.getElementById(logPanelId) : null;
     const logOutput = document.querySelector('[data-server-log-output]');
     const controls = [...document.querySelectorAll('[data-server-mode-surface] button, [data-server-mode-surface] input, [data-server-health-surface] button, [data-server-diagnostics-surface] button, [data-server-logs-surface] button')].filter((control) => control.offsetParent !== null);
-    const focusTarget = logsToggle ?? controls[0];
+    const focusTarget = meta.logsExpanded ? (logOutput ?? logsToggle ?? controls[0]) : (logsToggle ?? controls[0]);
     document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
     focusTarget?.focus({ preventScroll: true, focusVisible: true });
     const focusStyle = focusTarget ? getComputedStyle(focusTarget) : null;
@@ -92,7 +92,7 @@ async function measure(window, state, logsExpanded, zoom) {
       autoStartDisabled: document.querySelector('[data-server-management-surface] [role="switch"]')?.disabled ?? false,
       logsAssociation: !!logsToggle && !!logPanel && logsToggle.getAttribute('aria-controls') === logPanel.id,
       logsExpanded: logPanel ? !logPanel.hidden : false,
-      logsScroller: logOutput ? { overflowY: getComputedStyle(logOutput).overflowY, overscrollBehaviorY: getComputedStyle(logOutput).overscrollBehaviorY, clientHeight: logOutput.clientHeight, scrollHeight: logOutput.scrollHeight } : null,
+      logsScroller: logOutput ? { overflowY: getComputedStyle(logOutput).overflowY, overscrollBehaviorY: getComputedStyle(logOutput).overscrollBehaviorY, clientHeight: logOutput.clientHeight, scrollHeight: logOutput.scrollHeight, tabIndex: logOutput.tabIndex, role: logOutput.getAttribute('role'), ariaLabel: logOutput.getAttribute('aria-label') } : null,
       privacyWarning: !!document.querySelector('[data-server-logs-privacy]'),
       scrollersOutsideLogs: scrollersOutsideLogs.length,
     };
@@ -108,7 +108,7 @@ async function capture(window, state, logsExpanded, filename) {
     await wait(120);
   }
   fs.mkdirSync(screenshotDir, { recursive: true });
-  const image = await window.webContents.capturePage();
+  const image = await window.webContents.capturePage(undefined, { stayHidden: true });
   const target = path.resolve(screenshotDir, filename);
   fs.writeFileSync(target, image.toPNG());
   return target;

--- a/app/tests/gate5-information-architecture.test.ts
+++ b/app/tests/gate5-information-architecture.test.ts
@@ -30,10 +30,10 @@ describe('Gate 5 information architecture', () => {
     expect(appView).toContain("return match?.id ?? 'home'");
   });
 
-  test('embeds every existing server surface under Settings Advanced', () => {
+  test('embeds every existing server surface under Settings Server & diagnostics', () => {
     expect(settingsView).toContain("import ServerView");
-    expect(settingsView).toContain('id="advanced-settings-heading"');
-    expect(settingsView).toContain("<ServerView embedded />");
+    expect(settingsView).toContain('title="Server &amp; diagnostics"');
+    expect(settingsView).toContain('<ServerView embedded externalMode={externalMode} />');
 
     for (const operation of [
       'startServer',

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -202,7 +202,7 @@ describe('Home and shared server status', () => {
     expect(mount).not.toContain('updateServerSettings');
     expect(homeView).toContain('onclick={retry}');
     expect(homeView).toContain('External server — Eve cannot restart this endpoint.');
-    expect(homeView).toContain('Management mode cannot be confirmed. Open Settings &gt; Advanced.');
+    expect(homeView).toContain('Management mode cannot be confirmed. Open Settings &gt; Server &amp; diagnostics.');
     expect(statusController).toContain('const settings = await window.murmurMain.getSettings();');
     expect(statusController).toContain('setConfiguredExternalServer(settings.useExternalServer);');
     expect(homeView).toContain('if (retrying) return;');
@@ -229,7 +229,7 @@ describe('Home and shared server status', () => {
     expect(appView).toContain('aria-live="polite"');
     expect(serverView).toContain('let active = true;');
     expect(serverView).toContain('if (!active) return;');
-    expect(banner).toContain('Open Settings &gt; Advanced for details.');
+    expect(banner).toContain('Open Settings &gt; Server &amp; diagnostics for details.');
     expect(banner).not.toContain('Open Server and use Restart');
     expect(homeView).toContain('By default, Eve processes speech locally.');
     expect(homeView).toContain('audio is sent to that endpoint under your control.');

--- a/app/tests/settings-layout.test.ts
+++ b/app/tests/settings-layout.test.ts
@@ -33,7 +33,7 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(statusBanner).not.toContain('fixed');
     expect(statusBanner).not.toContain('pointer-events-none');
     expect(statusBanner).not.toContain('z-20');
-    expect(statusBanner).toContain('Open Settings &gt; Advanced for details.');
+    expect(statusBanner).toContain('Open Settings &gt; Server &amp; diagnostics for details.');
     expect(statusBanner).toContain('<ModelProgressCard state={modelDownload} announce={false} />');
     expect(statusCard).toContain('aria-live={announce ? \'polite\' : undefined}');
     expect(appView).toMatch(/<\/header>[\s\S]*?<ModelProgressBanner visible \/>[\s\S]*?<main id="main-content"/);
@@ -44,8 +44,8 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(settingsView).toContain('data-scroll-owner="settings-page"');
     expect(settingsView).toContain('min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain');
     expect(settingsView).not.toContain('h-screen');
-    expect(serverView).toContain("embedded ? 'min-w-0 space-y-4'");
-    expect(serverView).toContain('overflow-y-auto overscroll-contain');
+    expect(serverView).toContain("embedded ? 'min-w-0 space-y-6'");
+    expect(serverView).toContain('max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain');
   });
 
   test('stacks labels and controls at narrow widths and contains control content', () => {
@@ -61,6 +61,8 @@ describe('Phase 1 Settings layout contracts', () => {
 
   test('associates section headings and form controls with accessible names', () => {
     expect(settingsSection).toContain('aria-labelledby={headingId}');
+    expect(settingsSection).toContain('aria-describedby={descriptionId}');
+    expect(settingsSection).toContain('id={descriptionId}');
     expect(settingsSection).toContain('<h2 id={headingId}');
     expect(settingsView).toContain('<h1 class="sr-only">Settings</h1>');
     expect(settingsView).toContain('aria-label="Input device"');

--- a/app/tests/settings-server-cohesion.test.ts
+++ b/app/tests/settings-server-cohesion.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+const settingsView = source('../src/renderer/app/views/SettingsView.svelte');
+const serverView = source('../src/renderer/app/views/ServerView.svelte');
+const settingsRow = source('../src/renderer/app/components/SettingsRow.svelte');
+const appCss = source('../src/renderer/app/app.css');
+
+describe('Phase 3 Server and diagnostics cohesion contracts', () => {
+  test('uses one cohesive Server & diagnostics section without nested SettingsSection composition', () => {
+    expect(settingsView).toContain('title="Server &amp; diagnostics"');
+    expect(settingsView).toContain('data-server-diagnostics');
+    expect(settingsView).toContain('<ServerView embedded externalMode={externalMode} />');
+    expect(settingsView).not.toContain('<SettingsSection title="Server">');
+    expect(serverView).not.toContain('<SettingsSection');
+    expect(serverView).not.toContain('title="Settings"');
+    expect(serverView).toContain('const headingTag = $derived(embedded ? \'h3\' : \'h2\')');
+    expect(serverView).toContain('aria-labelledby={headingId(');
+  });
+
+  test('keeps management mode, endpoint, auto-start, health, and truthful external restrictions together', () => {
+    expect(settingsView).toContain('data-server-management');
+    expect(settingsView).toContain('data-server-mode-surface');
+    expect(settingsView).toContain('label="Use external server"');
+    expect(settingsView).toContain('data-external-server-panel');
+    expect(serverView).toContain('data-server-section="management"');
+    expect(serverView).toContain('label="Auto-start server"');
+    expect(serverView).toContain('disabled={externalMode}');
+    expect(serverView).toContain('data-server-action-restriction');
+    expect(serverView).toContain('!externalMode &&');
+    expect(serverView).toContain('window.murmurMain.startServer()');
+    expect(serverView).toContain('window.murmurMain.stopServer()');
+    expect(serverView).toContain('window.murmurMain.restartServer()');
+  });
+
+  test('keeps factual status and diagnostics readable without creating another live announcer', () => {
+    expect(serverView).toContain('data-server-health-status');
+    expect(serverView).toContain('data-server-status');
+    expect(serverView).toContain('data-server-diagnostic-warnings');
+    expect(serverView).toContain('<ModelProgressCard state={modelDownload} announce={false} />');
+    expect(serverView).not.toContain('aria-live="polite"');
+    expect(serverView).toContain('motion-safe:animate-ping');
+    expect(settingsRow).toContain('focus-visible:ring-2');
+    expect(appCss).toContain('@media (forced-colors: active)');
+    expect(appCss).toContain('@media (prefers-reduced-motion: reduce)');
+  });
+
+  test('makes logs the only bounded nested scroller and keeps the privacy warning visible', () => {
+    expect(serverView).toContain('data-server-logs-toggle');
+    expect(serverView).toContain('aria-expanded={showLogs}');
+    expect(serverView).toContain('aria-controls={logOutputId}');
+    expect(serverView).toContain('aria-describedby={privacyWarningId}');
+    expect(serverView).toContain('id={logOutputId} hidden={!showLogs}');
+    expect(serverView).toContain('data-server-logs-privacy');
+    expect(serverView).toContain('data-server-log-output');
+    expect(serverView).toContain('max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain');
+    expect(serverView).toContain('focus-within:ring-2');
+    expect(serverView).not.toContain('pointer-events-none');
+  });
+
+  test('keeps the Settings page as the only page-level scroll owner and wraps long controls', () => {
+    expect(settingsView.match(/overflow-y-auto/g)?.length).toBe(1);
+    expect(settingsView).toContain('data-scroll-owner="settings-page"');
+    expect(settingsView).toContain('min-h-9 w-full max-w-full rounded-lg border border-zinc-700');
+    expect(settingsView).toContain('[overflow-wrap:anywhere]');
+    expect(serverView).toContain('[overflow-wrap:anywhere]');
+  });
+});

--- a/app/tests/settings-server-cohesion.test.ts
+++ b/app/tests/settings-server-cohesion.test.ts
@@ -7,6 +7,7 @@ function source(path: string): string {
 
 const settingsView = source('../src/renderer/app/views/SettingsView.svelte');
 const serverView = source('../src/renderer/app/views/ServerView.svelte');
+const serverFixture = source('../src/renderer/app/fixtures/SettingsServerFixture.svelte');
 const settingsRow = source('../src/renderer/app/components/SettingsRow.svelte');
 const appCss = source('../src/renderer/app/app.css');
 
@@ -27,11 +28,15 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(settingsView).toContain('data-server-mode-surface');
     expect(settingsView).toContain('label="Use external server"');
     expect(settingsView).toContain('data-external-server-panel');
+    expect(serverFixture).toContain('{#if externalEnabled}');
     expect(serverView).toContain('data-server-section="management"');
     expect(serverView).toContain('label="Auto-start server"');
     expect(serverView).toContain('disabled={externalMode}');
     expect(serverView).toContain('data-server-action-restriction');
-    expect(serverView).toContain('!externalMode &&');
+    expect(serverView.match(/!externalMode &&/g)?.length).toBe(3);
+    expect(serverView).toContain('getServerManagementMode');
+    expect(serverView).toContain('Management mode &amp; endpoint section above.');
+    expect(serverView).toContain('Settings &gt; Server &amp; diagnostics.');
     expect(serverView).toContain('window.murmurMain.startServer()');
     expect(serverView).toContain('window.murmurMain.stopServer()');
     expect(serverView).toContain('window.murmurMain.restartServer()');
@@ -42,7 +47,10 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(serverView).toContain('data-server-status');
     expect(serverView).toContain('data-server-diagnostic-warnings');
     expect(serverView).toContain('<ModelProgressCard state={modelDownload} announce={false} />');
+    expect(serverView).toContain('aria-describedby={diagnosticsStatusId}');
+    expect(serverView).toContain('id={diagnosticsStatusId}');
     expect(serverView).not.toContain('aria-live="polite"');
+    expect(serverView).not.toContain('aria-label={`Server status: ${statusDisplay.label}`}');
     expect(serverView).toContain('motion-safe:animate-ping');
     expect(settingsRow).toContain('focus-visible:ring-2');
     expect(appCss).toContain('@media (forced-colors: active)');
@@ -57,9 +65,12 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(serverView).toContain('id={logOutputId} hidden={!showLogs}');
     expect(serverView).toContain('data-server-logs-privacy');
     expect(serverView).toContain('data-server-log-output');
+    expect(serverView).toContain('tabindex="0"');
+    expect(serverView).toContain('role="group"');
+    expect(serverView).toContain('aria-label="Server log output"');
     expect(serverView).toContain('max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain');
     expect(serverView).toContain('focus-within:ring-2');
-    expect(serverView).not.toContain('pointer-events-none');
+    expect(serverView).not.toContain('opacity-45 pointer-events-none select-none');
   });
 
   test('keeps the Settings page as the only page-level scroll owner and wraps long controls', () => {
@@ -68,5 +79,7 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(settingsView).toContain('min-h-9 w-full max-w-full rounded-lg border border-zinc-700');
     expect(settingsView).toContain('[overflow-wrap:anywhere]');
     expect(serverView).toContain('[overflow-wrap:anywhere]');
+    expect(serverView).toContain('serverState.version !== undefined');
+    expect(serverView).toContain('serverState.uptime !== undefined');
   });
 });

--- a/app/tests/settings-server-rendered.test.mjs
+++ b/app/tests/settings-server-rendered.test.mjs
@@ -1,0 +1,161 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, isAbsolute, relative, resolve } from 'node:path';
+
+const appRoot = resolve(import.meta.dir, '..');
+const fixtureTempRoot = resolve(tmpdir());
+const screenshotDir = resolve(fixtureTempRoot, 'eve-phase3-settings-server-screenshots');
+const vitePort = 52100 + (process.pid % 100);
+const viteProcess = Bun.spawn([
+  'node',
+  resolve(appRoot, 'node_modules/vite/bin/vite.js'),
+  '--host',
+  '127.0.0.1',
+], {
+  cwd: appRoot,
+  env: { ...process.env, MURMUR_DEV_PORT: String(vitePort) },
+  stdout: 'ignore',
+  stderr: 'pipe',
+  windowsHide: true,
+});
+const fixtureUrl = `http://127.0.0.1:${vitePort}/app/fixtures/settings-server-fixture.html`;
+const electronPath = resolve(appRoot, 'node_modules/electron/dist/electron.exe');
+const runnerPath = resolve(appRoot, 'tests/fixtures/settings-server-electron.cjs');
+
+function assertSafeUserDataPath(target) {
+  const resolvedTarget = resolve(target);
+  const relativeTarget = relative(fixtureTempRoot, resolvedTarget);
+  if (!relativeTarget || relativeTarget.startsWith('..') || isAbsolute(relativeTarget) || !basename(resolvedTarget).startsWith('eve-settings-server-')) {
+    throw new Error(`Refusing to remove unexpected fixture path: ${resolvedTarget}`);
+  }
+  return resolvedTarget;
+}
+
+async function cleanupUserData(target) {
+  const resolvedTarget = assertSafeUserDataPath(target);
+  await fs.rm(resolvedTarget, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+  return existsSync(resolvedTarget);
+}
+
+async function waitForFixtureServer() {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      const response = await fetch(fixtureUrl);
+      if (response.ok) return;
+    } catch {
+      // Vite is still starting.
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  viteProcess.kill();
+  const stderr = await new Response(viteProcess.stderr).text();
+  throw new Error(`Vite fixture server did not start on port ${vitePort}: ${stderr}`);
+}
+
+function runElectron() {
+  const child = Bun.spawn([electronPath, runnerPath, fixtureUrl], {
+    cwd: appRoot,
+    env: { ...process.env, EVE_PHASE3_SCREENSHOT_DIR: screenshotDir },
+    stdout: 'pipe',
+    stderr: 'pipe',
+    windowsHide: true,
+  });
+  return Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]).then(async ([stdout, stderr, code]) => {
+    let result = null;
+    let parseError = null;
+    try {
+      result = JSON.parse(stdout);
+    } catch (error) {
+      parseError = error;
+    }
+    const userDataPath = result?.userDataPath ?? resolve(fixtureTempRoot, `eve-settings-server-${child.pid}`);
+    const userDataExists = await cleanupUserData(userDataPath);
+    if (code !== 0) throw new Error(`Electron Server fixture exited with ${code}: ${stderr || stdout}`);
+    if (!result) throw new Error(`Electron Server fixture returned invalid JSON: ${parseError}\n${stderr}\n${stdout}`);
+    return { ...result, userDataExists };
+  });
+}
+
+afterAll(async () => {
+  viteProcess.kill();
+  await viteProcess.exited;
+});
+
+await waitForFixtureServer();
+const result = await runElectron();
+const { measurements } = result;
+
+describe('rendered Phase 3 Server and diagnostics fixture', () => {
+  test('keeps one page scroll owner and no horizontal overflow at narrow/high zoom states', () => {
+    expect(measurements.length).toBe(30);
+    for (const measurement of measurements) {
+      expect(measurement.owner.overflowY).toBe('auto');
+      expect(measurement.owner.scrollHeight).toBeGreaterThan(measurement.owner.clientHeight);
+      expect(measurement.owner.scrollWidth).toBeLessThanOrEqual(measurement.owner.clientWidth);
+      expect(measurement.document.scrollWidth).toBeLessThanOrEqual(measurement.document.clientWidth);
+      expect(measurement.scrollersOutsideLogs).toBe(1);
+      expect(measurement.controlsContained, JSON.stringify({ state: measurement.state, zoom: measurement.zoom, viewport: measurement.viewport, controlBounds: measurement.controlBounds, owner: measurement.owner.rect })).toBeTrue();
+    }
+  });
+
+  test('renders managed ready and error health states with enabled managed actions', () => {
+    const ready = measurements.find((measurement) => measurement.state === 'managed-ready' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const error = measurements.find((measurement) => measurement.state === 'managed-error' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    expect(ready.status).toBe('Running');
+    expect(ready.external).toBeFalse();
+    expect(ready.restriction).toBeFalse();
+    expect(ready.healthButtonsDisabled.every((disabled) => disabled === false)).toBeTrue();
+    expect(error.status).toBe('Error');
+    expect(error.external).toBeFalse();
+    expect(error.healthButtonsDisabled.every((disabled) => disabled === false)).toBeTrue();
+  });
+
+  test('renders external restrictions without hiding factual health, diagnostics, or logs', () => {
+    const external = measurements.find((measurement) => measurement.state === 'external-ready' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    expect(external.external).toBeTrue();
+    expect(external.restriction).toBeTrue();
+    expect(external.healthButtonsDisabled.every((disabled) => disabled === true)).toBeTrue();
+    expect(external.autoStartDisabled).toBeTrue();
+    expect(external.status).toBe('Running');
+    expect(external.privacyWarning).toBeTrue();
+  });
+
+  test('keeps collapsed and expanded logs associated, private-data warning visible, and output bounded', () => {
+    const collapsed = measurements.find((measurement) => measurement.state === 'managed-ready' && !measurement.logsExpanded && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const expanded = measurements.find((measurement) => measurement.state === 'managed-ready' && measurement.logsExpanded && measurement.zoom === 1 && measurement.viewport.width === 960);
+    expect(collapsed.logsAssociation).toBeTrue();
+    expect(collapsed.logsExpanded).toBeFalse();
+    expect(collapsed.privacyWarning).toBeTrue();
+    expect(expanded.logsAssociation).toBeTrue();
+    expect(expanded.logsExpanded).toBeTrue();
+    expect(expanded.logsScroller.overflowY).toBe('auto');
+    expect(expanded.logsScroller.overscrollBehaviorY).toBe('contain');
+    expect(expanded.logsScroller.scrollHeight).toBeGreaterThan(expanded.logsScroller.clientHeight);
+  });
+
+  test('keeps heading associations, visible focus, and long strings contained', () => {
+    const longStates = measurements.filter((measurement) => measurement.state === 'managed-long');
+    for (const measurement of longStates) {
+      expect(measurement.headingAssociation).toBeTrue();
+      expect(measurement.headingIdsUnique).toBeTrue();
+      expect(measurement.headingLevels[0]).toBe(1);
+      expect(measurement.headingLevels.slice(1).every((level) => level === 2 || level === 3)).toBeTrue();
+      expect(measurement.serverSubsectionCount).toBe(4);
+      expect(measurement.focus.focused).toBeTrue();
+      expect(measurement.focus.outlineWidth !== '0px' || measurement.focus.boxShadow !== 'none' || measurement.focus.containerBoxShadow !== 'none').toBeTrue();
+    }
+  });
+
+  test('cleans the isolated Electron userData directory and writes deterministic screenshots', () => {
+    expect(result.screenshots).toHaveLength(5);
+    for (const screenshot of result.screenshots) {
+      expect(existsSync(screenshot)).toBeTrue();
+    }
+    expect(result.userDataExists).toBeFalse();
+  });
+});

--- a/app/tests/settings-server-rendered.test.mjs
+++ b/app/tests/settings-server-rendered.test.mjs
@@ -136,6 +136,9 @@ describe('rendered Phase 3 Server and diagnostics fixture', () => {
     expect(expanded.logsScroller.overflowY).toBe('auto');
     expect(expanded.logsScroller.overscrollBehaviorY).toBe('contain');
     expect(expanded.logsScroller.scrollHeight).toBeGreaterThan(expanded.logsScroller.clientHeight);
+    expect(expanded.logsScroller.tabIndex).toBe(0);
+    expect(expanded.logsScroller.role).toBe('group');
+    expect(expanded.logsScroller.ariaLabel).toBe('Server log output');
   });
 
   test('keeps heading associations, visible focus, and long strings contained', () => {


### PR DESCRIPTION
## Summary
- Flatten embedded ServerView into one Server & diagnostics Settings area with management, endpoint, factual health/actions, diagnostics, and collapsed logs.
- Preserve shared status, IPC/persistence paths, external-mode restrictions, and no-download behavior.
- Add isolated synthetic Electron fixtures, responsive accessibility/layout assertions, and deterministic screenshots.

## Validation
- Focused: settings layout/cohesion/home/IA tests: 30 passing, 226 expectations.
- Focused rendered fixture: 6 passing, 251 expectations across 30 width/zoom states.
- Renderer typecheck: passing.
- Full matrix: build artifacts and fixture screenshots generated; svelte-check remains at six pre-existing errors, zero warnings in HistoryView, InsightsView, and App.svelte.

Screenshots: E:\\Temp\\eve-phase3-settings-server-screenshots\\managed-ready.png, managed-error.png, external-ready.png, logs-expanded.png, long-strings.png.

No package, install, release, or product runtime changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consolidated server management and diagnostics under **Settings > Server & diagnostics**.
  * Added clearer server status, health, diagnostics, logs, privacy notices, and responsive layouts.
  * Improved handling and messaging for externally managed servers.
* **Accessibility**
  * Improved associations between settings sections and their descriptions.
  * Enhanced headings, focus states, status messaging, and expandable log output.
* **Bug Fixes**
  * Updated guidance for model setup and unknown server-management states to the correct settings location.
* **Tests**
  * Added coverage for server states, responsive layouts, accessibility, scrolling, and external-server restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->