### PR TITLE
fix: preserve focused editor during SendInput paste

### DIFF
--- a/app/src/main/services/clipboard.ts
+++ b/app/src/main/services/clipboard.ts
@@ -93,6 +93,8 @@ public class NativePaste {
   public const ushort VK_MENU = 0x12;
   public const ushort VK_V = 0x56;
   public const int SW_RESTORE = 9;
+  private const int FOREGROUND_WAIT_MS = 750;
+  private const int FOREGROUND_POLL_MS = 25;
 
   private static void SendKey(ushort virtualKey, bool keyUp) {
     INPUT[] inputs = new INPUT[1];
@@ -110,21 +112,35 @@ public class NativePaste {
     SendKey(VK_MENU, true);
   }
 
+  private static bool WaitForForeground(IntPtr target) {
+    int waitedMs = 0;
+    while (GetForegroundWindow() != target && waitedMs < FOREGROUND_WAIT_MS) {
+      System.Threading.Thread.Sleep(FOREGROUND_POLL_MS);
+      waitedMs += FOREGROUND_POLL_MS;
+    }
+    return GetForegroundWindow() == target;
+  }
+
   public static void Paste(long targetWindowHandle) {
     if (targetWindowHandle != 0) {
       IntPtr target = new IntPtr(targetWindowHandle);
       if (IsWindow(target)) {
-        AllowForegroundSwitch();
-        if (IsIconic(target)) {
-          ShowWindow(target, SW_RESTORE);
-          System.Threading.Thread.Sleep(80);
-        }
-        if (!SetForegroundWindow(target)) {
-          throw new InvalidOperationException("Could not focus target window before paste.");
-        }
-        System.Threading.Thread.Sleep(120);
+        // The overlay is non-focusable, so the original editor normally remains
+        // foreground. Do not reactivate an already-active top-level window: some
+        // Chromium editors lose their focused child control when that happens.
         if (GetForegroundWindow() != target) {
-          throw new InvalidOperationException("Target window is not foreground before paste.");
+          AllowForegroundSwitch();
+          if (IsIconic(target)) {
+            ShowWindow(target, SW_RESTORE);
+            System.Threading.Thread.Sleep(80);
+          }
+          bool activationRequested = SetForegroundWindow(target);
+          if (!activationRequested && GetForegroundWindow() != target) {
+            throw new InvalidOperationException("Could not focus target window before paste.");
+          }
+          if (!WaitForForeground(target)) {
+            throw new InvalidOperationException("Target window is not foreground before paste.");
+          }
         }
       } else {
         throw new InvalidOperationException("Target window no longer exists before paste.");

--- a/app/tests/clipboard.test.ts
+++ b/app/tests/clipboard.test.ts
@@ -133,5 +133,9 @@ describe('buildSendInputScriptContent', () => {
     expect(script).toContain('Target window is not foreground before paste.');
     expect(script).toContain('if (IsIconic(target))');
     expect(script).toContain('ShowWindow(target, SW_RESTORE);');
+    expect(script).toContain('if (GetForegroundWindow() != target)');
+    expect(script).toContain('private static bool WaitForForeground(IntPtr target)');
+    expect(script).toContain('while (GetForegroundWindow() != target && waitedMs < FOREGROUND_WAIT_MS)');
+    expect(script).toContain('if (!activationRequested && GetForegroundWindow() != target)');
   });
 });


### PR DESCRIPTION
## Summary
- avoid reactivating the captured top-level window when it is already foreground, preserving focused Chromium/editor child controls
- retain guarded target restoration when the user has switched away
- poll boundedly for foreground activation instead of relying on one fixed delay
- add regression contracts for the generated Windows helper

## Validation
- targeted clipboard and pipeline tests pass (12 tests)
- full app source suite passes; two screenshot-only fixture captures were unavailable in the current desktop session because Electron reported no display capture surface
- history/insights check passes
- production app build passes
- no version, packaging, identity, IPC, profile, model, or privacy changes