### PR TITLE
Fix blank renderer recovery and Settings interaction regressions

### DIFF
--- a/app/src/renderer/app/components/SpeechModelChooser.svelte
+++ b/app/src/renderer/app/components/SpeechModelChooser.svelte
@@ -111,7 +111,7 @@
           {@const label = stateLabel(preset)}
           <label
             data-speech-model-option
-            class="flex min-w-0 items-start gap-3 py-3 first:pt-0 last:pb-0 focus-within:rounded-lg focus-within:outline-none focus-within:ring-2 focus-within:ring-zinc-100 focus-within:ring-offset-2 focus-within:ring-offset-[#08090a]
+            class="flex min-w-0 items-start gap-3 rounded-lg px-2 py-3 first:pt-2 last:pb-2 focus-within:outline focus-within:outline-2 focus-within:outline-offset-[-2px] focus-within:outline-zinc-100
               {disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}"
           >
             <input

--- a/app/src/renderer/app/main.ts
+++ b/app/src/renderer/app/main.ts
@@ -2,8 +2,44 @@ import './app.css';
 import App from './App.svelte';
 import { mount } from 'svelte';
 
-const app = mount(App, {
-  target: document.getElementById('app')!,
-});
+declare global {
+  interface Window {
+    __eveRendererFailed?: boolean;
+  }
+}
+
+function showRendererRecovery(error: unknown): void {
+  window.__eveRendererFailed = true;
+  console.error('Eve renderer failed and entered recovery mode', error);
+
+  const target = document.getElementById('app');
+  if (!target || target.querySelector('[data-renderer-recovery]')) return;
+  target.replaceChildren();
+
+  const recovery = document.createElement('main');
+  recovery.dataset.rendererRecovery = '';
+  recovery.className = 'flex h-full items-center justify-center bg-[#08090a] p-6 text-zinc-100';
+  recovery.innerHTML = `
+    <section class="w-full max-w-md rounded-2xl border border-white/10 bg-white/[0.03] p-6 text-center">
+      <p class="text-xs font-medium uppercase tracking-[0.16em] text-zinc-500">Eve</p>
+      <h1 class="mt-3 text-xl font-semibold text-zinc-50">The window needs a refresh</h1>
+      <p class="mt-2 text-sm leading-6 text-zinc-400">Your settings and recordings are safe. Reload Eve's interface to continue.</p>
+      <button data-renderer-reload type="button" class="mt-5 min-h-10 cursor-pointer rounded-lg bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-100">Reload interface</button>
+    </section>`;
+  recovery.querySelector<HTMLButtonElement>('[data-renderer-reload]')?.addEventListener('click', () => location.reload());
+  target.append(recovery);
+}
+
+window.addEventListener('error', (event) => showRendererRecovery(event.error ?? event.message));
+window.addEventListener('unhandledrejection', (event) => showRendererRecovery(event.reason));
+
+let app;
+try {
+  app = mount(App, {
+    target: document.getElementById('app')!,
+  });
+} catch (error) {
+  showRendererRecovery(error);
+}
 
 export default app;

--- a/app/src/renderer/app/main.ts
+++ b/app/src/renderer/app/main.ts
@@ -1,6 +1,6 @@
 import './app.css';
 import App from './App.svelte';
-import { mount } from 'svelte';
+import { mount, unmount } from 'svelte';
 
 declare global {
   interface Window {
@@ -14,6 +14,10 @@ function showRendererRecovery(error: unknown): void {
 
   const target = document.getElementById('app');
   if (!target || target.querySelector('[data-renderer-recovery]')) return;
+  if (app) {
+    void unmount(app);
+    app = undefined;
+  }
   target.replaceChildren();
 
   const recovery = document.createElement('main');
@@ -33,7 +37,7 @@ function showRendererRecovery(error: unknown): void {
 window.addEventListener('error', (event) => showRendererRecovery(event.error ?? event.message));
 window.addEventListener('unhandledrejection', (event) => showRendererRecovery(event.reason));
 
-let app;
+let app: ReturnType<typeof mount> | undefined;
 try {
   app = mount(App, {
     target: document.getElementById('app')!,

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -308,7 +308,7 @@
       <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Live status from the shared server controller; lifecycle actions apply only to the managed server.</p>
     </div>
     <div data-server-health-surface class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4">
-      <div data-server-health-status class="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div data-server-health-status class="grid min-w-0 gap-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center">
         <div class="flex min-w-0 items-center gap-3">
           <span class="relative flex h-3 w-3 shrink-0 items-center justify-center" aria-hidden="true">
             {#if serverState.status === 'running' && engineReady}
@@ -322,7 +322,26 @@
           {/if}
         </div>
 
-        <div class="flex min-w-0 flex-wrap items-center gap-2">
+        {#if serverState.status === 'running' && (serverState.pid !== undefined || serverState.port !== undefined || serverState.version !== undefined || serverState.uptime !== undefined)}
+          <dl data-server-health-details class="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-2 md:justify-center">
+            {#if serverState.port}
+              <div class="flex min-w-0 items-baseline gap-1.5"><dt class="text-[11px] text-zinc-500">Port</dt><dd class="break-all font-mono text-xs text-zinc-300">{serverState.port}</dd></div>
+            {/if}
+            {#if serverState.version}
+              <div class="flex min-w-0 items-baseline gap-1.5"><dt class="text-[11px] text-zinc-500">Version</dt><dd class="break-all font-mono text-xs text-zinc-300">v{serverState.version}</dd></div>
+            {/if}
+            {#if serverState.pid}
+              <div class="flex min-w-0 items-baseline gap-1.5"><dt class="text-[11px] text-zinc-500">PID</dt><dd class="break-all font-mono text-xs text-zinc-300">{serverState.pid}</dd></div>
+            {/if}
+            {#if serverState.uptime !== undefined}
+              <div class="flex min-w-0 items-baseline gap-1.5"><dt class="text-[11px] text-zinc-500">Uptime</dt><dd class="break-all font-mono text-xs text-zinc-300">{formatUptime(serverState.uptime)}</dd></div>
+            {/if}
+          </dl>
+        {:else}
+          <div></div>
+        {/if}
+
+        <div class="flex min-w-0 flex-wrap items-center gap-2 md:justify-end">
           {#if serverState.status === 'running'}
             <button
               type="button"
@@ -413,22 +432,6 @@
         </div>
       {/if}
 
-      {#if serverState.status === 'running' && (serverState.pid !== undefined || serverState.port !== undefined || serverState.version !== undefined || serverState.uptime !== undefined)}
-        <div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/[0.08] pt-4 sm:grid-cols-2">
-          {#if serverState.port}
-            <div class="min-w-0"><p class="text-xs text-zinc-500">Port</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">{serverState.port}</p></div>
-          {/if}
-          {#if serverState.version}
-            <div class="min-w-0"><p class="text-xs text-zinc-500">Version</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">v{serverState.version}</p></div>
-          {/if}
-          {#if serverState.pid}
-            <div class="min-w-0"><p class="text-xs text-zinc-500">PID</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">{serverState.pid}</p></div>
-          {/if}
-          {#if serverState.uptime !== undefined}
-            <div class="min-w-0"><p class="text-xs text-zinc-500">Uptime</p><p class="mt-1 break-all font-mono text-sm text-zinc-300">{formatUptime(serverState.uptime)}</p></div>
-          {/if}
-        </div>
-      {/if}
     </div>
   </section>
 
@@ -437,7 +440,7 @@
       <svelte:element this={headingTag} id={headingId('logs')} class="text-sm font-semibold text-zinc-200">Logs</svelte:element>
       <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Inspect recent server output only when needed for troubleshooting.</p>
     </div>
-    <div data-server-logs-surface class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4 focus-within:ring-2 focus-within:ring-zinc-100 focus-within:ring-offset-2 focus-within:ring-offset-[#08090a]">
+    <div data-server-logs-surface class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4">
       <button
         type="button"
         data-server-logs-toggle
@@ -448,7 +451,7 @@
         aria-expanded={showLogs}
         aria-controls={logOutputId}
         aria-describedby={privacyWarningId}
-        class="flex min-h-12 w-full min-w-0 items-center justify-between gap-3 rounded-lg border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-left transition-colors hover:bg-zinc-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+        class="flex min-h-12 w-full min-w-0 items-center justify-between gap-3 rounded-lg border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-left transition-colors hover:bg-zinc-800 cursor-pointer focus:outline focus:outline-2 focus:outline-offset-[-2px] focus:outline-zinc-100"
       >
         <span class="min-w-0 text-sm text-zinc-200 [overflow-wrap:anywhere]">Server logs</span>
         <span class="shrink-0 rounded-full border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs tabular-nums text-zinc-400">{logs.length}</span>
@@ -471,14 +474,15 @@
             {#if logsCopied}Copied{:else}Copy raw logs{/if}
           </button>
         </div>
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex (keyboard focus is required to scroll the bounded log region) -->
         <div
           data-server-log-output
           id={`${logOutputId}-scroll`}
           bind:this={logsContainer}
           tabindex="0"
-          role="group"
+          role="log"
           aria-label="Server log output"
-          class="mt-2 max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain rounded-lg border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+          class="mt-2 max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain rounded-lg border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs focus:outline focus:outline-2 focus:outline-offset-[-2px] focus:outline-zinc-100"
         >
           {#if logs.length === 0}
             <p class="py-8 text-center text-zinc-500">No logs yet</p>

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -338,7 +338,7 @@
             {/if}
           </dl>
         {:else}
-          <div></div>
+          <div class="hidden md:block"></div>
         {/if}
 
         <div class="flex min-w-0 flex-wrap items-center gap-2 md:justify-end">
@@ -464,7 +464,7 @@
             type="button"
             onclick={copyLogs}
             disabled={logs.length === 0}
-            class="inline-flex min-h-9 items-center justify-center gap-1 rounded-lg border border-zinc-700 px-3 py-2 text-xs transition-colors
+            class="inline-flex min-h-9 items-center justify-center gap-1 rounded-lg border border-zinc-700 px-3 py-2 text-xs transition-colors focus:outline focus:outline-2 focus:outline-offset-[-2px] focus:outline-zinc-100
               {logs.length === 0
                 ? 'cursor-not-allowed text-zinc-600'
                 : logsCopied

--- a/app/tests/fixtures/settings-speech-electron.cjs
+++ b/app/tests/fixtures/settings-speech-electron.cjs
@@ -86,10 +86,30 @@ async function capture(window, view, state, compatibility, filename) {
   return target;
 }
 
+async function exerciseModelSelection(window) {
+  await loadFixture(window, 'speech', 'ready', false);
+  return window.webContents.executeJavaScript(`(async () => {
+    const radios = [...document.querySelectorAll('input[type="radio"]')];
+    const results = [];
+    for (const radio of radios) {
+      radio.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      results.push({
+        label: radio.getAttribute('aria-label'),
+        checked: radio.checked,
+        panelPresent: !!document.querySelector('[data-speech-model-panel]'),
+        optionCount: document.querySelectorAll('[data-speech-model-option]').length,
+      });
+    }
+    return results;
+  })()`);
+}
+
 async function main() {
   let window = null;
   const measurements = [];
   const screenshots = [];
+  let interactions = [];
   await app.whenReady();
   try {
     window = new BrowserWindow({
@@ -124,11 +144,12 @@ async function main() {
         }
       }
     }
+    interactions = await exerciseModelSelection(window);
   } finally {
     if (window && !window.isDestroyed()) await window.close();
   }
 
-  process.stdout.write(JSON.stringify({ measurements, screenshots, userDataPath: userData }));
+  process.stdout.write(JSON.stringify({ measurements, screenshots, interactions, userDataPath: userData }));
   app.quit();
 }
 

--- a/app/tests/renderer-visual-guards.test.ts
+++ b/app/tests/renderer-visual-guards.test.ts
@@ -17,6 +17,10 @@ const settingsSection = readFileSync(
   new URL('../src/renderer/app/components/SettingsSection.svelte', import.meta.url),
   'utf8'
 );
+const rendererMain = readFileSync(
+  new URL('../src/renderer/app/main.ts', import.meta.url),
+  'utf8'
+);
 
 describe('renderer visual regression guards', () => {
   test('contains long unbroken history text inside its card', () => {
@@ -72,5 +76,13 @@ describe('renderer visual regression guards', () => {
     expect(settingsSection).toContain("variant === 'panel'");
     expect(settingsSection).toContain('aria-labelledby={headingId}');
     expect(settingsSection).not.toContain('overflow-hidden');
+  });
+
+  test('provides a renderer recovery surface instead of leaving a blank window', () => {
+    expect(rendererMain).toContain("window.addEventListener('error'");
+    expect(rendererMain).toContain("window.addEventListener('unhandledrejection'");
+    expect(rendererMain).toContain('data-renderer-recovery');
+    expect(rendererMain).toContain('Reload interface');
+    expect(rendererMain).not.toContain('normalized.message');
   });
 });

--- a/app/tests/renderer-visual-guards.test.ts
+++ b/app/tests/renderer-visual-guards.test.ts
@@ -81,6 +81,7 @@ describe('renderer visual regression guards', () => {
   test('provides a renderer recovery surface instead of leaving a blank window', () => {
     expect(rendererMain).toContain("window.addEventListener('error'");
     expect(rendererMain).toContain("window.addEventListener('unhandledrejection'");
+    expect(rendererMain).toContain('void unmount(app);');
     expect(rendererMain).toContain('data-renderer-recovery');
     expect(rendererMain).toContain('Reload interface');
     expect(rendererMain).not.toContain('normalized.message');

--- a/app/tests/settings-server-cohesion.test.ts
+++ b/app/tests/settings-server-cohesion.test.ts
@@ -44,6 +44,8 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
 
   test('keeps factual status and diagnostics readable without creating another live announcer', () => {
     expect(serverView).toContain('data-server-health-status');
+    expect(serverView).toContain('data-server-health-details');
+    expect(serverView).toContain('md:grid-cols-[auto_minmax(0,1fr)_auto]');
     expect(serverView).toContain('data-server-status');
     expect(serverView).toContain('data-server-diagnostic-warnings');
     expect(serverView).toContain('<ModelProgressCard state={modelDownload} announce={false} />');
@@ -66,10 +68,11 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(serverView).toContain('data-server-logs-privacy');
     expect(serverView).toContain('data-server-log-output');
     expect(serverView).toContain('tabindex="0"');
-    expect(serverView).toContain('role="group"');
+    expect(serverView).toContain('role="log"');
     expect(serverView).toContain('aria-label="Server log output"');
     expect(serverView).toContain('max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain');
-    expect(serverView).toContain('focus-within:ring-2');
+    expect(serverView).not.toContain('data-server-logs-surface class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4 focus-within');
+    expect(serverView).toContain('focus:outline-offset-[-2px]');
     expect(serverView).not.toContain('opacity-45 pointer-events-none select-none');
   });
 

--- a/app/tests/settings-server-rendered.test.mjs
+++ b/app/tests/settings-server-rendered.test.mjs
@@ -137,7 +137,7 @@ describe('rendered Phase 3 Server and diagnostics fixture', () => {
     expect(expanded.logsScroller.overscrollBehaviorY).toBe('contain');
     expect(expanded.logsScroller.scrollHeight).toBeGreaterThan(expanded.logsScroller.clientHeight);
     expect(expanded.logsScroller.tabIndex).toBe(0);
-    expect(expanded.logsScroller.role).toBe('group');
+    expect(expanded.logsScroller.role).toBe('log');
     expect(expanded.logsScroller.ariaLabel).toBe('Server log output');
   });
 

--- a/app/tests/settings-speech-cohesion.test.ts
+++ b/app/tests/settings-speech-cohesion.test.ts
@@ -29,7 +29,8 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(chooser).toContain('type="radio"');
     expect(chooser).toContain('data-speech-model-option');
     expect(chooser).toContain('name={`speech-model-preset-${componentId}`}');
-    expect(chooser).toContain('focus-within:ring-2');
+    expect(chooser).toContain('focus-within:outline');
+    expect(chooser).toContain('outline-offset-[-2px]');
     expect(chooser).not.toContain('sm:grid-cols-2');
     expect(chooser).not.toContain('rounded-xl border p-3 transition-colors');
   });

--- a/app/tests/settings-speech-rendered.test.mjs
+++ b/app/tests/settings-speech-rendered.test.mjs
@@ -124,7 +124,7 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
   });
 
   test('preserves external restrictions and the compatibility disclosure association', () => {
-    const external = measurements.find((measurement) => measurement.view === 'speech' && measurement.state === 'external' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const external = measurements.find((measurement) => measurement.view === 'speech' && measurement.state === 'external' && measurement.zoom === 1);
     expect(external.external).toBeTrue();
     expect(external.optionCount).toBe(0);
     expect(external.focus.focusWithin).toBeFalse();
@@ -132,6 +132,21 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
     const expanded = measurements.find((measurement) => measurement.compatibility);
     expect(expanded.compatibilityExpanded).toBeTrue();
     expect(expanded.compatibilityAssociation).toBeTrue();
+  });
+
+  test('keeps the renderer mounted while selecting every curated model', () => {
+    expect(result.interactions).toHaveLength(4);
+    expect(result.interactions.map((interaction) => interaction.label)).toEqual([
+      'English Performance, Selected',
+      'Recommended Multilingual, Current',
+      'Maximum Multilingual Accuracy, Selected',
+      'Lightweight, Selected',
+    ]);
+    for (const interaction of result.interactions) {
+      expect(interaction.checked).toBeTrue();
+      expect(interaction.panelPresent).toBeTrue();
+      expect(interaction.optionCount).toBe(4);
+    }
   });
 
   test('writes deterministic isolated screenshots and cleans Electron userData', () => {


### PR DESCRIPTION
## Summary
- keep curated model selection mounted and cover all four presets with a real rendered interaction sequence
- replace clipped/doubled focus rings with contained outlines
- compact managed-server health, metadata, and actions into a responsive strip
- show a privacy-safe renderer recovery surface instead of an unexplained blank window

## Validation
- 175 app tests pass
- rendered Settings Speech and Server fixtures pass across representative widths and zooms
- renderer/main production build passes without accessibility warnings
- no model mappings, IPC, persistence, identity, packaging, or release state changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recovery screen with a reload option when the app encounters startup errors or unexpected failures.
  * Improved server health layout with responsive inline details and clearer log semantics.
  * Enhanced speech model selection interactions and visual focus treatment.

* **Accessibility**
  * Improved focus outlines and log region labeling for better keyboard and assistive technology support.

* **Bug Fixes**
  * Improved renderer resilience by preventing failures from leaving the interface unusable.

* **Tests**
  * Added coverage for renderer recovery, speech model selection, and responsive server health behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->