### PR TITLE
Refresh Eve Home as a voice-first dashboard

### DIFF
--- a/app/src/renderer/app/fixtures/home-fixture.html
+++ b/app/src/renderer/app/fixtures/home-fixture.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-[#08090a]">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eve Home fixture</title>
+  </head>
+  <body class="h-full bg-[#08090a]">
+    <div id="fixture-root" class="h-full min-h-0 bg-[#08090a]"></div>
+    <script type="module" src="./home-fixture.ts"></script>
+  </body>
+</html>

--- a/app/src/renderer/app/fixtures/home-fixture.ts
+++ b/app/src/renderer/app/fixtures/home-fixture.ts
@@ -1,0 +1,70 @@
+import '../app.css';
+import { mount } from 'svelte';
+import type { ServerStatePayload } from '$shared/types';
+import HomeView from '../views/HomeView.svelte';
+import { serverStatusState, type ServerStatusPhase } from '../server-status';
+
+const params = new URLSearchParams(location.search);
+const phase = (params.get('phase') ?? 'ready') as ServerStatusPhase;
+
+const readyState: ServerStatePayload = {
+  status: 'running',
+  managed: true,
+  port: 51717,
+  engineStatus: {
+    current: 'whisper',
+    status: 'ready',
+    info: {
+      id: 'whisper',
+      name: 'Faster-Whisper',
+      model: 'large-v3-turbo',
+      supports_hotwords: true,
+      languages: ['en', 'de', 'fr', 'es', 'it', 'ja'],
+      model_size_gb: 1.5,
+      device: 'auto',
+    },
+  },
+  modelDownload: { model: 'large-v3-turbo', size_gb: 1.5, status: 'ready', phase: 'ready', cached: true },
+};
+
+const state: ServerStatePayload | null = phase === 'ready'
+  ? readyState
+  : phase === 'downloading'
+    ? {
+        ...readyState,
+        engineStatus: { current: 'whisper', status: 'loading' },
+        modelDownload: {
+          model: 'large-v3',
+          size_gb: 2.9,
+          status: 'downloading',
+          phase: 'downloading',
+          progress_percent: 48,
+          downloaded_bytes: 1_400_000_000,
+          total_bytes: 2_900_000_000,
+        },
+      }
+    : phase === 'error'
+      ? { status: 'error', managed: true, error: 'Fixture speech service unavailable.' }
+      : null;
+
+serverStatusState.set({
+  state,
+  phase,
+  announcement: `Fixture ${phase}`,
+  configuredExternalServer: false,
+});
+
+Object.assign(window, {
+  murmurMain: {
+    getSettings: async () => ({
+      hotkey: { keycode: 3675, ctrlKey: true, altKey: false, shiftKey: false, metaKey: false },
+      longHotkey: { keycode: 3675, ctrlKey: true, altKey: false, shiftKey: true, metaKey: false },
+    }),
+    getHotkeyDisplayName: async (hotkey: { shiftKey: boolean }) => hotkey.shiftKey ? 'Ctrl+Shift+Win' : 'Ctrl+Win',
+  },
+});
+
+mount(HomeView, {
+  target: document.getElementById('fixture-root')!,
+  props: { onNavigate: () => {} },
+});

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -32,6 +32,21 @@
 
   let readiness = $derived(phaseCopy[snapshot.phase]);
   let managementMode = $derived(getServerManagementMode(snapshot));
+  let phaseAccent = $derived(
+    snapshot.phase === 'ready'
+      ? 'emerald'
+      : snapshot.phase === 'error' || snapshot.phase === 'unavailable'
+        ? 'red'
+        : snapshot.phase === 'downloading' || snapshot.phase === 'loading' || snapshot.phase === 'checking'
+          ? 'amber'
+          : 'zinc'
+  );
+  let reportedLanguages = $derived(Array.isArray(engine?.languages) ? engine.languages : []);
+  let reportedModelSize = $derived(
+    typeof engine?.model_size_gb === 'number' && Number.isFinite(engine.model_size_gb) && engine.model_size_gb > 0
+      ? engine.model_size_gb
+      : null
+  );
 
   onMount(() => {
     async function loadSettings(): Promise<void> {
@@ -62,57 +77,84 @@
   }
 </script>
 
-<div class="h-full overflow-y-auto p-4 sm:p-6">
-  <div class="mx-auto flex max-w-4xl flex-col gap-5">
-    <section class="rounded-2xl border border-white/10 bg-white/[0.03] p-5 sm:p-6" aria-labelledby="home-readiness-heading">
-      <p class="text-xs font-medium uppercase tracking-[0.16em] text-zinc-500">Eve</p>
-      <div class="mt-3 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h1 id="home-readiness-heading" class="text-2xl font-semibold text-zinc-50">{readiness.title}</h1>
-          <p class="mt-1 max-w-xl text-sm text-zinc-400">{readiness.detail}</p>
+<div data-home-scroll-owner class="h-full overflow-y-auto overscroll-contain px-4 py-5 sm:px-6 sm:py-7">
+  <div class="mx-auto flex max-w-4xl flex-col gap-4 pb-5">
+    <section
+      data-home-hero
+      class="relative min-w-0 overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_82%_18%,rgba(56,189,248,0.14),transparent_34%),radial-gradient(circle_at_22%_90%,rgba(16,185,129,0.10),transparent_38%),linear-gradient(145deg,rgba(255,255,255,0.055),rgba(255,255,255,0.018))] px-5 py-6 sm:px-7 sm:py-7"
+      aria-labelledby="home-readiness-heading"
+    >
+      <div aria-hidden="true" class="pointer-events-none absolute -right-20 -top-24 h-64 w-64 rounded-full border border-sky-300/10"></div>
+      <div aria-hidden="true" class="pointer-events-none absolute -right-8 -top-12 h-40 w-40 rounded-full border border-sky-300/10"></div>
+
+      <div class="relative grid min-w-0 gap-7 md:grid-cols-[minmax(0,1fr)_220px] md:items-center">
+        <div class="min-w-0">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1.5 text-xs text-zinc-300">
+              <span class="relative flex h-2 w-2" aria-hidden="true">
+                {#if snapshot.phase === 'ready'}<span class="absolute inline-flex h-full w-full motion-safe:animate-ping rounded-full bg-emerald-300 opacity-60"></span>{/if}
+                <span class="relative inline-flex h-2 w-2 rounded-full {phaseAccent === 'emerald' ? 'bg-emerald-300' : phaseAccent === 'red' ? 'bg-red-300' : phaseAccent === 'amber' ? 'bg-amber-300' : 'bg-zinc-500'}"></span>
+              </span>
+              {snapshot.phase === 'ready' ? 'Listening when you are' : readiness.title}
+            </span>
+            {#if managementMode === 'external'}
+              <span class="rounded-full border border-white/10 px-3 py-1.5 text-xs text-zinc-400">External processing</span>
+            {/if}
+          </div>
+
+          <p class="mt-6 text-xs font-semibold uppercase tracking-[0.24em] text-zinc-500">Your words, ready to move</p>
+          <h1 id="home-readiness-heading" class="mt-2 max-w-xl text-3xl font-semibold tracking-[-0.035em] text-zinc-50 sm:text-4xl">
+            {readiness.title}
+          </h1>
+          <p class="mt-3 max-w-xl text-sm leading-6 text-zinc-400">{readiness.detail}</p>
+
+          <dl data-home-engine-summary class="mt-6 flex min-w-0 flex-wrap gap-x-5 gap-y-3 border-t border-white/[0.08] pt-4">
+            <div class="min-w-0">
+              <dt class="text-[10px] font-medium uppercase tracking-[0.16em] text-zinc-500">Engine</dt>
+              <dd class="mt-1 max-w-[220px] truncate text-sm text-zinc-200">{engine?.name ?? server?.engineStatus?.current ?? 'Checking…'}</dd>
+            </div>
+            <div class="min-w-0">
+              <dt class="text-[10px] font-medium uppercase tracking-[0.16em] text-zinc-500">Model</dt>
+              <dd class="mt-1 max-w-[260px] truncate text-sm text-zinc-200">{model?.model ?? engine?.model ?? 'Checking…'}</dd>
+            </div>
+            {#if reportedModelSize !== null}
+              <div>
+                <dt class="text-[10px] font-medium uppercase tracking-[0.16em] text-zinc-500">Size</dt>
+                <dd class="mt-1 text-sm text-zinc-200">~{reportedModelSize.toFixed(1)} GB</dd>
+              </div>
+            {/if}
+          </dl>
         </div>
-        {#if managementMode === 'external'}
-          <p class="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
-            External server — Eve cannot restart this endpoint.
-          </p>
-        {:else if server?.managed && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
-          <button
-            type="button"
-            onclick={retry}
-            disabled={retrying}
-            class="rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08090a]
-              {retrying ? 'bg-zinc-800 text-zinc-500 cursor-not-allowed' : 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer'}"
-          >
-            {retrying ? 'Retrying…' : 'Retry managed server'}
-          </button>
-        {:else if managementMode === 'unknown' && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
-          <p class="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
-            Management mode cannot be confirmed. Open Settings &gt; Server &amp; diagnostics.
-          </p>
-        {/if}
+
+        <div data-home-voice-orb class="relative mx-auto flex h-44 w-44 items-center justify-center md:h-48 md:w-48" aria-hidden="true">
+          <div class="absolute inset-0 rounded-full border border-white/10 bg-white/[0.025] shadow-[0_20px_80px_rgba(14,165,233,0.10)]"></div>
+          <div class="absolute inset-5 rounded-full border border-sky-300/15 bg-gradient-to-br from-sky-300/10 via-transparent to-emerald-300/10 {snapshot.phase === 'ready' ? 'motion-safe:animate-pulse' : ''}"></div>
+          <div class="relative flex h-20 w-24 items-center justify-center gap-1 rounded-full border border-white/10 bg-black/25 shadow-inner">
+            {#each ['h-1.5', 'h-2.5', 'h-4', 'h-6', 'h-4', 'h-2.5', 'h-1.5'] as heightClass}
+              <span class="w-1 rounded-full {heightClass} {phaseAccent === 'emerald' ? 'bg-emerald-300/80' : phaseAccent === 'red' ? 'bg-red-300/70' : phaseAccent === 'amber' ? 'bg-amber-300/75' : 'bg-zinc-500'} {snapshot.phase === 'ready' ? 'motion-safe:animate-pulse' : ''}"></span>
+            {/each}
+          </div>
+        </div>
       </div>
 
-      <dl class="mt-5 grid gap-3 sm:grid-cols-2">
-        <div class="rounded-xl border border-white/10 bg-black/20 p-3">
-          <dt class="text-xs font-medium uppercase tracking-[0.12em] text-zinc-500">Current engine</dt>
-          <dd class="mt-1 text-sm text-zinc-100">{engine?.name ?? server?.engineStatus?.current ?? 'Checking current engine…'}</dd>
-        </div>
-        <div class="rounded-xl border border-white/10 bg-black/20 p-3">
-          <dt class="text-xs font-medium uppercase tracking-[0.12em] text-zinc-500">Selected model</dt>
-          <dd class="mt-1 text-sm text-zinc-100">{model?.model ?? engine?.model ?? 'Checking selected model…'}</dd>
-        </div>
-      </dl>
-
-      {#if engine}
-        <p class="mt-4 text-xs leading-5 text-zinc-400">
-          {engine.languages.length > 0 ? `Languages: ${engine.languages.join(', ')}.` : 'Language coverage is not reported by the current engine.'}
-          {#if engine.model_size_gb > 0} Approx. {engine.model_size_gb.toFixed(1)} GB.{/if}
-          {#if engine.device} Running on {engine.device}.{/if}
-        </p>
+      {#if managementMode === 'external'}
+        <p class="relative mt-5 text-xs leading-5 text-zinc-500">External server — Eve cannot restart this endpoint.</p>
+      {:else if server?.managed && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
+        <button
+          type="button"
+          onclick={retry}
+          disabled={retrying}
+          class="relative mt-5 min-h-10 rounded-full px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08090a]
+            {retrying ? 'bg-zinc-800 text-zinc-500 cursor-not-allowed' : 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer'}"
+        >
+          {retrying ? 'Retrying…' : 'Retry managed server'}
+        </button>
+      {:else if managementMode === 'unknown' && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
+        <p class="relative mt-5 text-xs leading-5 text-zinc-500">Management mode cannot be confirmed. Open Settings &gt; Server &amp; diagnostics.</p>
       {/if}
 
       {#if model && snapshot.phase === 'downloading'}
-        <p class="mt-4 text-sm text-zinc-300">
+        <p class="relative mt-4 text-xs text-zinc-400">
           {#if typeof model.downloaded_bytes === 'number' && typeof model.total_bytes === 'number' && model.total_bytes > 0}
             Download progress is available in the preparation banner.
           {:else}
@@ -120,34 +162,51 @@
           {/if}
         </p>
       {/if}
-
     </section>
 
-    <section class="grid gap-4 lg:grid-cols-2" aria-label="Dictation shortcuts and guidance">
-      <article class="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
-        <h2 class="text-base font-semibold text-zinc-100">Quick dictation</h2>
-        <p class="mt-1 text-sm text-zinc-400">Use for short, immediate speech-to-text input.</p>
-        <p class="mt-4 font-mono text-sm text-zinc-200">{quickHotkey}</p>
+    <section data-home-modes class="grid gap-3 sm:grid-cols-2" aria-label="Dictation shortcuts and guidance">
+      <article class="group min-w-0 rounded-2xl border border-white/[0.08] bg-white/[0.025] p-4 transition-colors hover:border-sky-300/20 hover:bg-sky-300/[0.035]">
+        <div class="flex min-w-0 items-start justify-between gap-3">
+          <div class="min-w-0">
+            <p class="text-xs font-medium text-sky-300">Quick</p>
+            <h2 class="mt-1 text-base font-semibold text-zinc-100">Say it. Send it.</h2>
+            <p class="mt-1 text-xs leading-5 text-zinc-500">Short, immediate speech-to-text input.</p>
+          </div>
+          <span aria-hidden="true" class="text-lg text-zinc-600 transition-transform group-hover:translate-x-0.5 group-hover:text-sky-300">→</span>
+        </div>
+        <p class="mt-4 inline-flex max-w-full rounded-lg bg-black/25 px-2.5 py-1.5 font-mono text-xs text-zinc-300 [overflow-wrap:anywhere]">{quickHotkey}</p>
       </article>
-      <article class="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
-        <h2 class="text-base font-semibold text-zinc-100">Long dictation</h2>
-        <p class="mt-1 text-sm text-zinc-400">Use for longer recordings that Eve processes after capture.</p>
-        <p class="mt-4 font-mono text-sm text-zinc-200">{longHotkey}</p>
+      <article class="group min-w-0 rounded-2xl border border-white/[0.08] bg-white/[0.025] p-4 transition-colors hover:border-violet-300/20 hover:bg-violet-300/[0.035]">
+        <div class="flex min-w-0 items-start justify-between gap-3">
+          <div class="min-w-0">
+            <p class="text-xs font-medium text-violet-300">Long</p>
+            <h2 class="mt-1 text-base font-semibold text-zinc-100">Keep the thought flowing.</h2>
+            <p class="mt-1 text-xs leading-5 text-zinc-500">Longer recordings are processed after capture.</p>
+          </div>
+          <span aria-hidden="true" class="text-lg text-zinc-600 transition-transform group-hover:translate-x-0.5 group-hover:text-violet-300">→</span>
+        </div>
+        <p class="mt-4 inline-flex max-w-full rounded-lg bg-black/25 px-2.5 py-1.5 font-mono text-xs text-zinc-300 [overflow-wrap:anywhere]">{longHotkey}</p>
       </article>
     </section>
 
-    <section class="rounded-2xl border border-white/10 bg-white/[0.03] p-5" aria-labelledby="home-privacy-heading">
-      <h2 id="home-privacy-heading" class="text-base font-semibold text-zinc-100">Processing and privacy</h2>
-      <p class="mt-1 text-sm leading-6 text-zinc-400">By default, Eve processes speech locally. If you configure an external endpoint, audio is sent to that endpoint under your control. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
-      {#if shortcutsError}
-        <p class="mt-3 text-xs text-zinc-500">Shortcut labels could not be read. Open Settings to review them.</p>
-      {/if}
-    </section>
+    <div class="flex min-w-0 flex-col gap-3 rounded-2xl border border-white/[0.08] bg-white/[0.018] p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="min-w-0">
+        <h2 id="home-privacy-heading" class="text-sm font-medium text-zinc-200">Private by default</h2>
+        <p class="mt-1 max-w-2xl text-xs leading-5 text-zinc-500">By default, Eve processes speech locally. If you configure an external endpoint, audio is sent to that endpoint under your control. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
+        {#if shortcutsError}<p class="mt-2 text-xs text-zinc-500">Shortcut labels could not be read. Open Settings to review them.</p>{/if}
+      </div>
+      <span class="shrink-0 rounded-full border border-emerald-300/15 bg-emerald-300/[0.05] px-3 py-1.5 text-xs text-emerald-300">Local-first</span>
+    </div>
 
-    <nav aria-label="Home actions" class="flex flex-wrap gap-2">
-      <button type="button" onclick={() => onNavigate('history')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100">Open History</button>
-      <button type="button" onclick={() => onNavigate('insights')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100">Open Insights</button>
-      <button type="button" onclick={() => onNavigate('settings')} class="rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-200 hover:bg-white/[0.06] cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100">Open Settings</button>
+    <nav aria-label="Home actions" class="flex min-w-0 flex-wrap items-center gap-1 text-xs">
+      <span class="mr-2 text-zinc-600">Explore</span>
+      <button type="button" onclick={() => onNavigate('history')} class="rounded-full px-3 py-2 text-zinc-400 transition-colors hover:bg-white/[0.05] hover:text-zinc-100 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-zinc-100">History</button>
+      <button type="button" onclick={() => onNavigate('insights')} class="rounded-full px-3 py-2 text-zinc-400 transition-colors hover:bg-white/[0.05] hover:text-zinc-100 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-zinc-100">Insights</button>
+      <button type="button" onclick={() => onNavigate('settings')} class="rounded-full px-3 py-2 text-zinc-400 transition-colors hover:bg-white/[0.05] hover:text-zinc-100 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-zinc-100">Settings</button>
     </nav>
+
+    {#if engine && reportedLanguages.length > 0}
+      <p class="sr-only">Languages reported by the current engine: {reportedLanguages.join(', ')}.</p>
+    {/if}
   </div>
 </div>

--- a/app/tests/fixtures/home-electron.cjs
+++ b/app/tests/fixtures/home-electron.cjs
@@ -1,0 +1,71 @@
+const { app, BrowserWindow } = require('electron');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const baseUrl = process.argv[2];
+if (!baseUrl) throw new Error('fixture URL is required');
+const screenshotDir = path.resolve(process.env.EVE_HOME_SCREENSHOT_DIR || path.join(os.tmpdir(), 'eve-home-screenshots'));
+const userData = path.resolve(os.tmpdir(), `eve-home-${process.pid}`);
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+app.setPath('userData', userData);
+app.commandLine.appendSwitch('disable-gpu');
+app.commandLine.appendSwitch('force-device-scale-factor', '1');
+
+async function main() {
+  await app.whenReady();
+  const window = new BrowserWindow({
+    width: 960,
+    height: 900,
+    show: false,
+    frame: false,
+    backgroundColor: '#08090a',
+    webPreferences: { contextIsolation: true, nodeIntegration: false },
+  });
+  const measurements = [];
+  const screenshots = [];
+  try {
+    for (const phase of ['ready', 'downloading', 'error']) {
+      await window.loadURL(`${baseUrl}?phase=${phase}`);
+      await wait(200);
+      for (const [width, height] of [[960, 900], [360, 720]]) {
+        window.setContentSize(width, height);
+        await wait(80);
+        for (const zoom of [1, 1.5]) {
+          await window.webContents.setZoomFactor(zoom);
+          await wait(80);
+          measurements.push(await window.webContents.executeJavaScript(`(() => {
+            const owner = document.querySelector('[data-home-scroll-owner]');
+            const hero = document.querySelector('[data-home-hero]');
+            const orb = document.querySelector('[data-home-voice-orb]');
+            return {
+              phase: '${phase}', zoom: ${zoom}, viewport: { width: innerWidth, height: innerHeight },
+              owner: owner ? { overflowY: getComputedStyle(owner).overflowY, scrollWidth: owner.scrollWidth, clientWidth: owner.clientWidth } : null,
+              hero: !!hero, orb: !!orb,
+              document: { scrollWidth: document.documentElement.scrollWidth, clientWidth: document.documentElement.clientWidth },
+              heading: document.querySelector('#home-readiness-heading')?.textContent?.trim(),
+              actionCount: document.querySelectorAll('nav[aria-label="Home actions"] button').length,
+            };
+          })()`));
+        }
+      }
+      await window.webContents.setZoomFactor(1);
+      window.setContentSize(960, 900);
+      await wait(100);
+      fs.mkdirSync(screenshotDir, { recursive: true });
+      const target = path.join(screenshotDir, `home-${phase}.png`);
+      fs.writeFileSync(target, (await window.webContents.capturePage()).toPNG());
+      screenshots.push(target);
+    }
+  } finally {
+    if (!window.isDestroyed()) window.destroy();
+  }
+  process.stdout.write(JSON.stringify({ measurements, screenshots, userDataPath: userData }));
+  app.quit();
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  app.exit(1);
+});

--- a/app/tests/home-rendered.test.mjs
+++ b/app/tests/home-rendered.test.mjs
@@ -1,0 +1,61 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+const appRoot = resolve(import.meta.dir, '..');
+const screenshotDir = resolve(tmpdir(), 'eve-home-screenshots');
+const vitePort = 53000 + (process.pid % 100);
+const fixtureUrl = `http://127.0.0.1:${vitePort}/app/fixtures/home-fixture.html`;
+const vite = Bun.spawn(['node', resolve(appRoot, 'node_modules/vite/bin/vite.js'), '--host', '127.0.0.1'], {
+  cwd: appRoot,
+  env: { ...process.env, MURMUR_DEV_PORT: String(vitePort) },
+  stdout: 'ignore', stderr: 'pipe', windowsHide: true,
+});
+
+for (let attempt = 0; attempt < 60; attempt += 1) {
+  try { if ((await fetch(fixtureUrl)).ok) break; } catch {}
+  await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+}
+
+const child = Bun.spawn([
+  resolve(appRoot, 'node_modules/electron/dist/electron.exe'),
+  resolve(appRoot, 'tests/fixtures/home-electron.cjs'),
+  fixtureUrl,
+], {
+  cwd: appRoot,
+  env: { ...process.env, EVE_HOME_SCREENSHOT_DIR: screenshotDir },
+  stdout: 'pipe', stderr: 'pipe', windowsHide: true,
+});
+const [stdout, stderr, code] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
+if (code !== 0) throw new Error(`Home fixture exited ${code}: ${stderr || stdout}`);
+const result = JSON.parse(stdout);
+await fs.rm(result.userDataPath, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+
+afterAll(async () => { vite.kill(); await vite.exited; });
+
+describe('rendered Home experience', () => {
+  test('contains the expressive hero and avoids horizontal overflow across phases, widths, and zooms', () => {
+    expect(result.measurements).toHaveLength(12);
+    for (const measurement of result.measurements) {
+      expect(measurement.hero).toBeTrue();
+      expect(measurement.orb).toBeTrue();
+      expect(measurement.owner.overflowY).toBe('auto');
+      expect(measurement.owner.scrollWidth).toBeLessThanOrEqual(measurement.owner.clientWidth);
+      expect(measurement.document.scrollWidth).toBeLessThanOrEqual(measurement.document.clientWidth);
+      expect(measurement.actionCount).toBe(3);
+    }
+  });
+
+  test('keeps truthful readiness copy for ready, download, and error states', () => {
+    expect(result.measurements.find((item) => item.phase === 'ready').heading).toBe('Ready for dictation');
+    expect(result.measurements.find((item) => item.phase === 'downloading').heading).toBe('Preparing speech model');
+    expect(result.measurements.find((item) => item.phase === 'error').heading).toBe('Speech setup needs attention');
+  });
+
+  test('writes isolated deterministic screenshots', () => {
+    expect(result.screenshots).toHaveLength(3);
+    for (const screenshot of result.screenshots) expect(existsSync(screenshot)).toBeTrue();
+    expect(existsSync(result.userDataPath)).toBeFalse();
+  });
+});

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -243,6 +243,16 @@ describe('Home and shared server status', () => {
     expect(banner).toContain('getServerManagementMode($serverStatusState)');
   });
 
+  test('uses the expressive Home composition and tolerates sparse runtime metadata', () => {
+    expect(homeView).toContain('data-home-hero');
+    expect(homeView).toContain('data-home-voice-orb');
+    expect(homeView).toContain('data-home-modes');
+    expect(homeView).toContain('Your words, ready to move');
+    expect(homeView).toContain('Array.isArray(engine?.languages)');
+    expect(homeView).toContain("typeof engine?.model_size_gb === 'number'");
+    expect(homeView).not.toContain('engine.languages.length');
+  });
+
   test('preserves the frozen Eve identity and v0.8.0 version baseline', () => {
     expect(packageJson).toContain('"version": "0.8.0"');
     expect(packageJson).toContain('"appId": "io.github.burntcookiedough.eve"');


### PR DESCRIPTION
## Summary
- replace the Settings-like Home card stack with an expressive, compact voice-first hero
- keep factual readiness, engine/model metadata, Quick/Long guidance, privacy, and navigation
- tolerate sparse runtime engine metadata instead of risking a renderer failure
- add deterministic rendered coverage for ready, downloading, and error states across desktop/narrow widths and zoom

## Validation
- 179 app tests pass
- renderer/main production build passes
- screenshots inspected for ready, downloading, and error states
- no download/reload is initiated on Home mount
- no model mappings, IPC, persistence, identity, packaging, or release state changed