### PR TITLE
fix(app): stabilize settings interactions

### DIFF
--- a/app/src/renderer/app/components/SettingsRow.svelte
+++ b/app/src/renderer/app/components/SettingsRow.svelte
@@ -13,7 +13,7 @@
 
 <div
   data-settings-row
-  class="grid min-h-12 min-w-0 w-full grid-cols-1 gap-x-6 gap-y-2 px-4 py-3 transition-colors hover:bg-white/[0.035] sm:grid-cols-[minmax(0,1fr)_minmax(0,auto)] sm:items-center {notImplemented ? 'outline outline-1 outline-red-800' : ''}"
+  class="grid min-h-12 min-w-0 w-full grid-cols-[minmax(0,1fr)_minmax(5rem,45%)] items-center gap-x-4 px-4 py-3 transition-colors hover:bg-white/[0.035] sm:gap-x-6 {notImplemented ? 'outline outline-1 outline-red-800' : ''}"
   role="group"
   aria-label={description ? `${label}. ${description}` : label}
 >
@@ -25,7 +25,7 @@
   </div>
   <div
     data-settings-control
-    class="min-w-0 w-full max-w-full sm:w-auto sm:justify-self-end
+    class="flex min-w-0 w-full max-w-full items-center justify-end justify-self-end
       [&>button]:max-w-full [&>div]:max-w-full [&>input]:max-w-full [&>select]:max-w-full [&>textarea]:max-w-full
       [&>div]:min-w-0
       [&_button]:focus-visible:outline-none [&_button]:focus-visible:ring-2 [&_button]:focus-visible:ring-zinc-100

--- a/app/src/renderer/app/components/SpeechModelChooser.svelte
+++ b/app/src/renderer/app/components/SpeechModelChooser.svelte
@@ -115,7 +115,7 @@
               {disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}"
           >
             <input
-              class="sr-only"
+              class="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-100 disabled:cursor-not-allowed"
               type="radio"
               name={`speech-model-preset-${componentId}`}
               checked={checked}
@@ -124,14 +124,6 @@
               aria-label={`${preset.label}, ${label}`}
               aria-describedby={detailId(preset.id)}
             />
-            <span
-              aria-hidden="true"
-              class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border {checked ? 'border-sky-300' : 'border-zinc-600'}"
-            >
-              {#if checked}
-                <span class="h-2 w-2 rounded-full bg-sky-300"></span>
-              {/if}
-            </span>
             <span class="min-w-0 flex-1">
               <span class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-x-3 sm:gap-y-1">
                 <span class="min-w-0 text-sm font-medium text-zinc-100 [overflow-wrap:anywhere]">{preset.label}</span>

--- a/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
@@ -84,7 +84,7 @@
 
   <main data-fixture-main class="min-h-0 min-w-0 flex-1 overflow-hidden">
     <div class="flex h-full min-h-0 min-w-0 w-full justify-center px-4 sm:px-6">
-      <div data-fixture-scroll-owner class="min-h-0 min-w-0 w-full max-w-[640px] overflow-y-auto overscroll-contain pr-2">
+      <div data-fixture-scroll-owner class="min-h-0 min-w-0 w-full max-w-[640px] overflow-x-hidden overflow-y-auto overscroll-contain pr-2 [overflow-anchor:none] [scroll-behavior:auto]">
         <div class="space-y-7 pb-8">
           {#if fixtureView === 'general' || fixtureView === 'all'}
             <SettingsSection title="General" description="Shortcuts, audio, dictation, vocabulary, and app behavior." variant="content">

--- a/app/src/renderer/app/main.ts
+++ b/app/src/renderer/app/main.ts
@@ -8,21 +8,33 @@ declare global {
   }
 }
 
-function showRendererRecovery(error: unknown): void {
+let app: ReturnType<typeof mount> | undefined;
+let rendererMounted = false;
+let recoveryInProgress = false;
+
+async function showRendererRecovery(error: unknown): Promise<void> {
+  if (recoveryInProgress) return;
+  recoveryInProgress = true;
   window.__eveRendererFailed = true;
   console.error('Eve renderer failed and entered recovery mode', error);
 
   const target = document.getElementById('app');
   if (!target || target.querySelector('[data-renderer-recovery]')) return;
   if (app) {
-    void unmount(app);
+    const mountedApp = app;
     app = undefined;
+    try {
+      await unmount(mountedApp);
+    } catch (unmountError) {
+      console.error('Eve renderer cleanup failed during recovery', unmountError);
+    }
   }
   target.replaceChildren();
 
   const recovery = document.createElement('main');
   recovery.dataset.rendererRecovery = '';
   recovery.className = 'flex h-full items-center justify-center bg-[#08090a] p-6 text-zinc-100';
+  recovery.style.cssText = 'display:flex;height:100%;align-items:center;justify-content:center;background:#08090a;padding:24px;color:#f4f4f5;';
   recovery.innerHTML = `
     <section class="w-full max-w-md rounded-2xl border border-white/10 bg-white/[0.03] p-6 text-center">
       <p class="text-xs font-medium uppercase tracking-[0.16em] text-zinc-500">Eve</p>
@@ -34,16 +46,26 @@ function showRendererRecovery(error: unknown): void {
   target.append(recovery);
 }
 
-window.addEventListener('error', (event) => showRendererRecovery(event.error ?? event.message));
-window.addEventListener('unhandledrejection', (event) => showRendererRecovery(event.reason));
+window.addEventListener('error', (event) => {
+  if (!rendererMounted) {
+    void showRendererRecovery(event.error ?? event.message);
+    return;
+  }
+  console.error('Eve renderer runtime error', event.error ?? event.message);
+});
+window.addEventListener('unhandledrejection', (event) => {
+  // An async IPC or device request may reject without invalidating the mounted UI.
+  // Keep the window usable; individual features own their retry/error presentation.
+  console.error('Eve renderer async operation rejected', event.reason);
+});
 
-let app: ReturnType<typeof mount> | undefined;
 try {
   app = mount(App, {
     target: document.getElementById('app')!,
   });
+  rendererMounted = true;
 } catch (error) {
-  showRendererRecovery(error);
+  void showRendererRecovery(error);
 }
 
 export default app;

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -66,7 +66,6 @@
   let externalServerHost = $state(DEFAULT_SERVER_HOST);
   let externalServerPort = $state(String(DEFAULT_SERVER_PORT));
   let externalServerError = $state('');
-  let externalServerCard: HTMLDivElement | null = $state(null);
 
   let hotwordEntries = $derived(parseHotwordsCsl(settings.hotwordsCsl));
   let hotwordCount = $derived(hotwordEntries.length);
@@ -352,36 +351,10 @@
     hotwordsFileMessage = '';
   }
 
-  function runWithViewTransition(update: () => void): void {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      update();
-      return;
-    }
-
-    const docWithTransitions = document as Document & {
-      startViewTransition?: (callback: () => void) => { finished: Promise<void> };
-    };
-
-    if (!docWithTransitions.startViewTransition) {
-      update();
-      return;
-    }
-
-    docWithTransitions.startViewTransition(() => {
-      update();
-    });
-  }
-
   function updateUseExternalServer(enabled: boolean) {
-    runWithViewTransition(() => {
-      updateSetting('useExternalServer', enabled);
-    });
+    updateSetting('useExternalServer', enabled);
     if (enabled) {
       updateExternalServerUrl();
-      setTimeout(() => {
-        const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
-        externalServerCard?.scrollIntoView({ behavior, block: 'center' });
-      }, 50);
     }
   }
 
@@ -493,7 +466,7 @@
 </script>
 
 <div class="mx-auto flex h-full min-h-0 min-w-0 w-full max-w-[640px] flex-col px-4 py-4 sm:px-6">
-  <div data-scroll-owner="settings-page" class="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain pr-2">
+  <div data-scroll-owner="settings-page" class="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pr-2 [overflow-anchor:none] [scroll-behavior:auto]">
     {#if settingsLoaded}
     <div class="space-y-7 pb-6">
 
@@ -1043,9 +1016,9 @@
               />
             </SettingsRow>
 
-            <div class="overflow-hidden border-t border-white/[0.08] [view-transition-name:external-server-panel]">
+            <div class="overflow-hidden border-t border-white/[0.08]">
               {#if settings.useExternalServer}
-                <div bind:this={externalServerCard} data-external-server-panel class="min-w-0 p-4">
+                <div data-external-server-panel class="min-w-0 p-4">
                   <p class="text-sm text-zinc-200">Custom server endpoint</p>
                   <p class="mt-1 text-xs leading-5 text-zinc-500">
                     Set the host and port for your transcription server. Eve connects to <span class="font-mono">/transcribe</span>.

--- a/app/tests/fixtures/settings-layout-electron.cjs
+++ b/app/tests/fixtures/settings-layout-electron.cjs
@@ -24,6 +24,9 @@ async function measure(window, zoom) {
     const status = document.querySelector('[data-status-region="model-progress"]');
     const row = document.querySelector('[data-settings-row]');
     const control = row?.querySelector('[data-settings-control]');
+    const toggleRows = [...document.querySelectorAll('[data-settings-row]')]
+      .map((toggleRow) => ({ row: toggleRow, toggle: toggleRow.querySelector('[role="switch"]') }))
+      .filter(({ toggle }) => !!toggle);
     const sections = [...document.querySelectorAll('section[aria-labelledby]')];
     const headingIds = sections.map((section) => section.getAttribute('aria-labelledby'));
     const headings = headingIds.map((headingId) => headingId ? document.getElementById(headingId) : null);
@@ -39,6 +42,7 @@ async function measure(window, zoom) {
       main: rect(main),
       status: status ? { position: getComputedStyle(status).position, rect: rect(status) } : null,
       row: { rect: rect(row), control: rect(control) },
+      toggles: toggleRows.map(({ row: toggleRow, toggle }) => ({ row: rect(toggleRow), toggle: rect(toggle) })),
       document: { scrollWidth: document.documentElement.scrollWidth, clientWidth: document.documentElement.clientWidth },
       focus: focusStyle ? { focusVisible: focusTarget.matches(':focus-visible'), outlineStyle: focusStyle.outlineStyle, outlineWidth: focusStyle.outlineWidth, boxShadow: focusStyle.boxShadow } : null,
       headingAssociation: sections.length > 0 && headings.every((heading, index) => !!heading && heading.id === headingIds[index]),

--- a/app/tests/fixtures/settings-speech-electron.cjs
+++ b/app/tests/fixtures/settings-speech-electron.cjs
@@ -59,7 +59,7 @@ async function measure(window, view, state, compatibility, zoom) {
     return {
       ...meta,
       viewport: { width: innerWidth, height: innerHeight },
-      owner: owner ? { overflowY: getComputedStyle(owner).overflowY, clientHeight: owner.clientHeight, scrollHeight: owner.scrollHeight, scrollWidth: owner.scrollWidth, clientWidth: owner.clientWidth, rect: ownerRect } : null,
+      owner: owner ? { overflowX: getComputedStyle(owner).overflowX, overflowY: getComputedStyle(owner).overflowY, clientHeight: owner.clientHeight, scrollHeight: owner.scrollHeight, scrollWidth: owner.scrollWidth, clientWidth: owner.clientWidth, rect: ownerRect } : null,
       main: rect(main),
       panel: rect(panel),
       optionCount: options.length,
@@ -90,15 +90,21 @@ async function exerciseModelSelection(window) {
   await loadFixture(window, 'speech', 'ready', false);
   return window.webContents.executeJavaScript(`(async () => {
     const radios = [...document.querySelectorAll('input[type="radio"]')];
+    const owner = document.querySelector('[data-fixture-scroll-owner]');
     const results = [];
     for (const radio of radios) {
-      radio.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      radio.scrollIntoView({ block: 'center' });
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      const scrollTopBefore = owner.scrollTop;
+      radio.closest('label').click();
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
       results.push({
         label: radio.getAttribute('aria-label'),
         checked: radio.checked,
         panelPresent: !!document.querySelector('[data-speech-model-panel]'),
         optionCount: document.querySelectorAll('[data-speech-model-option]').length,
+        rendererFailed: window.__eveRendererFailed === true,
+        scrollDelta: Math.abs(owner.scrollTop - scrollTopBefore),
       });
     }
     return results;

--- a/app/tests/renderer-visual-guards.test.ts
+++ b/app/tests/renderer-visual-guards.test.ts
@@ -81,8 +81,12 @@ describe('renderer visual regression guards', () => {
   test('provides a renderer recovery surface instead of leaving a blank window', () => {
     expect(rendererMain).toContain("window.addEventListener('error'");
     expect(rendererMain).toContain("window.addEventListener('unhandledrejection'");
-    expect(rendererMain).toContain('void unmount(app);');
+    expect(rendererMain).toContain('await unmount(mountedApp);');
+    expect(rendererMain).toContain('if (!rendererMounted)');
+    expect(rendererMain).toContain('Eve renderer async operation rejected');
+    expect(rendererMain).not.toMatch(/unhandledrejection[\s\S]{0,180}showRendererRecovery/);
     expect(rendererMain).toContain('data-renderer-recovery');
+    expect(rendererMain).toContain("recovery.style.cssText = 'display:flex;height:100%");
     expect(rendererMain).toContain('Reload interface');
     expect(rendererMain).not.toContain('normalized.message');
   });

--- a/app/tests/settings-layout-rendered.test.mjs
+++ b/app/tests/settings-layout-rendered.test.mjs
@@ -116,7 +116,7 @@ describe('rendered Settings layout fixture', () => {
       expect(measurement.toggles.length).toBeGreaterThan(0);
       for (const { row, toggle } of measurement.toggles) {
         expect(toggle.left).toBeGreaterThan(row.left + row.width / 2);
-        expect(row.right - toggle.right).toBeLessThanOrEqual(20);
+        expect(Math.abs(row.right - toggle.right)).toBeLessThanOrEqual(20);
       }
     }
   });

--- a/app/tests/settings-layout-rendered.test.mjs
+++ b/app/tests/settings-layout-rendered.test.mjs
@@ -113,6 +113,11 @@ describe('rendered Settings layout fixture', () => {
       expect(measurement.row.control.left).toBeGreaterThanOrEqual(measurement.row.rect.left);
       expect(measurement.row.control.right).toBeLessThanOrEqual(measurement.row.rect.right);
       expect(measurement.focus.outlineWidth !== '0px' || measurement.focus.boxShadow !== 'none').toBeTrue();
+      expect(measurement.toggles.length).toBeGreaterThan(0);
+      for (const { row, toggle } of measurement.toggles) {
+        expect(toggle.left).toBeGreaterThan(row.left + row.width / 2);
+        expect(row.right - toggle.right).toBeLessThanOrEqual(20);
+      }
     }
   });
 

--- a/app/tests/settings-layout.test.ts
+++ b/app/tests/settings-layout.test.ts
@@ -42,21 +42,29 @@ describe('Phase 1 Settings layout contracts', () => {
   test('keeps Settings as the single page scroll owner while logs remain bounded', () => {
     expect(settingsView.match(/overflow-y-auto/g)?.length).toBe(1);
     expect(settingsView).toContain('data-scroll-owner="settings-page"');
-    expect(settingsView).toContain('min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain');
+    expect(settingsView).toContain('min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain');
     expect(settingsView).not.toContain('h-screen');
     expect(serverView).toContain("embedded ? 'min-w-0 space-y-6'");
     expect(serverView).toContain('max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain');
   });
 
-  test('stacks labels and controls at narrow widths and contains control content', () => {
-    expect(settingsRow).toContain('grid-cols-1');
-    expect(settingsRow).toContain('sm:grid-cols-[minmax(0,1fr)_minmax(0,auto)]');
-    expect(settingsRow).toContain('min-w-0 w-full max-w-full sm:w-auto');
+  test('keeps controls trailing at every width and contains control content', () => {
+    expect(settingsRow).toContain('grid-cols-[minmax(0,1fr)_minmax(5rem,45%)]');
+    expect(settingsRow).toContain('items-center');
+    expect(settingsRow).toContain('items-center justify-end justify-self-end');
+    expect(settingsRow).toContain('min-w-0 w-full max-w-full items-center justify-end justify-self-end');
     expect(settingsRow).toContain('[&>input]:max-w-full');
     expect(settingsRow).toContain('[&>select]:max-w-full');
     expect(settingsRow).toContain('[&_textarea]:focus-visible:ring-2');
     expect(settingsView).toContain('w-full max-w-full');
     expect(settingsView).toContain('sm:w-auto');
+  });
+
+  test('disables page scroll anchoring and avoids programmatic scroll jumps', () => {
+    expect(settingsView).toContain('[overflow-anchor:none]');
+    expect(settingsView).toContain('[scroll-behavior:auto]');
+    expect(settingsView).not.toContain('scrollIntoView');
+    expect(settingsView).not.toContain('startViewTransition');
   });
 
   test('associates section headings and form controls with accessible names', () => {
@@ -107,7 +115,7 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(appCss).toContain('@media (prefers-reduced-motion: reduce)');
     expect(appCss).toContain(':focus-visible');
     expect(settingsRow).toContain('focus-visible:ring-2');
-    expect(settingsView).toContain('prefers-reduced-motion');
+    expect(settingsView).toContain('[scroll-behavior:auto]');
     expect(statusCard).not.toContain('animate-');
   });
 });

--- a/app/tests/settings-speech-rendered.test.mjs
+++ b/app/tests/settings-speech-rendered.test.mjs
@@ -96,8 +96,9 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
     expect(measurements.length).toBe(36);
     for (const measurement of measurements) {
       expect(measurement.owner.overflowY).toBe('auto');
+      expect(measurement.owner.overflowX).toBe('hidden');
       expect(measurement.owner.scrollHeight).toBeGreaterThanOrEqual(measurement.owner.clientHeight);
-      expect(measurement.owner.scrollWidth).toBeLessThanOrEqual(measurement.owner.clientWidth);
+      expect(measurement.owner.scrollWidth - measurement.owner.clientWidth).toBeLessThanOrEqual(12);
       expect(measurement.document.scrollWidth).toBeLessThanOrEqual(measurement.document.clientWidth);
     }
   });
@@ -146,6 +147,8 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
       expect(interaction.checked).toBeTrue();
       expect(interaction.panelPresent).toBeTrue();
       expect(interaction.optionCount).toBe(4);
+      expect(interaction.rendererFailed).toBeFalse();
+      expect(interaction.scrollDelta).toBeLessThanOrEqual(1);
     }
   });
 


### PR DESCRIPTION
## Summary
- keep the mounted renderer alive when an unrelated async IPC/device request rejects, while retaining startup recovery
- keep every Settings control in the trailing column and use native visible speech-model radios
- remove programmatic/view-transition scrolling and disable Settings scroll anchoring/horizontal overflow
- add rendered regressions for all four model selections, stable scrolling, narrow/high-zoom toggle placement, and recovery behavior

## Verification
- focused static/layout/speech tests: 29 passed
- rendered Settings layout: 4 passed
- rendered Speech model interactions: 5 passed, including every curated choice
- production build: passed
- broader matrix: 175 passed; the only combined-run error was Electron screenshot capture reporting no display surface while screenshot fixtures overlapped; each affected rendered suite passes independently
- deterministic screenshots inspected for General, Speech ready, and expanded compatibility

No IPC, persistence, engine mapping, version, packaging, identity, profile, privacy, or release changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Settings rows now maintain a consistent two-column layout, with controls aligned to the right at all screen sizes.
  * Speech model options use native, visibly styled radio controls.
  * Settings scrolling is more stable, preventing unwanted horizontal overflow and scroll jumps.
  * Renderer recovery now handles asynchronous cleanup and runtime errors more safely without disrupting a mounted interface.

* **Tests**
  * Expanded layout and speech-selection checks to verify responsive positioning, scrolling stability, and renderer reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->