### PR TITLE
Fix public model authentication fallback

### DIFF
--- a/server/src/transcription/engines/nemotron.py
+++ b/server/src/transcription/engines/nemotron.py
@@ -7,6 +7,8 @@ import sys
 import tempfile
 import threading
 import warnings
+from contextlib import contextmanager
+from typing import Any, Iterator
 
 import numpy as np
 import soundfile as sf
@@ -21,6 +23,31 @@ logger = logging.getLogger(__name__)
 
 _NETWORK_ERROR_MARKERS = ("TLS", "SSL", "certificate", "ConnectionError", "urlopen")
 _MODEL_SIZE_GB = 2.3
+_CURATED_PUBLIC_MODELS = frozenset({"nvidia/nemotron-speech-streaming-en-0.6b"})
+_HF_TOKEN_OVERRIDE_LOCK = threading.RLock()
+
+
+@contextmanager
+def _public_model_anonymous_access(model_name: str, hf_common: Any) -> Iterator[None]:
+    """Force anonymous Hub reads only for Eve's known-public curated models.
+
+    NeMo explicitly calls ``get_token()`` and forwards the result to every Hub
+    request. A stale saved credential can therefore break an otherwise public
+    download. Returning ``False`` uses huggingface_hub's explicit anonymous
+    mode; the original token resolver is restored before leaving this scope.
+    Advanced/custom model identifiers keep NeMo's existing authentication.
+    """
+    if model_name not in _CURATED_PUBLIC_MODELS:
+        yield
+        return
+
+    with _HF_TOKEN_OVERRIDE_LOCK:
+        original_get_token = hf_common.get_hf_token
+        hf_common.get_hf_token = lambda: False
+        try:
+            yield
+        finally:
+            hf_common.get_hf_token = original_get_token
 
 
 def _iter_exception_chain(exc: BaseException) -> list[BaseException]:
@@ -170,6 +197,7 @@ class NemotronEngine:
         logging.getLogger("nv_one_logger").setLevel(logging.ERROR)
 
         import nemo.collections.asr as nemo_asr
+        from nemo.core.classes import common as nemo_common
 
         # Now that NeMo's Logger singleton exists with its handlers,
         # add blocking filters that persist across transcribe() calls.
@@ -182,7 +210,8 @@ class NemotronEngine:
         logger.info("Loading Nemotron model: %s (device=%s)", model_name, resolved_device)
 
         try:
-            self._model = nemo_asr.models.ASRModel.from_pretrained(model_name)
+            with _public_model_anonymous_access(model_name, nemo_common):
+                self._model = nemo_asr.models.ASRModel.from_pretrained(model_name)
         except Exception as exc:
             if _is_network_error(exc):
                 logger.warning(
@@ -191,7 +220,8 @@ class NemotronEngine:
                 old_val = os.environ.get("HF_HUB_OFFLINE")
                 os.environ["HF_HUB_OFFLINE"] = "1"
                 try:
-                    self._model = nemo_asr.models.ASRModel.from_pretrained(model_name)
+                    with _public_model_anonymous_access(model_name, nemo_common):
+                        self._model = nemo_asr.models.ASRModel.from_pretrained(model_name)
                 except Exception as offline_exc:
                     if preflight_cached is False:
                         update_model_download_state(

--- a/server/src/transcription/errors.py
+++ b/server/src/transcription/errors.py
@@ -33,3 +33,73 @@ class VramExhaustedError(RecoverableTranscriptionError):
             message="GPU VRAM exhausted during transcription; using last successful result.",
             last_result=last_result,
         )
+
+
+_AUTH_ERROR_MARKERS = (
+    "oauth token signature",
+    "invalid token",
+    "401 client error",
+    "unauthorized",
+)
+_REPOSITORY_ERROR_MARKERS = (
+    "repository not found",
+    "gated repo",
+    "cannot access gated repo",
+)
+_OFFLINE_ERROR_MARKERS = (
+    "outgoing traffic has been disabled",
+    "offline mode",
+    "offline mode is enabled",
+)
+_NETWORK_ERROR_MARKERS = (
+    "connectionerror",
+    "connection error",
+    "connection refused",
+    "connection reset",
+    "timed out",
+    "timeout",
+    "certificate",
+    "tls",
+    "ssl",
+)
+
+
+def _exception_text(exc: BaseException) -> str:
+    """Collect exception causes for classification without exposing them to clients."""
+    seen: set[int] = set()
+    pending: list[BaseException | None] = [exc]
+    messages: list[str] = []
+    while pending:
+        current = pending.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        messages.append(str(current))
+        pending.extend((current.__cause__, current.__context__))
+    return "\n".join(messages).lower()
+
+
+def safe_engine_preparation_message(exc: BaseException) -> str:
+    """Return a stable user-facing engine error while logs retain the raw exception."""
+    text = _exception_text(exc)
+    if any(marker in text for marker in _AUTH_ERROR_MARKERS):
+        return (
+            "Hugging Face authentication failed while preparing this model. "
+            "Check access for an Advanced model, then retry or revert."
+        )
+    if any(marker in text for marker in _REPOSITORY_ERROR_MARKERS):
+        return (
+            "The selected model repository could not be accessed. "
+            "Check its name and access requirements, then retry or revert."
+        )
+    if any(marker in text for marker in _OFFLINE_ERROR_MARKERS):
+        return (
+            "This model is not fully cached and Eve is offline. "
+            "Connect to the internet, then retry or revert."
+        )
+    if any(marker in text for marker in _NETWORK_ERROR_MARKERS):
+        return (
+            "Eve could not reach the model provider. "
+            "Check your connection, then retry or revert."
+        )
+    return "The selected speech model could not be prepared. Retry or revert and review diagnostics if it continues."

--- a/server/src/transcription/factory.py
+++ b/server/src/transcription/factory.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from transcription.base import EngineInfo, EngineSession, TranscriptionEngine
+from transcription.errors import safe_engine_preparation_message
 from transcription.vram import (
     detect_gpu_capabilities,
     estimate_max_duration_s,
@@ -438,7 +439,7 @@ class EngineManager:
 
         except Exception as e:
             logger.error("Engine swap failed: %s", e)
-            self._swap_error = str(e)
+            self._swap_error = safe_engine_preparation_message(e)
             self._pending_status = None
             self._pending_engine_id = None
             self._pending_message = None

--- a/server/tests/test_public_model_auth.py
+++ b/server/tests/test_public_model_auth.py
@@ -9,7 +9,9 @@ from transcription.errors import safe_engine_preparation_message
 
 
 def test_curated_public_model_forces_anonymous_access_and_restores_token_resolver() -> None:
-    original = lambda: "stale-saved-token"
+    def original() -> str:
+        return "stale-saved-token"
+
     hf_common = SimpleNamespace(get_hf_token=original)
 
     with _public_model_anonymous_access(
@@ -21,7 +23,9 @@ def test_curated_public_model_forces_anonymous_access_and_restores_token_resolve
 
 
 def test_custom_model_preserves_existing_hugging_face_authentication() -> None:
-    original = lambda: "private-model-token"
+    def original() -> str:
+        return "private-model-token"
+
     hf_common = SimpleNamespace(get_hf_token=original)
 
     with _public_model_anonymous_access("private-org/custom-asr", hf_common):
@@ -31,7 +35,9 @@ def test_custom_model_preserves_existing_hugging_face_authentication() -> None:
 
 
 def test_public_model_token_override_is_restored_after_failure() -> None:
-    original = lambda: "stale-saved-token"
+    def original() -> str:
+        return "stale-saved-token"
+
     hf_common = SimpleNamespace(get_hf_token=original)
 
     with pytest.raises(RuntimeError, match="download failed"):

--- a/server/tests/test_public_model_auth.py
+++ b/server/tests/test_public_model_auth.py
@@ -1,0 +1,69 @@
+"""Regression coverage for public model authentication and safe preparation errors."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from transcription.engines.nemotron import _public_model_anonymous_access
+from transcription.errors import safe_engine_preparation_message
+
+
+def test_curated_public_model_forces_anonymous_access_and_restores_token_resolver() -> None:
+    original = lambda: "stale-saved-token"
+    hf_common = SimpleNamespace(get_hf_token=original)
+
+    with _public_model_anonymous_access(
+        "nvidia/nemotron-speech-streaming-en-0.6b", hf_common
+    ):
+        assert hf_common.get_hf_token() is False
+
+    assert hf_common.get_hf_token is original
+
+
+def test_custom_model_preserves_existing_hugging_face_authentication() -> None:
+    original = lambda: "private-model-token"
+    hf_common = SimpleNamespace(get_hf_token=original)
+
+    with _public_model_anonymous_access("private-org/custom-asr", hf_common):
+        assert hf_common.get_hf_token() == "private-model-token"
+
+    assert hf_common.get_hf_token is original
+
+
+def test_public_model_token_override_is_restored_after_failure() -> None:
+    original = lambda: "stale-saved-token"
+    hf_common = SimpleNamespace(get_hf_token=original)
+
+    with pytest.raises(RuntimeError, match="download failed"):
+        with _public_model_anonymous_access(
+            "nvidia/nemotron-speech-streaming-en-0.6b", hf_common
+        ):
+            assert hf_common.get_hf_token() is False
+            raise RuntimeError("download failed")
+
+    assert hf_common.get_hf_token is original
+
+
+@pytest.mark.parametrize(
+    ("raw_error", "expected"),
+    [
+        (
+            "401 Client Error: Repository Not Found; OAuth token signature verification failed",
+            "Hugging Face authentication failed",
+        ),
+        ("Cannot access gated repo", "model repository could not be accessed"),
+        ("Outgoing traffic has been disabled", "Eve is offline"),
+        ("TLS certificate verification failed", "could not reach the model provider"),
+        ("C:/private/path/native-loader.dll exploded", "could not be prepared"),
+    ],
+)
+def test_engine_preparation_errors_are_classified_without_leaking_provider_details(
+    raw_error: str,
+    expected: str,
+) -> None:
+    message = safe_engine_preparation_message(RuntimeError(raw_error))
+
+    assert expected in message
+    assert "http" not in message.lower()
+    assert "request id" not in message.lower()
+    assert "c:/" not in message.lower()

--- a/server/tests/test_review_fixes.py
+++ b/server/tests/test_review_fixes.py
@@ -143,7 +143,10 @@ async def test_swap_engine_restores_on_failure(monkeypatch: pytest.MonkeyPatch) 
     assert manager._engine is not None
     assert manager._engine._engine_id == "whisper"
     assert manager.get_status().status == "ready"
-    assert manager.get_status().message == "Nemotron import failed"
+    assert manager.get_status().message == (
+        "The selected speech model could not be prepared. "
+        "Retry or revert and review diagnostics if it continues."
+    )
     # Should have tried nemotron, then restored whisper
     assert create_calls == ["nemotron", "whisper"]
 


### PR DESCRIPTION
## Summary
- force explicit anonymous Hugging Face access only for Eve's known-public Nemotron preset
- preserve NeMo's existing token behavior for Advanced/custom model identifiers
- sanitize engine preparation failures before they reach Settings while retaining raw details in server logs
- cover stale-token, restoration, custom-auth, and error-classification regressions

## Validation
- server full matrix: 159 passed
- Settings/model contracts: 11 passed
- focused regression matrix: 31 passed
- Python compile and git diff checks passed

## Release boundary
This does not modify the immutable public v0.8.0 tag or assets. After review and merge, package it through a separate v0.8.1 prerelease preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to curated public transcription models without requiring user authentication.
  * Preserved authentication for custom models and restored access settings after download failures.
  * Replaced technical engine-loading errors with clear, user-friendly messages.
  * Prevented provider details and private paths from appearing in error messages.

* **Tests**
  * Added coverage for public and custom model authentication behavior, failure recovery, and safe error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->