### PR TITLE
Prepare Eve v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local dictation for Windows, built as an Electron desktop client with a packaged Python transcription service.
 
-<img src="https://img.shields.io/badge/v0.8.0-orange?style=flat-square" alt="v0.8.0">
+<img src="https://img.shields.io/badge/v0.8.1-orange?style=flat-square" alt="v0.8.1">
 
 > [!IMPORTANT]
 > Current source builds use the visible **Eve** product, executable, installer, and shortcut names, the `io.github.burntcookiedough.eve` AppUserModelID, and a separate `%APPDATA%\Eve` profile. Eve v0.7.0 is public; historical v0.6.3 **Murmur** assets remain immutable. The frozen installer GUID, internal `murmur` package name, compatibility payload name, and `MURMUR_*` interfaces remain stable for upgrade compatibility. Eve does not import or delete Murmur History, settings, or other personal state.

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -25,6 +25,7 @@ const serverView = source('../src/renderer/app/views/ServerView.svelte');
 const preload = source('../src/main/preload/main.ts');
 const declarations = source('../src/renderer/global.d.ts');
 const packageJson = source('../package.json');
+const serverVersion = source('../../server/src/version.py');
 
 describe('Home and shared server status', () => {
   test('initializes one subscription, reseeds on focus, and tears down only its own listener', async () => {
@@ -253,8 +254,11 @@ describe('Home and shared server status', () => {
     expect(homeView).not.toContain('engine.languages.length');
   });
 
-  test('preserves the frozen Eve identity and v0.8.0 version baseline', () => {
-    expect(packageJson).toContain('"version": "0.8.0"');
+  test('preserves the frozen Eve identity and cross-runtime version baseline', () => {
+    const appVersion = (JSON.parse(packageJson) as { version: string }).version;
+    const backendVersion = serverVersion.match(/^SERVER_VERSION = "([^"]+)"$/m)?.[1];
+    expect(appVersion).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(appVersion).toBe(backendVersion);
     expect(packageJson).toContain('"appId": "io.github.burntcookiedough.eve"');
     expect(packageJson).toContain('"guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204"');
   });

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$ExpectedVersion = "0.8.0",
+    [string]$ExpectedVersion = "0.8.1",
     [string]$InstallerDir = "E:\EveRelease\release-prep\full-nsis-web\nsis-web",
     [string]$InstallDir = "E:\EveRelease\release-prep\smoke-install\Eve",
     [string]$BaseBranch = "trunk",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.8.0"
+version = "0.8.1"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.8.0"
+SERVER_VERSION = "0.8.1"

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "murmur"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- bump the public-model authentication hotfix release from 0.8.0 to 0.8.1 exactly once
- update all managed version surfaces and the locked server metadata
- leave v0.8.0 tag and assets immutable

## Validation
- python scripts/version.py check --tag v0.8.1
- git diff --check

This PR contains no runtime changes beyond the already-merged hotfix in #49.