### PR TITLE
Fix public Whisper model catalog authentication

### DIFF
--- a/server/src/transcription/engines/whisper.py
+++ b/server/src/transcription/engines/whisper.py
@@ -37,8 +37,14 @@ logger = logging.getLogger(__name__)
 _NETWORK_ERROR_MARKERS = ("TLS", "SSL", "certificate", "ConnectionError", "urlopen")
 _CUDA_DLL_ERROR_MARKERS = ("cublas", "cudart", "cufft", "cudnn", "cuda")
 _MODEL_REPO_PREFIX = "Systran/faster-whisper-"
-_MODEL_ALIASES = {
+# This is the authoritative catalog for every built-in Whisper choice exposed
+# through Settings. The values are Eve's known-public upstream repositories.
+_PUBLIC_BUILTIN_MODELS = {
     "large-v3-turbo": "mobiuslabsgmbh/faster-whisper-large-v3-turbo",
+    "large-v3": "Systran/faster-whisper-large-v3",
+    "medium": "Systran/faster-whisper-medium",
+    "small": "Systran/faster-whisper-small",
+    "tiny": "Systran/faster-whisper-tiny",
 }
 
 
@@ -95,9 +101,22 @@ def _resolve_repo_id(model: str) -> str | None:
         return None
     if "/" in model:
         return model
-    if model in _MODEL_ALIASES:
-        return _MODEL_ALIASES[model]
+    if model in _PUBLIC_BUILTIN_MODELS:
+        return _PUBLIC_BUILTIN_MODELS[model]
     return f"{_MODEL_REPO_PREFIX}{model}"
+
+
+def _download_repo(repo_id: str) -> str:
+    """Download curated public models anonymously and preserve custom auth.
+
+    ``huggingface_hub`` otherwise sends a saved token implicitly. A stale token
+    can make a public repository return 401, so Eve's fixed curated catalog uses
+    explicit anonymous access. Advanced/custom identifiers retain the library's
+    existing authentication behavior.
+    """
+    if repo_id in _PUBLIC_BUILTIN_MODELS.values():
+        return download_model(repo_id, use_auth_token=False)
+    return download_model(repo_id)
 
 
 def _get_cuda_active(device: str) -> bool:
@@ -243,7 +262,7 @@ class WhisperEngine:
         try:
             if repo_id and preflight_cached is False:
                 with track_huggingface_download_progress():
-                    model_source = download_model(repo_id)
+                    model_source = _download_repo(repo_id)
                 mark_model_loading()
             self._model = WhisperModel(
                 model_source,

--- a/server/tests/test_backend_hardening.py
+++ b/server/tests/test_backend_hardening.py
@@ -132,7 +132,9 @@ def test_whisper_uncached_model_reports_downloading(
 
     monkeypatch.setattr(whisper, "get_repo_cache_status", lambda _repo: cache_status)
     monkeypatch.setattr(whisper, "WhisperModel", FakeWhisperModel)
-    monkeypatch.setattr(whisper, "download_model", lambda _repo: "cache/snapshot")
+    monkeypatch.setattr(
+        whisper, "download_model", lambda _repo, **_kwargs: "cache/snapshot"
+    )
     monkeypatch.setattr(whisper, "_get_cuda_active", lambda _device: False)
 
     whisper.WhisperEngine(

--- a/server/tests/test_public_model_auth.py
+++ b/server/tests/test_public_model_auth.py
@@ -4,7 +4,9 @@ from types import SimpleNamespace
 
 import pytest
 
+from config import Settings
 from transcription.engines.nemotron import _public_model_anonymous_access
+import transcription.engines.whisper as whisper
 from transcription.errors import safe_engine_preparation_message
 
 
@@ -48,6 +50,94 @@ def test_public_model_token_override_is_restored_after_failure() -> None:
             raise RuntimeError("download failed")
 
     assert hf_common.get_hf_token is original
+
+
+@pytest.mark.parametrize(
+    ("model", "repo_id"),
+    [
+        ("large-v3-turbo", "mobiuslabsgmbh/faster-whisper-large-v3-turbo"),
+        ("large-v3", "Systran/faster-whisper-large-v3"),
+        ("medium", "Systran/faster-whisper-medium"),
+        ("small", "Systran/faster-whisper-small"),
+        ("tiny", "Systran/faster-whisper-tiny"),
+    ],
+)
+def test_public_whisper_builtin_models_resolve_to_registered_upstreams(
+    model: str, repo_id: str
+) -> None:
+    assert whisper._resolve_repo_id(model) == repo_id
+
+
+@pytest.mark.parametrize(
+    "repo_id",
+    [
+        "mobiuslabsgmbh/faster-whisper-large-v3-turbo",
+        "Systran/faster-whisper-large-v3",
+        "Systran/faster-whisper-medium",
+        "Systran/faster-whisper-small",
+        "Systran/faster-whisper-tiny",
+    ],
+)
+def test_curated_whisper_presets_force_anonymous_download(
+    repo_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, object]] = []
+
+    def fake_download(requested_repo: str, **kwargs: object) -> str:
+        calls.append((requested_repo, kwargs.get("use_auth_token")))
+        return "cache/snapshot"
+
+    monkeypatch.setattr(whisper, "download_model", fake_download)
+
+    assert whisper._download_repo(repo_id) == "cache/snapshot"
+    assert calls == [(repo_id, False)]
+
+
+def test_custom_whisper_model_preserves_existing_authentication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_download(requested_repo: str, **kwargs: object) -> str:
+        calls.append((requested_repo, kwargs))
+        return "cache/private-snapshot"
+
+    monkeypatch.setattr(whisper, "download_model", fake_download)
+
+    assert whisper._download_repo("private-org/custom-whisper") == (
+        "cache/private-snapshot"
+    )
+    assert calls == [("private-org/custom-whisper", {})]
+
+
+def test_local_whisper_path_skips_hub_resolution_and_download(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_model = tmp_path / "local-whisper-model"
+    local_model.mkdir()
+    model_sources: list[str] = []
+
+    class FakeWhisperModel:
+        def __init__(self, model_source: str, **_kwargs: object) -> None:
+            model_sources.append(model_source)
+
+    def unexpected_hub_access(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("local paths must not access the Hub")
+
+    monkeypatch.setattr(whisper, "get_repo_cache_status", unexpected_hub_access)
+    monkeypatch.setattr(whisper, "download_model", unexpected_hub_access)
+    monkeypatch.setattr(whisper, "WhisperModel", FakeWhisperModel)
+    monkeypatch.setattr(whisper, "_get_cuda_active", lambda _device: False)
+
+    whisper.WhisperEngine(
+        Settings(
+            whisper_model=str(local_model),
+            whisper_device="cpu",
+            whisper_compute_type="int8",
+        )
+    )
+
+    assert model_sources == [str(local_model)]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- register all exposed Whisper presets with their canonical public upstream repositories
- force anonymous `faster-whisper` downloads only for that registered public catalog
- preserve authenticated custom repositories, local paths, Nemotron behavior, and privacy-safe errors

## Verification
- `server/.venv/Scripts/python.exe -m pytest tests/test_public_model_auth.py tests/test_backend_hardening.py -q` (35 passed)
- `server/.venv/Scripts/python.exe -m pytest -q` (171 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Whisper model resolution for built-in models.
  * Ensured curated public models download without requiring Hugging Face authentication.
  * Preserved authentication behavior for custom repositories.
  * Improved handling of local model paths so they bypass unnecessary downloads.
* **Tests**
  * Added regression coverage for model resolution, authentication, and local-path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->