### PR TITLE
Validate engine settings against runtime capabilities

### DIFF
--- a/app/src/renderer/app/server-setting-options.ts
+++ b/app/src/renderer/app/server-setting-options.ts
@@ -1,0 +1,7 @@
+import type { ServerSettingOption } from '../../shared/types.js';
+
+export function disabledOptionReasons(options: Array<ServerSettingOption<unknown>>): string[] {
+  return options.flatMap((option) =>
+    option.disabled && option.reason ? [`${option.label}: ${option.reason}`] : [],
+  );
+}

--- a/app/src/renderer/app/server-setting-options.ts
+++ b/app/src/renderer/app/server-setting-options.ts
@@ -5,3 +5,15 @@ export function disabledOptionReasons(options: Array<ServerSettingOption<unknown
     option.disabled && option.reason ? [`${option.label}: ${option.reason}`] : [],
   );
 }
+
+export function optionsForDraftWhisperDevice(
+  options: Array<ServerSettingOption<unknown>>,
+  whisperDevice: string,
+): Array<ServerSettingOption<unknown>> {
+  return options.map((option) => {
+    const state = option.device_compatibility?.[whisperDevice];
+    return state
+      ? { ...option, disabled: state.disabled, reason: state.reason ?? undefined }
+      : option;
+  });
+}

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -11,7 +11,7 @@
   import { SPEECH_MODEL_PRESETS, hasPendingCompatibilityChanges, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../speech-model-presets';
   import { getServerManagementMode, serverStatusState } from '../server-status';
   import { serverSettingsStateKey, shouldClearServerSettings, shouldRetryServerSettings } from '../server-settings-recovery';
-  import { disabledOptionReasons } from '../server-setting-options';
+  import { disabledOptionReasons, optionsForDraftWhisperDevice } from '../server-setting-options';
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting, type ServerSettingOption } from '$shared/types';
   import { HOTWORDS_WARNING_THRESHOLD, formatHotwordsCsl, parseHotwordsCsl } from '$shared/hotwords';
@@ -97,6 +97,7 @@
   }
 
   let selectedEngine = $derived(getSettingValue<string>('engine') ?? 'nemotron');
+  let draftWhisperDevice = $derived(getSettingValue<string>('whisper_device') ?? 'auto');
   let selectedPreset = $derived(SPEECH_MODEL_PRESETS.find((preset) =>
     getSettingValue<string>('engine') === preset.engine && getSettingValue<string>(preset.setting) === preset.model
   ) ?? null);
@@ -129,6 +130,13 @@
   // Convenience: get options for a select setting
   function getOptions(key: string): Array<ServerSettingOption<unknown>> {
     return (serverSettings?.[key]?.options as Array<ServerSettingOption<unknown>>) ?? [];
+  }
+
+  function getWhisperComputeOptions(): Array<ServerSettingOption<unknown>> {
+    return optionsForDraftWhisperDevice(
+      getOptions('whisper_compute_type'),
+      draftWhisperDevice,
+    );
   }
 
   function isEngineAvailable(engineId: unknown): boolean {
@@ -848,11 +856,11 @@
               disabled={externalMode}
               class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
-              {#each getOptions('whisper_compute_type') as option}
+              {#each getWhisperComputeOptions() as option}
                 <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
               {/each}
             </select>
-            {#each disabledOptionReasons(getOptions('whisper_compute_type')) as reason}
+            {#each disabledOptionReasons(getWhisperComputeOptions()) as reason}
               <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
             {/each}
           </SettingsRow>

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -11,8 +11,9 @@
   import { SPEECH_MODEL_PRESETS, hasPendingCompatibilityChanges, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../speech-model-presets';
   import { getServerManagementMode, serverStatusState } from '../server-status';
   import { serverSettingsStateKey, shouldClearServerSettings, shouldRetryServerSettings } from '../server-settings-recovery';
+  import { disabledOptionReasons } from '../server-setting-options';
   import { toast } from '$lib/toast.svelte';
-  import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting } from '$shared/types';
+  import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting, type ServerSettingOption } from '$shared/types';
   import { HOTWORDS_WARNING_THRESHOLD, formatHotwordsCsl, parseHotwordsCsl } from '$shared/hotwords';
 
   const DEFAULT_SERVER_HOST = 'localhost';
@@ -126,8 +127,8 @@
   }
 
   // Convenience: get options for a select setting
-  function getOptions(key: string): Array<{ value: unknown; label: string; description?: string }> {
-    return (serverSettings?.[key]?.options as Array<{ value: unknown; label: string; description?: string }>) ?? [];
+  function getOptions(key: string): Array<ServerSettingOption<unknown>> {
+    return (serverSettings?.[key]?.options as Array<ServerSettingOption<unknown>>) ?? [];
   }
 
   function isEngineAvailable(engineId: unknown): boolean {
@@ -833,7 +834,7 @@
               class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
               {#each getOptions('whisper_model') as option}
-                <option value={option.value}>{option.label}</option>
+                <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
               {/each}
             </select>
           </SettingsRow>
@@ -848,9 +849,12 @@
               class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
               {#each getOptions('whisper_compute_type') as option}
-                <option value={option.value}>{option.label}</option>
+                <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
               {/each}
             </select>
+            {#each disabledOptionReasons(getOptions('whisper_compute_type')) as reason}
+              <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
+            {/each}
           </SettingsRow>
         {/if}
 
@@ -886,9 +890,12 @@
               class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
               {#each getOptions('nemotron_device') as option}
-                <option value={option.value}>{option.label}</option>
+                <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
               {/each}
             </select>
+            {#each disabledOptionReasons(getOptions('nemotron_device')) as reason}
+              <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
+            {/each}
           </SettingsRow>
         {/if}
         {#if serverSettings.whisper_device && isVisible(serverSettings.whisper_device)}
@@ -901,9 +908,12 @@
               class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
               {#each getOptions('whisper_device') as option}
-                <option value={option.value}>{option.label}</option>
+                <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
               {/each}
             </select>
+            {#each disabledOptionReasons(getOptions('whisper_device')) as reason}
+              <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
+            {/each}
           </SettingsRow>
         {/if}
         {#if serverSettings.unload_before_swap}

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -304,6 +304,7 @@ export interface ServerSettingOption<T> {
   description?: string;
   disabled?: boolean;
   reason?: string;
+  device_compatibility?: Record<string, { disabled: boolean; reason?: string | null }>;
 }
 
 export interface ServerSetting<T> {

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -298,12 +298,20 @@ export interface Settings {
 }
 
 // Server settings types (fetched from server REST API)
+export interface ServerSettingOption<T> {
+  value: T;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  reason?: string;
+}
+
 export interface ServerSetting<T> {
   value: T;
   label: string;
   description: string;
   type: 'select' | 'number' | 'bool' | 'text';
-  options?: Array<{ value: T; label: string; description?: string }>;
+  options?: Array<ServerSettingOption<T>>;
   range?: [number, number];
   requires_reload: boolean;
   category: string;

--- a/app/tests/server-setting-options.test.ts
+++ b/app/tests/server-setting-options.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { disabledOptionReasons } from '../src/renderer/app/server-setting-options.js';
+
+describe('Server setting option compatibility metadata', () => {
+  test('returns visible reasons for disabled options', () => {
+    expect(disabledOptionReasons([
+      { value: 'auto', label: 'Auto' },
+      { value: 'cuda', label: 'CUDA', disabled: true, reason: 'PyTorch CUDA is unavailable.' },
+    ])).toEqual(['CUDA: PyTorch CUDA is unavailable.']);
+  });
+
+  test('accepts metadata from older servers without disabled fields', () => {
+    expect(disabledOptionReasons([
+      { value: 'cpu', label: 'CPU' },
+    ])).toEqual([]);
+  });
+
+  test('renders disabled options and their reasons in compatibility selects', () => {
+    const settingsView = readFileSync(
+      new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url),
+      'utf8',
+    );
+
+    expect(settingsView).toContain('disabled={option.disabled}');
+    expect(settingsView).toContain('data-setting-option-reason');
+    expect(settingsView).toContain("disabledOptionReasons(getOptions('whisper_compute_type'))");
+    expect(settingsView).toContain("disabledOptionReasons(getOptions('whisper_device'))");
+    expect(settingsView).toContain("disabledOptionReasons(getOptions('nemotron_device'))");
+  });
+});

--- a/app/tests/server-setting-options.test.ts
+++ b/app/tests/server-setting-options.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
-import { disabledOptionReasons } from '../src/renderer/app/server-setting-options.js';
+import {
+  disabledOptionReasons,
+  optionsForDraftWhisperDevice,
+} from '../src/renderer/app/server-setting-options.js';
 
 describe('Server setting option compatibility metadata', () => {
   test('returns visible reasons for disabled options', () => {
@@ -16,6 +19,37 @@ describe('Server setting option compatibility metadata', () => {
     ])).toEqual([]);
   });
 
+  test.each([
+    ['cpu', true, true],
+    ['cuda', false, false],
+  ])('uses the draft %s device for precision availability', (device, float16Disabled, mixedDisabled) => {
+    const options = optionsForDraftWhisperDevice([
+      {
+        value: 'float16',
+        label: 'Float16',
+        disabled: true,
+        reason: 'Not supported by CTranslate2 on cpu.',
+        device_compatibility: {
+          cpu: { disabled: true, reason: 'Not supported by CTranslate2 on cpu.' },
+          cuda: { disabled: false },
+        },
+      },
+      {
+        value: 'int8_float16',
+        label: 'Int8+Float16',
+        disabled: true,
+        reason: 'Not supported by CTranslate2 on cpu.',
+        device_compatibility: {
+          cpu: { disabled: true, reason: 'Not supported by CTranslate2 on cpu.' },
+          cuda: { disabled: false },
+        },
+      },
+    ], device);
+
+    expect(options[0].disabled).toBe(float16Disabled);
+    expect(options[1].disabled).toBe(mixedDisabled);
+  });
+
   test('renders disabled options and their reasons in compatibility selects', () => {
     const settingsView = readFileSync(
       new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url),
@@ -24,7 +58,8 @@ describe('Server setting option compatibility metadata', () => {
 
     expect(settingsView).toContain('disabled={option.disabled}');
     expect(settingsView).toContain('data-setting-option-reason');
-    expect(settingsView).toContain("disabledOptionReasons(getOptions('whisper_compute_type'))");
+    expect(settingsView).toContain('getWhisperComputeOptions()');
+    expect(settingsView).toContain("disabledOptionReasons(getWhisperComputeOptions())");
     expect(settingsView).toContain("disabledOptionReasons(getOptions('whisper_device'))");
     expect(settingsView).toContain("disabledOptionReasons(getOptions('nemotron_device'))");
   });

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -35,6 +35,15 @@ logger = logging.getLogger(__name__)
 _engine_tasks: set[asyncio.Task[None]] = set()
 
 
+def _safe_settings_validation_detail(error: ValidationError) -> str:
+    """Return a concise validation message without echoing submitted values."""
+    errors = error.errors()
+    if not errors:
+        return "Invalid settings."
+    message = str(errors[0].get("msg", "Invalid settings."))
+    return message.removeprefix("Value error, ")
+
+
 def _schedule_engine_swap(engine_mgr: Any, settings: Settings) -> asyncio.Task[None]:
     """Keep background engine loads alive and observe their completion."""
     task = asyncio.create_task(_swap_engine_background(engine_mgr, settings))
@@ -173,7 +182,9 @@ def create_app() -> FastAPI:
         try:
             new_settings = update_settings(patch)
         except ValidationError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
+            raise HTTPException(
+                status_code=400, detail=_safe_settings_validation_detail(e)
+            ) from e
         engine_mgr = get_engine_manager()
 
         reload_started = False

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -122,7 +122,9 @@ class Settings(BaseSettings):
 
     @field_validator("whisper_language", mode="before")
     @classmethod
-    def normalize_language(cls, value: str | None) -> str | None:
+    def normalize_language(cls, value: Any) -> str | None:
+        if value is not None and not isinstance(value, str):
+            raise ValueError("Whisper language must be a string or null.")
         return normalize_whisper_language(value)
 
     @model_validator(mode="after")
@@ -379,6 +381,20 @@ def get_settings_with_metadata(settings: Settings) -> dict[str, Any]:
             if disabled:
                 option_data["disabled"] = True
                 option_data["reason"] = reason
+            if key == "whisper_compute_type":
+                option_data["device_compatibility"] = {}
+                for device in ("auto", "cpu", "cuda"):
+                    device_disabled, device_reason = option_compatibility(
+                        key,
+                        str(option["value"]),
+                        capabilities,
+                        settings,
+                        whisper_device=device,
+                    )
+                    option_data["device_compatibility"][device] = {
+                        "disabled": device_disabled,
+                        "reason": device_reason,
+                    }
             options.append(option_data)
         result[key] = {
             "value": values[key],

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -9,8 +9,15 @@ from pathlib import Path
 import tempfile
 from typing import Any, Literal
 
-from pydantic import Field, ValidationError
+from pydantic import Field, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from engine_compatibility import (
+    get_runtime_capabilities,
+    normalize_whisper_language,
+    option_compatibility,
+    validate_engine_compatibility,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +34,14 @@ def _load_settings_json() -> dict[str, Any]:
     settings_file = get_settings_file_path()
     if settings_file.exists():
         try:
-            return json.loads(settings_file.read_text(encoding="utf-8"))
+            values = json.loads(settings_file.read_text(encoding="utf-8"))
+            if not isinstance(values, dict):
+                logger.warning("Settings file must contain a JSON object")
+                return {}
+            if values.get("whisper_compute_type") == "int16":
+                values["whisper_compute_type"] = "auto"
+                logger.warning("Migrated legacy Whisper int16 precision setting to auto")
+            return values
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to read settings.json: %s", e)
     return {}
@@ -74,7 +88,7 @@ class Settings(BaseSettings):
     whisper_model: str = "large-v3-turbo"
     whisper_device: Literal["auto", "cpu", "cuda"] = "auto"
     whisper_compute_type: Literal[
-        "auto", "int8", "int8_float16", "int16", "float16", "float32"
+        "auto", "int8", "int8_float16", "float16", "float32"
     ] = "auto"
     whisper_language: str | None = "en"
     whisper_beam_size: int = Field(default=1, ge=1, le=10)
@@ -105,6 +119,21 @@ class Settings(BaseSettings):
     # Logging
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
     log_binary: bool = False
+
+    @field_validator("whisper_language", mode="before")
+    @classmethod
+    def normalize_language(cls, value: str | None) -> str | None:
+        return normalize_whisper_language(value)
+
+    @model_validator(mode="after")
+    def validate_runtime_compatibility(self) -> Settings:
+        validate_engine_compatibility(
+            whisper_device=self.whisper_device,
+            whisper_compute_type=self.whisper_compute_type,
+            nemotron_device=self.nemotron_device,
+            capabilities=get_runtime_capabilities(),
+        )
+        return self
 
 
 # Settings metadata for dynamic UI rendering
@@ -339,10 +368,22 @@ PERSISTED_INTERNAL_KEYS: set[str] = set()
 def get_settings_with_metadata(settings: Settings) -> dict[str, Any]:
     values = settings.model_dump()
     result = {}
+    capabilities = get_runtime_capabilities()
     for key, meta in SETTINGS_METADATA.items():
+        options = []
+        for option in meta.get("options", []):
+            option_data = dict(option)
+            disabled, reason = option_compatibility(
+                key, str(option["value"]), capabilities, settings
+            )
+            if disabled:
+                option_data["disabled"] = True
+                option_data["reason"] = reason
+            options.append(option_data)
         result[key] = {
             "value": values[key],
             **meta,
+            **({"options": options} if "options" in meta else {}),
         }
     return result
 

--- a/server/src/engine_compatibility.py
+++ b/server/src/engine_compatibility.py
@@ -1,0 +1,187 @@
+"""Bounded runtime capability checks for engine settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ComputeCapability:
+    """Supported compute types for one CTranslate2 device."""
+
+    compute_types: frozenset[str] | None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeCapabilities:
+    """Compatibility facts discovered without loading a model."""
+
+    whisper_cpu: ComputeCapability
+    whisper_cuda: ComputeCapability
+    nemotron_cuda_available: bool
+    nemotron_cuda_reason: str | None = None
+
+    @property
+    def whisper_cuda_available(self) -> bool:
+        return bool(self.whisper_cuda.compute_types)
+
+    def whisper_device_for(self, requested_device: str) -> str:
+        if requested_device == "auto" and self.whisper_cuda_available:
+            return "cuda"
+        return "cpu" if requested_device == "auto" else requested_device
+
+
+def _load_ctranslate2() -> Any:
+    import ctranslate2
+
+    return ctranslate2
+
+
+def _load_torch() -> Any:
+    import torch
+
+    return torch
+
+
+def _probe_compute_types(runtime: Any, device: str) -> ComputeCapability:
+    try:
+        compute_types = frozenset(runtime.get_supported_compute_types(device))
+    except Exception:
+        return ComputeCapability(
+            None, "CTranslate2 capability check failed for this device."
+        )
+    if not compute_types:
+        return ComputeCapability(
+            None, "CTranslate2 reported no supported compute types for this device."
+        )
+    return ComputeCapability(compute_types)
+
+
+def get_runtime_capabilities() -> RuntimeCapabilities:
+    """Probe installed runtimes only; never load or download model data."""
+    try:
+        ctranslate2 = _load_ctranslate2()
+    except Exception:
+        whisper_cpu = ComputeCapability(None, "CTranslate2 runtime is unavailable.")
+        whisper_cuda = ComputeCapability(None, "CTranslate2 runtime is unavailable.")
+    else:
+        whisper_cpu = _probe_compute_types(ctranslate2, "cpu")
+        try:
+            cuda_count = ctranslate2.get_cuda_device_count()
+        except Exception:
+            whisper_cuda = ComputeCapability(
+                None, "CTranslate2 CUDA capability check failed."
+            )
+        else:
+            if cuda_count < 1:
+                whisper_cuda = ComputeCapability(
+                    None, "CTranslate2 did not find a usable CUDA device."
+                )
+            else:
+                whisper_cuda = _probe_compute_types(ctranslate2, "cuda")
+
+    try:
+        torch = _load_torch()
+        nemotron_cuda_available = bool(torch.cuda.is_available())
+    except Exception:
+        nemotron_cuda_available = False
+        nemotron_cuda_reason = "PyTorch CUDA support is unavailable."
+    else:
+        nemotron_cuda_reason = (
+            None if nemotron_cuda_available else "PyTorch did not find a usable CUDA device."
+        )
+
+    return RuntimeCapabilities(
+        whisper_cpu=whisper_cpu,
+        whisper_cuda=whisper_cuda,
+        nemotron_cuda_available=nemotron_cuda_available,
+        nemotron_cuda_reason=nemotron_cuda_reason,
+    )
+
+
+def get_whisper_language_codes() -> frozenset[str] | None:
+    """Return Faster-Whisper's installed language codes when available."""
+    try:
+        from faster_whisper.tokenizer import _LANGUAGE_CODES
+    except Exception:
+        return None
+    return frozenset(_LANGUAGE_CODES)
+
+
+def normalize_whisper_language(value: str | None) -> str | None:
+    """Normalize a manual language code, preserving blank auto-detection."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    language_codes = get_whisper_language_codes()
+    if language_codes is not None and normalized not in language_codes:
+        raise ValueError("Unsupported Whisper language code.")
+    return normalized
+
+
+def validate_engine_compatibility(
+    *,
+    whisper_device: str,
+    whisper_compute_type: str,
+    nemotron_device: str,
+    capabilities: RuntimeCapabilities,
+) -> None:
+    """Reject explicit settings that the currently installed runtimes cannot use."""
+    if whisper_device == "cuda" and not capabilities.whisper_cuda_available:
+        raise ValueError(capabilities.whisper_cuda.reason or "Whisper CUDA is unavailable.")
+
+    if nemotron_device == "cuda" and not capabilities.nemotron_cuda_available:
+        raise ValueError(capabilities.nemotron_cuda_reason or "Nemotron CUDA is unavailable.")
+
+    if whisper_compute_type == "auto":
+        return
+
+    effective_device = capabilities.whisper_device_for(whisper_device)
+    capability = (
+        capabilities.whisper_cuda
+        if effective_device == "cuda"
+        else capabilities.whisper_cpu
+    )
+    if capability.compute_types is None:
+        raise ValueError(capability.reason or "Whisper precision capability is unavailable.")
+    if whisper_compute_type not in capability.compute_types:
+        raise ValueError(
+            f"Whisper precision {whisper_compute_type} is not supported on {effective_device}."
+        )
+
+
+def option_compatibility(
+    key: str, value: str, capabilities: RuntimeCapabilities, settings: Any
+) -> tuple[bool, str | None]:
+    """Return UI option state using the same facts as server-side validation."""
+    if key == "whisper_device" and value == "cuda":
+        return (
+            not capabilities.whisper_cuda_available,
+            capabilities.whisper_cuda.reason,
+        )
+    if key == "nemotron_device" and value == "cuda":
+        return (
+            not capabilities.nemotron_cuda_available,
+            capabilities.nemotron_cuda_reason,
+        )
+    if key != "whisper_compute_type" or value == "auto":
+        return False, None
+
+    effective_device = capabilities.whisper_device_for(settings.whisper_device)
+    capability = (
+        capabilities.whisper_cuda
+        if effective_device == "cuda"
+        else capabilities.whisper_cpu
+    )
+    if capability.compute_types is None:
+        return True, capability.reason
+    if value not in capability.compute_types:
+        return (
+            True,
+            f"Not supported by CTranslate2 on {effective_device}.",
+        )
+    return False, None

--- a/server/src/engine_compatibility.py
+++ b/server/src/engine_compatibility.py
@@ -155,7 +155,12 @@ def validate_engine_compatibility(
 
 
 def option_compatibility(
-    key: str, value: str, capabilities: RuntimeCapabilities, settings: Any
+    key: str,
+    value: str,
+    capabilities: RuntimeCapabilities,
+    settings: Any,
+    *,
+    whisper_device: str | None = None,
 ) -> tuple[bool, str | None]:
     """Return UI option state using the same facts as server-side validation."""
     if key == "whisper_device" and value == "cuda":
@@ -171,7 +176,9 @@ def option_compatibility(
     if key != "whisper_compute_type" or value == "auto":
         return False, None
 
-    effective_device = capabilities.whisper_device_for(settings.whisper_device)
+    effective_device = capabilities.whisper_device_for(
+        whisper_device or settings.whisper_device
+    )
     capability = (
         capabilities.whisper_cuda
         if effective_device == "cuda"

--- a/server/tests/test_engine_compatibility.py
+++ b/server/tests/test_engine_compatibility.py
@@ -1,0 +1,218 @@
+"""Regression coverage for runtime-derived engine compatibility."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+import app as server_app
+import config
+import engine_compatibility as compatibility
+from engine_compatibility import ComputeCapability, RuntimeCapabilities
+
+
+def _capabilities(
+    *,
+    cpu: frozenset[str] | None = frozenset({"int8", "float32"}),
+    cuda: frozenset[str] | None = None,
+    cpu_reason: str | None = None,
+    cuda_reason: str | None = "CTranslate2 did not find a usable CUDA device.",
+    nemotron_cuda: bool = False,
+) -> RuntimeCapabilities:
+    return RuntimeCapabilities(
+        whisper_cpu=ComputeCapability(cpu, cpu_reason),
+        whisper_cuda=ComputeCapability(cuda, cuda_reason),
+        nemotron_cuda_available=nemotron_cuda,
+        nemotron_cuda_reason=(
+            None if nemotron_cuda else "PyTorch did not find a usable CUDA device."
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(config, "_settings", None)
+    yield
+    config._settings = None
+
+
+@pytest.mark.parametrize(
+    ("compute_type", "valid"),
+    [
+        ("auto", True),
+        ("int8", True),
+        ("float32", True),
+        ("float16", False),
+        ("int8_float16", False),
+    ],
+)
+def test_cpu_precision_uses_ctranslate2_capabilities(
+    compute_type: str, valid: bool
+) -> None:
+    capabilities = _capabilities()
+    kwargs = {
+        "whisper_device": "cpu",
+        "whisper_compute_type": compute_type,
+        "nemotron_device": "cpu",
+        "capabilities": capabilities,
+    }
+
+    if valid:
+        compatibility.validate_engine_compatibility(**kwargs)
+    else:
+        with pytest.raises(ValueError, match="not supported on cpu"):
+            compatibility.validate_engine_compatibility(**kwargs)
+
+
+def test_cuda_device_and_precision_follow_available_capabilities() -> None:
+    capabilities = _capabilities(
+        cuda=frozenset({"int8", "float16", "int8_float16", "float32"}),
+        cuda_reason=None,
+        nemotron_cuda=True,
+    )
+
+    compatibility.validate_engine_compatibility(
+        whisper_device="cuda",
+        whisper_compute_type="float16",
+        nemotron_device="cuda",
+        capabilities=capabilities,
+    )
+
+    unavailable = _capabilities()
+    with pytest.raises(ValueError, match="CTranslate2 did not find a usable CUDA device"):
+        compatibility.validate_engine_compatibility(
+            whisper_device="cuda",
+            whisper_compute_type="auto",
+            nemotron_device="cpu",
+            capabilities=unavailable,
+        )
+    with pytest.raises(ValueError, match="PyTorch did not find a usable CUDA device"):
+        compatibility.validate_engine_compatibility(
+            whisper_device="cpu",
+            whisper_compute_type="auto",
+            nemotron_device="cuda",
+            capabilities=unavailable,
+        )
+
+
+def test_probe_failure_disables_explicit_precision_with_a_clean_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed_runtime = SimpleNamespace(
+        get_supported_compute_types=lambda _device: (_ for _ in ()).throw(RuntimeError()),
+        get_cuda_device_count=lambda: 0,
+    )
+    monkeypatch.setattr(compatibility, "_load_ctranslate2", lambda: failed_runtime)
+    monkeypatch.setattr(compatibility, "_load_torch", lambda: SimpleNamespace(cuda=SimpleNamespace(is_available=lambda: False)))
+
+    capabilities = compatibility.get_runtime_capabilities()
+    disabled, reason = compatibility.option_compatibility(
+        "whisper_compute_type", "int8", capabilities, SimpleNamespace(whisper_device="cpu")
+    )
+
+    assert disabled is True
+    assert reason == "CTranslate2 capability check failed for this device."
+    with pytest.raises(ValueError, match="CTranslate2 capability check failed"):
+        compatibility.validate_engine_compatibility(
+            whisper_device="cpu",
+            whisper_compute_type="int8",
+            nemotron_device="cpu",
+            capabilities=capabilities,
+        )
+
+
+def test_whisper_language_normalizes_blank_and_rejects_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        compatibility, "get_whisper_language_codes", lambda: frozenset({"en", "de"})
+    )
+
+    assert compatibility.normalize_whisper_language(" En ") == "en"
+    assert compatibility.normalize_whisper_language("   ") is None
+    with pytest.raises(ValueError, match="Unsupported Whisper language code"):
+        compatibility.normalize_whisper_language("english")
+
+
+def test_legacy_int16_is_narrowly_migrated_without_resetting_other_settings(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(
+        json.dumps({"whisper_compute_type": "int16", "whisper_model": "tiny"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MURMUR_SETTINGS_FILE", str(settings_file))
+    monkeypatch.setattr(config, "get_runtime_capabilities", lambda: _capabilities())
+
+    settings = config.get_settings()
+
+    assert settings.whisper_compute_type == "auto"
+    assert settings.whisper_model == "tiny"
+
+
+def test_invalid_patch_does_not_persist_or_schedule_a_swap(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings_file = tmp_path / "settings.json"
+    original = {"whisper_compute_type": "int8"}
+    settings_file.write_text(json.dumps(original), encoding="utf-8")
+    monkeypatch.setenv("MURMUR_SETTINGS_FILE", str(settings_file))
+    monkeypatch.setattr(config, "get_runtime_capabilities", lambda: _capabilities())
+    monkeypatch.setattr(
+        server_app, "discover_engines", lambda: [{"id": "whisper", "available": True}]
+    )
+    swaps: list[object] = []
+    monkeypatch.setattr(server_app, "_schedule_engine_swap", lambda *args: swaps.append(args))
+    handler = next(
+        route.endpoint
+        for route in server_app.create_app().routes
+        if getattr(route, "path", None) == "/settings" and "PATCH" in route.methods
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        import asyncio
+
+        asyncio.run(handler({"whisper_compute_type": "float16"}))
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Whisper precision float16 is not supported on cpu."
+    assert config.get_settings().whisper_compute_type == "int8"
+    assert json.loads(settings_file.read_text(encoding="utf-8")) == original
+    assert swaps == []
+
+
+def test_metadata_marks_the_same_cpu_precision_as_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "get_runtime_capabilities", lambda: _capabilities())
+    settings = config.Settings(
+        whisper_device="cpu", whisper_compute_type="int8", nemotron_device="cpu"
+    )
+
+    metadata = config.get_settings_with_metadata(settings)
+    float16 = next(
+        option
+        for option in metadata["whisper_compute_type"]["options"]
+        if option["value"] == "float16"
+    )
+
+    assert float16 == {
+        "value": "float16",
+        "label": "Float16",
+        "disabled": True,
+        "reason": "Not supported by CTranslate2 on cpu.",
+    }
+
+
+def test_hidden_legacy_int16_is_rejected_for_new_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "get_runtime_capabilities", lambda: _capabilities())
+
+    with pytest.raises(ValidationError):
+        config.update_settings({"whisper_compute_type": "int16"})

--- a/server/tests/test_engine_compatibility.py
+++ b/server/tests/test_engine_compatibility.py
@@ -138,6 +138,15 @@ def test_whisper_language_normalizes_blank_and_rejects_unknown(
         compatibility.normalize_whisper_language("english")
 
 
+def test_whisper_language_rejects_non_string_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "get_runtime_capabilities", lambda: _capabilities())
+
+    with pytest.raises(ValidationError, match="Whisper language must be a string or null"):
+        config.Settings(whisper_language=123)
+
+
 def test_legacy_int16_is_narrowly_migrated_without_resetting_other_settings(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -206,6 +215,20 @@ def test_metadata_marks_the_same_cpu_precision_as_disabled(
         "label": "Float16",
         "disabled": True,
         "reason": "Not supported by CTranslate2 on cpu.",
+        "device_compatibility": {
+            "auto": {
+                "disabled": True,
+                "reason": "Not supported by CTranslate2 on cpu.",
+            },
+            "cpu": {
+                "disabled": True,
+                "reason": "Not supported by CTranslate2 on cpu.",
+            },
+            "cuda": {
+                "disabled": True,
+                "reason": "CTranslate2 did not find a usable CUDA device.",
+            },
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- derive Whisper and Nemotron device/precision compatibility from installed runtimes
- normalize and validate Whisper language codes before persistence or engine swaps
- expose disabled compatibility options with concise UI reasons while keeping server validation authoritative

## Verification
- `server/.venv/Scripts/python.exe -m pytest -q` (183 passed)
- focused app settings/UI tests and `bun run test:history` passed
- `bun run build` passed
- local full `bun test` stalled without output; CI should run the canonical app matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now identify unavailable engine, device, compute, and language options.
  * Disabled choices display explanations through tooltips and warnings.
  * Whisper language codes are normalized automatically.
  * Legacy Whisper precision settings are migrated to supported defaults.

* **Bug Fixes**
  * Settings validation prevents incompatible engine configurations.
  * Error responses no longer expose submitted setting values.
  * Invalid or malformed saved settings are handled more safely.

* **Tests**
  * Added coverage for compatibility detection, disabled options, migrations, language handling, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->