### PR TITLE
Fix transactional model switching

### DIFF
--- a/app/src/renderer/app/engine-settings-transaction.ts
+++ b/app/src/renderer/app/engine-settings-transaction.ts
@@ -1,0 +1,16 @@
+import type { EngineStatus } from '../../shared/types.js';
+
+export function shouldRefreshCommittedSettings(
+  pending: Record<string, unknown>,
+  preparationRequested: boolean,
+  preparationObserved: boolean,
+  preparationFailed: boolean,
+  status: EngineStatus | null,
+): boolean {
+  return preparationRequested
+    && preparationObserved
+    && !preparationFailed
+    && Object.keys(pending).length > 0
+    && status?.status === 'ready'
+    && !status.pending;
+}

--- a/app/src/renderer/app/engine-settings-transaction.ts
+++ b/app/src/renderer/app/engine-settings-transaction.ts
@@ -1,5 +1,11 @@
 import type { EngineStatus } from '../../shared/types.js';
 
+export function shouldDisableEngineRevert(
+  preparationActive: boolean,
+): boolean {
+  return preparationActive;
+}
+
 export function shouldRefreshCommittedSettings(
   pending: Record<string, unknown>,
   preparationRequested: boolean,

--- a/app/src/renderer/app/engine-settings-transaction.ts
+++ b/app/src/renderer/app/engine-settings-transaction.ts
@@ -1,5 +1,17 @@
 import type { EngineStatus } from '../../shared/types.js';
 
+export type EnginePreparationPhase = 'preparing' | 'failed' | 'ready' | 'unknown';
+
+export function enginePreparationPhase(
+  status: EngineStatus | null,
+): EnginePreparationPhase {
+  if (!status) return 'unknown';
+  if (status.status === 'error' || status.pending?.status === 'error' || status.message) return 'failed';
+  if (status.status === 'loading' || status.pending) return 'preparing';
+  if (status.status === 'ready') return 'ready';
+  return 'unknown';
+}
+
 export function shouldDisableEngineRevert(
   preparationActive: boolean,
 ): boolean {

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -12,7 +12,7 @@
   import { getServerManagementMode, serverStatusState } from '../server-status';
   import { serverSettingsStateKey, shouldClearServerSettings, shouldRetryServerSettings } from '../server-settings-recovery';
   import { disabledOptionReasons, optionsForDraftWhisperDevice } from '../server-setting-options';
-  import { shouldDisableEngineRevert, shouldRefreshCommittedSettings } from '../engine-settings-transaction';
+  import { enginePreparationPhase, shouldDisableEngineRevert, shouldRefreshCommittedSettings } from '../engine-settings-transaction';
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting, type ServerSettingOption } from '$shared/types';
   import { HOTWORDS_WARNING_THRESHOLD, formatHotwordsCsl, parseHotwordsCsl } from '$shared/hotwords';
@@ -91,7 +91,7 @@
   // Local engine settings (track pending changes before apply)
   let pendingEngine = $state<Record<string, unknown>>({});
   let sharedServerState = $derived($serverStatusState.state);
-  let sharedEngineStatus = $derived(sharedServerState?.engineStatus ?? engineStatus);
+  let sharedEngineStatus = $derived(engineStatus ?? sharedServerState?.engineStatus ?? null);
   let externalMode = $derived(settings.useExternalServer || getServerManagementMode($serverStatusState) === 'external');
 
   // Derive current values (server value overridden by pending)
@@ -108,8 +108,8 @@
   ) ?? null);
   let stagedPreset = $derived(stagedPresetFromPending(pendingEngine));
   let preparationFailed = $derived(
-    !!sharedEngineStatus?.message || sharedEngineStatus?.status === 'error' || sharedEngineStatus?.pending?.status === 'error' ||
-    (stagedPreset !== null && sharedServerState?.modelDownload?.model === stagedPreset.model && sharedServerState.modelDownload.status === 'error')
+    enginePreparationPhase(sharedEngineStatus) === 'failed' ||
+    (!enginePreparationActive && stagedPreset !== null && sharedServerState?.modelDownload?.model === stagedPreset.model && sharedServerState.modelDownload.status === 'error')
   );
   let engineRevertDisabled = $derived(shouldDisableEngineRevert(enginePreparationActive));
 
@@ -340,6 +340,10 @@
       return;
     }
 
+    if (state?.engineStatus) {
+      engineStatus = state.engineStatus;
+    }
+
     if (shouldRetryServerSettings(state, serverConnected, serverSettingsLoading, lastServerSettingsAttemptKey)) {
       lastServerSettingsAttemptKey = serverSettingsStateKey(state);
       void loadServerSettings();
@@ -467,6 +471,9 @@
         enginePreparationRequested = true;
         enginePreparationActive = true;
         enginePreparationObserved = response.engine_status.status === 'loading' || !!response.engine_status.pending;
+        if (!enginePreparationObserved) {
+          await confirmEnginePreparationStatus();
+        }
       } else if (response.engine_status.status === 'ready' && !response.engine_status.pending) {
         pendingEngine = {};
       }
@@ -475,6 +482,32 @@
       engineApplyError = error instanceof Error ? error.message : 'Failed to apply engine settings.';
     } finally {
       engineApplying = false;
+    }
+  }
+
+  async function confirmEnginePreparationStatus(): Promise<void> {
+    if (!(await loadServerSettings())) return;
+
+    const phase = enginePreparationPhase(engineStatus);
+    if (phase === 'preparing') {
+      enginePreparationObserved = true;
+      return;
+    }
+    if (phase === 'failed') {
+      enginePreparationActive = false;
+      engineApplyError = engineStatus?.pending?.message ?? engineStatus?.message ?? 'Engine reload failed.';
+      return;
+    }
+    if (phase === 'ready') {
+      const candidateCommitted = Object.entries(pendingEngine).every(
+        ([key, value]) => serverSettings?.[key]?.value === value,
+      );
+      if (!candidateCommitted) return;
+      pendingEngine = {};
+      enginePreparationRequested = false;
+      enginePreparationActive = false;
+      enginePreparationObserved = false;
+      engineApplyError = '';
     }
   }
 

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -12,7 +12,7 @@
   import { getServerManagementMode, serverStatusState } from '../server-status';
   import { serverSettingsStateKey, shouldClearServerSettings, shouldRetryServerSettings } from '../server-settings-recovery';
   import { disabledOptionReasons, optionsForDraftWhisperDevice } from '../server-setting-options';
-  import { shouldRefreshCommittedSettings } from '../engine-settings-transaction';
+  import { shouldDisableEngineRevert, shouldRefreshCommittedSettings } from '../engine-settings-transaction';
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting, type ServerSettingOption } from '$shared/types';
   import { HOTWORDS_WARNING_THRESHOLD, formatHotwordsCsl, parseHotwordsCsl } from '$shared/hotwords';
@@ -82,6 +82,7 @@
   let compatibilityControlsOpen = $state(false);
   let engineApplying = $state(false);
   let enginePreparationRequested = $state(false);
+  let enginePreparationActive = $state(false);
   let enginePreparationObserved = $state(false);
   let refreshingCommittedSettings = $state(false);
   let availableEngines = $state<string[]>([]);
@@ -110,6 +111,7 @@
     !!sharedEngineStatus?.message || sharedEngineStatus?.status === 'error' || sharedEngineStatus?.pending?.status === 'error' ||
     (stagedPreset !== null && sharedServerState?.modelDownload?.model === stagedPreset.model && sharedServerState.modelDownload.status === 'error')
   );
+  let engineRevertDisabled = $derived(shouldDisableEngineRevert(enginePreparationActive));
 
   // Whether the current engine supports hotwords (Whisper: yes, Nemotron: no)
   let hotwordsSupported = $derived(sharedEngineStatus?.info?.supports_hotwords ?? true);
@@ -440,8 +442,10 @@
   }
 
   function revertEngineSettings(): void {
+    if (enginePreparationActive) return;
     pendingEngine = {};
     enginePreparationRequested = false;
+    enginePreparationActive = false;
     enginePreparationObserved = false;
     engineApplyError = '';
     void loadServerSettings();
@@ -461,6 +465,7 @@
       availableEngines = response.available_engines ?? availableEngines;
       if (response.reload_started) {
         enginePreparationRequested = true;
+        enginePreparationActive = true;
         enginePreparationObserved = response.engine_status.status === 'loading' || !!response.engine_status.pending;
       } else if (response.engine_status.status === 'ready' && !response.engine_status.pending) {
         pendingEngine = {};
@@ -474,11 +479,13 @@
   }
 
   $effect(() => {
-    if (enginePreparationRequested && (sharedEngineStatus?.status === 'loading' || !!sharedEngineStatus?.pending)) {
+    if (enginePreparationActive && (sharedEngineStatus?.status === 'loading' || !!sharedEngineStatus?.pending)) {
       enginePreparationObserved = true;
     }
     if (Object.keys(pendingEngine).length === 0) return;
     if (preparationFailed) {
+      if (enginePreparationActive && !enginePreparationObserved) return;
+      enginePreparationActive = false;
       engineApplyError = sharedEngineStatus?.pending?.message ?? sharedEngineStatus?.message ?? 'Engine reload failed.';
       return;
     }
@@ -500,6 +507,7 @@
       if (await loadServerSettings()) {
         pendingEngine = {};
         enginePreparationRequested = false;
+        enginePreparationActive = false;
         enginePreparationObserved = false;
         engineApplyError = '';
       }
@@ -809,7 +817,7 @@
             {#if stagedPreset && !externalMode}
               <div class="mt-3 flex flex-wrap items-center gap-2">
                 <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
-                <button type="button" onclick={revertEngineSettings} disabled={engineApplying} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
+                <button type="button" onclick={revertEngineSettings} disabled={engineApplying || engineRevertDisabled} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying || engineRevertDisabled ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
               </div>
               {#if engineApplyError}<p class="mt-2 text-xs text-red-300">{engineApplyError}</p>{/if}
             {/if}
@@ -994,7 +1002,7 @@
                       Apply compatibility changes
                     {/if}
                   </button>
-                  <button type="button" onclick={revertEngineSettings} disabled={engineApplying || externalMode} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying || externalMode ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
+                  <button type="button" onclick={revertEngineSettings} disabled={engineApplying || engineRevertDisabled || externalMode} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying || engineRevertDisabled || externalMode ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
                 </div>
               {/if}
             </div>

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -12,6 +12,7 @@
   import { getServerManagementMode, serverStatusState } from '../server-status';
   import { serverSettingsStateKey, shouldClearServerSettings, shouldRetryServerSettings } from '../server-settings-recovery';
   import { disabledOptionReasons, optionsForDraftWhisperDevice } from '../server-setting-options';
+  import { shouldRefreshCommittedSettings } from '../engine-settings-transaction';
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting, type ServerSettingOption } from '$shared/types';
   import { HOTWORDS_WARNING_THRESHOLD, formatHotwordsCsl, parseHotwordsCsl } from '$shared/hotwords';
@@ -80,6 +81,9 @@
   let lastServerSettingsAttemptKey = $state<string | null>(null);
   let compatibilityControlsOpen = $state(false);
   let engineApplying = $state(false);
+  let enginePreparationRequested = $state(false);
+  let enginePreparationObserved = $state(false);
+  let refreshingCommittedSettings = $state(false);
   let availableEngines = $state<string[]>([]);
   let engineApplyError = $state('');
 
@@ -265,8 +269,8 @@
     }
   }
 
-  async function loadServerSettings() {
-    if (serverSettingsLoading) return;
+  async function loadServerSettings(): Promise<boolean> {
+    if (serverSettingsLoading) return false;
     serverSettingsLoading = true;
     try {
       const serverData = await window.murmurMain.getServerSettings();
@@ -274,11 +278,13 @@
       engineStatus = serverData.engine_status;
       availableEngines = serverData.available_engines ?? [];
       serverConnected = true;
+      return true;
     } catch {
       serverSettings = null;
       engineStatus = null;
       availableEngines = [];
       serverConnected = false;
+      return false;
     } finally {
       serverSettingsLoading = false;
     }
@@ -433,11 +439,12 @@
     engineApplyError = '';
   }
 
-  function revertPreset(): void {
-    if (!stagedPreset) return;
-    const { engine: _engine, [stagedPreset.setting]: _model, ...advancedPending } = pendingEngine;
-    pendingEngine = advancedPending;
+  function revertEngineSettings(): void {
+    pendingEngine = {};
+    enginePreparationRequested = false;
+    enginePreparationObserved = false;
     engineApplyError = '';
+    void loadServerSettings();
   }
 
   async function applyEngineSettings() {
@@ -452,7 +459,12 @@
       serverSettings = response.settings;
       engineStatus = response.engine_status;
       availableEngines = response.available_engines ?? availableEngines;
-      if (!response.reload_started && response.engine_status.status === 'ready' && !response.engine_status.pending) pendingEngine = {};
+      if (response.reload_started) {
+        enginePreparationRequested = true;
+        enginePreparationObserved = response.engine_status.status === 'loading' || !!response.engine_status.pending;
+      } else if (response.engine_status.status === 'ready' && !response.engine_status.pending) {
+        pendingEngine = {};
+      }
     } catch (error) {
       // Keep pending changes on failure so user can retry
       engineApplyError = error instanceof Error ? error.message : 'Failed to apply engine settings.';
@@ -462,16 +474,39 @@
   }
 
   $effect(() => {
+    if (enginePreparationRequested && (sharedEngineStatus?.status === 'loading' || !!sharedEngineStatus?.pending)) {
+      enginePreparationObserved = true;
+    }
     if (Object.keys(pendingEngine).length === 0) return;
     if (preparationFailed) {
       engineApplyError = sharedEngineStatus?.pending?.message ?? sharedEngineStatus?.message ?? 'Engine reload failed.';
       return;
     }
-    if (stagedPreset && presetMatchesReadyEngine(stagedPreset, sharedEngineStatus)) {
-      pendingEngine = {};
-      engineApplyError = '';
+    if (shouldRefreshCommittedSettings(
+      pendingEngine,
+      enginePreparationRequested,
+      enginePreparationObserved,
+      preparationFailed,
+      sharedEngineStatus,
+    )) {
+      void refreshCommittedSettings();
     }
   });
+
+  async function refreshCommittedSettings(): Promise<void> {
+    if (refreshingCommittedSettings) return;
+    refreshingCommittedSettings = true;
+    try {
+      if (await loadServerSettings()) {
+        pendingEngine = {};
+        enginePreparationRequested = false;
+        enginePreparationObserved = false;
+        engineApplyError = '';
+      }
+    } finally {
+      refreshingCommittedSettings = false;
+    }
+  }
 </script>
 
 <div class="mx-auto flex h-full min-h-0 min-w-0 w-full max-w-[640px] flex-col px-4 py-4 sm:px-6">
@@ -774,7 +809,7 @@
             {#if stagedPreset && !externalMode}
               <div class="mt-3 flex flex-wrap items-center gap-2">
                 <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
-                <button type="button" onclick={revertPreset} disabled={engineApplying} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
+                <button type="button" onclick={revertEngineSettings} disabled={engineApplying} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
               </div>
               {#if engineApplyError}<p class="mt-2 text-xs text-red-300">{engineApplyError}</p>{/if}
             {/if}
@@ -941,21 +976,26 @@
             <div class="flex flex-wrap items-center justify-between gap-3">
               <p class="text-xs text-amber-300">Compatibility changes require an engine reload.</p>
               {#if !stagedPreset}
-                <button
-                  type="button"
-                  onclick={applyEngineSettings}
-                  disabled={engineApplying || externalMode}
-                  class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
-                    {engineApplying || externalMode
-                      ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed'
-                      : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}"
-                >
-                  {#if engineApplying}
-                    Preparing…
-                  {:else}
-                    Apply compatibility changes
-                  {/if}
-                </button>
+                <div class="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onclick={applyEngineSettings}
+                    disabled={engineApplying || externalMode}
+                    class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
+                      {engineApplying || externalMode
+                        ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed'
+                        : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}"
+                  >
+                    {#if engineApplying}
+                      Preparing…
+                    {:else if preparationFailed}
+                      Retry compatibility changes
+                    {:else}
+                      Apply compatibility changes
+                    {/if}
+                  </button>
+                  <button type="button" onclick={revertEngineSettings} disabled={engineApplying || externalMode} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying || externalMode ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
+                </div>
               {/if}
             </div>
             {#if engineApplyError}

--- a/app/tests/engine-settings-transaction.test.ts
+++ b/app/tests/engine-settings-transaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { shouldDisableEngineRevert, shouldRefreshCommittedSettings } from '../src/renderer/app/engine-settings-transaction.js';
+import { enginePreparationPhase, shouldDisableEngineRevert, shouldRefreshCommittedSettings } from '../src/renderer/app/engine-settings-transaction.js';
 import { readFileSync } from 'node:fs';
 
 describe('Engine settings transaction UI', () => {
@@ -29,6 +29,13 @@ describe('Engine settings transaction UI', () => {
     })).toBeFalse();
   });
 
+  test('treats a refreshed terminal failure as complete when loading was missed', () => {
+    expect(enginePreparationPhase({
+      current: 'whisper', status: 'ready', message: 'Preparation failed.',
+    })).toBe('failed');
+    expect(shouldDisableEngineRevert(false)).toBeFalse();
+  });
+
   test('keeps Retry/Revert transactional in the settings surface', () => {
     const settingsView = readFileSync(
       new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url),
@@ -36,6 +43,7 @@ describe('Engine settings transaction UI', () => {
     );
 
     expect(settingsView).toContain('enginePreparationRequested = true');
+    expect(settingsView).toContain('await confirmEnginePreparationStatus()');
     expect(settingsView).toContain('void refreshCommittedSettings()');
     expect(settingsView).toContain('if (await loadServerSettings())');
     expect(settingsView).toContain('function revertEngineSettings()');

--- a/app/tests/engine-settings-transaction.test.ts
+++ b/app/tests/engine-settings-transaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { shouldRefreshCommittedSettings } from '../src/renderer/app/engine-settings-transaction.js';
+import { shouldDisableEngineRevert, shouldRefreshCommittedSettings } from '../src/renderer/app/engine-settings-transaction.js';
 import { readFileSync } from 'node:fs';
 
 describe('Engine settings transaction UI', () => {
@@ -8,6 +8,8 @@ describe('Engine settings transaction UI', () => {
     expect(shouldRefreshCommittedSettings(pending, true, true, true, {
       current: 'nemotron', status: 'error', message: 'Preparation failed.',
     })).toBeFalse();
+    expect(shouldDisableEngineRevert(true)).toBeTrue();
+    expect(shouldDisableEngineRevert(false)).toBeFalse();
   });
 
   test('refreshes committed settings before clearing a ready advanced candidate', () => {
@@ -38,5 +40,6 @@ describe('Engine settings transaction UI', () => {
     expect(settingsView).toContain('if (await loadServerSettings())');
     expect(settingsView).toContain('function revertEngineSettings()');
     expect(settingsView).toContain('pendingEngine = {};');
+    expect(settingsView).toContain('disabled={engineApplying || engineRevertDisabled}');
   });
 });

--- a/app/tests/engine-settings-transaction.test.ts
+++ b/app/tests/engine-settings-transaction.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { shouldRefreshCommittedSettings } from '../src/renderer/app/engine-settings-transaction.js';
+import { readFileSync } from 'node:fs';
+
+describe('Engine settings transaction UI', () => {
+  test('keeps a curated candidate staged through failure for Retry or Revert', () => {
+    const pending = { engine: 'whisper', whisper_model: 'medium' };
+    expect(shouldRefreshCommittedSettings(pending, true, true, true, {
+      current: 'nemotron', status: 'error', message: 'Preparation failed.',
+    })).toBeFalse();
+  });
+
+  test('refreshes committed settings before clearing a ready advanced candidate', () => {
+    const pending = {
+      whisper_device: 'cuda',
+      whisper_compute_type: 'float16',
+      whisper_language: 'en',
+    };
+    expect(shouldRefreshCommittedSettings(pending, true, false, false, {
+      current: 'whisper', status: 'ready',
+    })).toBeFalse();
+    expect(shouldRefreshCommittedSettings(pending, true, true, false, {
+      current: 'whisper', status: 'ready',
+    })).toBeTrue();
+    expect(shouldRefreshCommittedSettings(pending, false, true, false, {
+      current: 'whisper', status: 'ready',
+    })).toBeFalse();
+  });
+
+  test('keeps Retry/Revert transactional in the settings surface', () => {
+    const settingsView = readFileSync(
+      new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url),
+      'utf8',
+    );
+
+    expect(settingsView).toContain('enginePreparationRequested = true');
+    expect(settingsView).toContain('void refreshCommittedSettings()');
+    expect(settingsView).toContain('if (await loadServerSettings())');
+    expect(settingsView).toContain('function revertEngineSettings()');
+    expect(settingsView).toContain('pendingEngine = {};');
+  });
+});

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -201,6 +201,7 @@ describe('Home and shared server status', () => {
     expect(mount).toContain('getSettings');
     expect(mount).not.toContain('restartServer');
     expect(mount).not.toContain('updateServerSettings');
+    expect(mount).not.toContain('prepare');
     expect(homeView).toContain('onclick={retry}');
     expect(homeView).toContain('External server — Eve cannot restart this endpoint.');
     expect(homeView).toContain('Management mode cannot be confirmed. Open Settings &gt; Server &amp; diagnostics.');

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -42,6 +42,7 @@ describe('speech model presets', () => {
   test('keeps selection and preparation explicit in the Settings surface', () => {
     const settings = readFileSync(new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url), 'utf8');
     const chooser = readFileSync(new URL('../src/renderer/app/components/SpeechModelChooser.svelte', import.meta.url), 'utf8');
+    const transaction = readFileSync(new URL('../src/renderer/app/engine-settings-transaction.ts', import.meta.url), 'utf8');
     expect(chooser).toContain('type="radio"');
     expect(chooser).toContain('name={`speech-model-preset-${componentId}`}');
     expect(chooser).toContain('Apply and prepare model confirms the change.');
@@ -51,8 +52,8 @@ describe('speech model presets', () => {
     expect(settings).toContain('shouldClearServerSettings');
     expect(settings).toContain('serverSettingsLoading');
     expect(settings).not.toContain('async function pollEngineStatus');
-    expect(settings).toContain('!!sharedEngineStatus?.message');
-    expect(settings).toContain("sharedEngineStatus?.pending?.status === 'error'");
+    expect(settings).toContain("enginePreparationPhase(sharedEngineStatus) === 'failed'");
+    expect(transaction).toContain("status.pending?.status === 'error'");
     expect(settings).toContain('sharedEngineStatus?.pending?.message ?? sharedEngineStatus?.message');
     expect(settings).toContain("'Retry preparation'");
     expect(settings).toContain("'nemotron_model'");

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -63,10 +63,11 @@ describe('speech model presets', () => {
     expect(settings).toContain('whisper_compute_type');
     expect(settings).toContain('Raw Whisper compatibility model, including Medium and Tiny');
     expect(settings).toContain('!stagedPreset');
-    expect(settings).toContain('const { engine: _engine, [stagedPreset.setting]: _model, ...advancedPending }');
+    expect(settings).toContain('function revertEngineSettings()');
+    expect(settings).toContain('pendingEngine = {};');
   });
 
-  test('routes only an actual staged preset through model preparation and preserves advanced pending values on revert', () => {
+  test('routes only an actual staged preset through model preparation and clears the full candidate on revert', () => {
     expect(stagedPresetFromPending({ whisper_compute_type: 'int8' })).toBeNull();
     expect(stagedPresetFromPending({ engine: 'whisper', whisper_model: 'medium' })).toBeNull();
     expect(stagedPresetFromPending({ engine: 'whisper', whisper_model: 'large-v3-turbo', whisper_compute_type: 'int8' })?.id).toBe('recommended-multilingual');

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -14,9 +14,10 @@ from config import (
     API_KEYS,
     RELOAD_KEYS,
     Settings,
+    build_settings_candidate,
+    commit_settings,
     get_settings,
     get_settings_with_metadata,
-    update_settings,
 )
 from diagnostics import collect_diagnostics
 from session.manager import get_session_manager
@@ -33,6 +34,7 @@ from websocket.handler import websocket_handler
 
 logger = logging.getLogger(__name__)
 _engine_tasks: set[asyncio.Task[None]] = set()
+_settings_preparation_pending = False
 
 
 def _safe_settings_validation_detail(error: ValidationError) -> str:
@@ -44,9 +46,15 @@ def _safe_settings_validation_detail(error: ValidationError) -> str:
     return message.removeprefix("Value error, ")
 
 
-def _schedule_engine_swap(engine_mgr: Any, settings: Settings) -> asyncio.Task[None]:
+def _schedule_engine_swap(
+    engine_mgr: Any, settings: Settings, *, commit_on_success: bool = False
+) -> asyncio.Task[None]:
     """Keep background engine loads alive and observe their completion."""
-    task = asyncio.create_task(_swap_engine_background(engine_mgr, settings))
+    task = asyncio.create_task(
+        _swap_engine_background(
+            engine_mgr, settings, commit_on_success=commit_on_success
+        )
+    )
     _engine_tasks.add(task)
     task.add_done_callback(_engine_tasks.discard)
     return task
@@ -155,10 +163,16 @@ def create_app() -> FastAPI:
 
     @app.patch("/settings")
     async def update_server_settings(body: dict[str, Any]) -> dict:
+        global _settings_preparation_pending
         # Filter to only API-managed keys
         patch = {k: v for k, v in body.items() if k in API_KEYS}
         if not patch:
             raise HTTPException(status_code=400, detail="No valid settings provided")
+        if _settings_preparation_pending:
+            raise HTTPException(
+                status_code=409,
+                detail="A settings change is already being prepared.",
+            )
 
         discovered_engines = discover_engines()
         available_engines = [e["id"] for e in discovered_engines if e["available"]]
@@ -180,7 +194,7 @@ def create_app() -> FastAPI:
         needs_reload = bool(set(patch.keys()) & RELOAD_KEYS)
 
         try:
-            new_settings = update_settings(patch)
+            candidate = build_settings_candidate(patch)
         except ValidationError as e:
             raise HTTPException(
                 status_code=400, detail=_safe_settings_validation_detail(e)
@@ -190,13 +204,17 @@ def create_app() -> FastAPI:
         reload_started = False
         if needs_reload:
             reload_started = True
-            _schedule_engine_swap(engine_mgr, new_settings)
+            _settings_preparation_pending = True
+            _schedule_engine_swap(engine_mgr, candidate, commit_on_success=True)
+            committed_settings = get_settings()
+        else:
+            committed_settings = commit_settings(candidate)
 
         status = engine_mgr.get_status()
         session_mgr = get_session_manager()
 
         response: dict[str, Any] = {
-            "settings": get_settings_with_metadata(new_settings),
+            "settings": get_settings_with_metadata(committed_settings),
             "engine_status": serialize_engine_status(status),
             "available_engines": available_engines,
             "reload_required": needs_reload,
@@ -242,8 +260,16 @@ def create_app() -> FastAPI:
     return app
 
 
-async def _swap_engine_background(engine_mgr: Any, settings: Settings) -> None:
+async def _swap_engine_background(
+    engine_mgr: Any, settings: Settings, *, commit_on_success: bool = False
+) -> None:
+    global _settings_preparation_pending
     try:
         await engine_mgr.swap_engine(settings)
+        if commit_on_success:
+            commit_settings(settings)
     except Exception as e:
         logger.error("Background engine swap failed: %s", e)
+    finally:
+        if commit_on_success:
+            _settings_preparation_pending = False

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -214,7 +214,7 @@ def create_app() -> FastAPI:
                 raise HTTPException(
                     status_code=500,
                     detail="Could not save settings. Please try again.",
-                )
+                ) from None
 
         status = engine_mgr.get_status()
         session_mgr = get_session_manager()

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -208,7 +208,13 @@ def create_app() -> FastAPI:
             _schedule_engine_swap(engine_mgr, candidate, commit_on_success=True)
             committed_settings = get_settings()
         else:
-            committed_settings = commit_settings(candidate)
+            try:
+                committed_settings = commit_settings(candidate)
+            except OSError:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Could not save settings. Please try again.",
+                )
 
         status = engine_mgr.get_status()
         session_mgr = get_session_manager()
@@ -265,9 +271,11 @@ async def _swap_engine_background(
 ) -> None:
     global _settings_preparation_pending
     try:
-        await engine_mgr.swap_engine(settings)
-        if commit_on_success:
+        def persist_candidate() -> None:
             commit_settings(settings)
+
+        before_activate = persist_candidate if commit_on_success else None
+        await engine_mgr.swap_engine(settings, before_activate=before_activate)
     except Exception as e:
         logger.error("Background engine swap failed: %s", e)
     finally:

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -424,20 +424,29 @@ def get_settings() -> Settings:
     return _settings
 
 
-def update_settings(patch: dict[str, Any]) -> Settings:
-    global _settings
+def build_settings_candidate(patch: dict[str, Any]) -> Settings:
+    """Validate a complete settings candidate without committing it."""
     current = get_settings()
     current_dict = current.model_dump()
     current_dict.update(patch)
     try:
-        updated = Settings(**current_dict)
+        return Settings(**current_dict)
     except ValidationError as e:
         logger.warning("Rejected invalid settings update: %s", e)
         raise
-    _settings = updated
-    # Persist non-default values
-    _persist_settings(_settings)
-    return _settings
+
+
+def commit_settings(candidate: Settings) -> Settings:
+    """Commit one validated settings candidate to memory and disk."""
+    global _settings
+    _settings = candidate
+    _persist_settings(candidate)
+    return candidate
+
+
+def update_settings(patch: dict[str, Any]) -> Settings:
+    """Immediately commit a validated settings patch for non-reload callers."""
+    return commit_settings(build_settings_candidate(patch))
 
 
 def _persist_settings(settings: Settings) -> None:

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -439,8 +439,8 @@ def build_settings_candidate(patch: dict[str, Any]) -> Settings:
 def commit_settings(candidate: Settings) -> Settings:
     """Commit one validated settings candidate to memory and disk."""
     global _settings
-    _settings = candidate
     _persist_settings(candidate)
+    _settings = candidate
     return candidate
 
 
@@ -483,3 +483,4 @@ def _persist_settings(settings: Settings) -> None:
                 temp_path.unlink(missing_ok=True)
             except OSError:
                 pass
+        raise

--- a/server/src/transcription/factory.py
+++ b/server/src/transcription/factory.py
@@ -7,6 +7,7 @@ import gc
 import importlib.util
 import logging
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
@@ -332,15 +333,30 @@ class EngineManager:
         with self._lock:
             return len(self._active_sessions)
 
-    async def swap_engine(self, new_settings: Settings) -> None:
+    async def swap_engine(
+        self,
+        new_settings: Settings,
+        *,
+        before_activate: Callable[[], None] | None = None,
+    ) -> None:
         # Lazily create the asyncio lock (must be created in an event loop context)
         if self._swap_lock is None:
             self._swap_lock = asyncio.Lock()
 
         async with self._swap_lock:
-            await self._swap_engine_inner(new_settings)
+            if before_activate is None:
+                await self._swap_engine_inner(new_settings)
+            else:
+                await self._swap_engine_inner(
+                    new_settings, before_activate=before_activate
+                )
 
-    async def _swap_engine_inner(self, new_settings: Settings) -> None:
+    async def _swap_engine_inner(
+        self,
+        new_settings: Settings,
+        *,
+        before_activate: Callable[[], None] | None = None,
+    ) -> None:
         try:
             with self._lock:
                 if self._shutting_down:
@@ -374,48 +390,59 @@ class EngineManager:
                 await loop.run_in_executor(None, old_engine.shutdown)
                 _force_free_vram()
 
+            async def restore_previous_engine() -> None:
+                if not should_unload_old or self._shutting_down:
+                    return
+                logger.warning(
+                    "Engine activation failed; attempting to restore previous engine"
+                )
+                try:
+                    restored = await loop.run_in_executor(
+                        None, lambda: _create_engine(self._settings)
+                    )
+                    discard_restored = False
+                    with self._lock:
+                        if self._shutting_down:
+                            discard_restored = True
+                        else:
+                            self._engine = restored
+                    if discard_restored:
+                        await loop.run_in_executor(None, restored.shutdown)
+                    else:
+                        logger.info("Previous engine restored successfully")
+                except Exception as restore_error:
+                    logger.error("Failed to restore previous engine: %s", restore_error)
+
             try:
                 new_engine = await loop.run_in_executor(None, lambda: _create_engine(new_settings))
             except Exception as create_error:
-                if should_unload_old and not self._shutting_down:
-                    # Old engine was unloaded; attempt to restore it
-                    logger.warning(
-                        "New engine creation failed; attempting to restore previous engine"
-                    )
-                    try:
-                        restored = await loop.run_in_executor(
-                            None, lambda: _create_engine(self._settings)
-                        )
-                        discard_restored = False
-                        with self._lock:
-                            if self._shutting_down:
-                                discard_restored = True
-                            else:
-                                self._engine = restored
-                        if discard_restored:
-                            await loop.run_in_executor(None, restored.shutdown)
-                        else:
-                            logger.info("Previous engine restored successfully")
-                    except Exception as restore_error:
-                        logger.error(
-                            "Failed to restore previous engine: %s", restore_error
-                        )
+                await restore_previous_engine()
                 raise create_error
 
-            discard_new_engine = False
-            with self._lock:
-                if self._shutting_down:
-                    discard_new_engine = True
-                    old_engine = None
-                    has_active = False
-                else:
-                    old_engine = self._engine
-                    self._engine = new_engine
-                    self._settings = new_settings
-                    has_active = (
-                        old_engine is not None
-                        and old_engine in self._active_sessions.values()
-                    )
+            try:
+                discard_new_engine = False
+                with self._lock:
+                    if self._shutting_down:
+                        discard_new_engine = True
+                        old_engine = None
+                        has_active = False
+                    else:
+                        if before_activate is not None:
+                            before_activate()
+                        old_engine = self._engine
+                        self._engine = new_engine
+                        self._settings = new_settings
+                        has_active = (
+                            old_engine is not None
+                            and old_engine in self._active_sessions.values()
+                        )
+            except Exception:
+                try:
+                    await loop.run_in_executor(None, new_engine.shutdown)
+                except Exception as shutdown_error:
+                    logger.error("Failed to discard unactivated engine: %s", shutdown_error)
+                await restore_previous_engine()
+                raise
 
             if discard_new_engine:
                 logger.info("Discarding engine that finished loading during shutdown")

--- a/server/tests/test_review_fixes.py
+++ b/server/tests/test_review_fixes.py
@@ -152,6 +152,45 @@ async def test_swap_engine_restores_on_failure(monkeypatch: pytest.MonkeyPatch) 
 
 
 @pytest.mark.asyncio
+async def test_swap_engine_restores_old_engine_when_activation_callback_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(engine="whisper", unload_before_swap=True)
+    monkeypatch.setattr(factory_module, "_get_available_engine_ids", lambda: ["whisper"])
+    _stub_gpu(monkeypatch)
+
+    created: list[_DummyEngine] = []
+
+    def _fake_create(s: Settings) -> _DummyEngine:
+        engine = _DummyEngine(s.engine)
+        created.append(engine)
+        return engine
+
+    shutdown_calls: list[str] = []
+    monkeypatch.setattr(factory_module, "_create_engine", _fake_create)
+    monkeypatch.setattr(_DummyEngine, "shutdown", lambda self: shutdown_calls.append(self._engine_id))
+
+    manager = factory_module.EngineManager(settings)
+    manager._engine = _DummyEngine("whisper")
+
+    with pytest.raises(OSError, match="disk unavailable"):
+        await manager.swap_engine(
+            Settings(
+                engine="whisper",
+                whisper_model="medium",
+                unload_before_swap=True,
+            ),
+            before_activate=lambda: (_ for _ in ()).throw(OSError("disk unavailable")),
+        )
+
+    assert manager._engine is created[1]
+    assert manager._engine._engine_id == "whisper"
+    assert manager._settings is settings
+    assert len(created) == 2
+    assert shutdown_calls == ["whisper", "whisper"]
+
+
+@pytest.mark.asyncio
 async def test_swap_engine_restore_also_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     """When both new engine and restore fail, _engine is None and original error propagates."""
     settings = Settings(engine="whisper", unload_before_swap=True)

--- a/server/tests/test_settings_transactions.py
+++ b/server/tests/test_settings_transactions.py
@@ -19,10 +19,12 @@ class _EngineManager:
         self.failure = failure
         self.calls: list[Settings] = []
 
-    async def swap_engine(self, settings: Settings) -> None:
+    async def swap_engine(self, settings: Settings, *, before_activate=None) -> None:
         self.calls.append(settings)
         if self.failure:
             raise self.failure
+        if before_activate is not None:
+            before_activate()
         self.current = settings.engine
 
     def get_status(self) -> SimpleNamespace:
@@ -82,6 +84,24 @@ def test_candidate_validation_does_not_mutate_committed_memory_or_file() -> None
     assert candidate.whisper_model == "medium"
     assert config.get_settings() is committed
     assert settings_file.read_text(encoding="utf-8") == before
+
+
+def test_commit_persists_before_replacing_committed_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    committed = _committed_settings()
+    candidate = config.build_settings_candidate({"whisper_model": "medium"})
+    observed_committed: list[Settings] = []
+
+    def persist(_settings: Settings) -> None:
+        observed_committed.append(config.get_settings())
+
+    monkeypatch.setattr(config, "_persist_settings", persist)
+
+    config.commit_settings(candidate)
+
+    assert observed_committed == [committed]
+    assert config.get_settings() is candidate
 
 
 @pytest.mark.asyncio
@@ -177,6 +197,28 @@ async def test_failed_mixed_reload_commits_nothing_and_keeps_live_engine(
 
 
 @pytest.mark.asyncio
+async def test_reload_persistence_failure_keeps_engine_and_committed_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    committed = _committed_settings()
+    settings_file = config.get_settings_file_path()
+    before = settings_file.read_text(encoding="utf-8")
+    candidate = config.build_settings_candidate({"whisper_model": "medium"})
+    manager = _EngineManager()
+    monkeypatch.setattr(config, "_persist_settings", lambda _settings: (_ for _ in ()).throw(OSError("disk unavailable")))
+    server_app._settings_preparation_pending = True
+
+    await server_app._swap_engine_background(
+        manager, candidate, commit_on_success=True
+    )
+
+    assert manager.current == "whisper"
+    assert config.get_settings() is committed
+    assert settings_file.read_text(encoding="utf-8") == before
+    assert server_app._settings_preparation_pending is False
+
+
+@pytest.mark.asyncio
 async def test_pending_reload_rejects_new_updates_without_overwriting_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -208,3 +250,25 @@ async def test_non_reload_patch_commits_immediately(monkeypatch: pytest.MonkeyPa
     assert response["reload_started"] is False
     assert response["settings"]["partial_emission_interval"]["value"] == 0.5
     assert config.get_settings().partial_emission_interval == 0.5
+
+
+@pytest.mark.asyncio
+async def test_non_reload_persistence_failure_keeps_committed_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    committed = _committed_settings()
+    settings_file = config.get_settings_file_path()
+    before = settings_file.read_text(encoding="utf-8")
+    monkeypatch.setattr(
+        server_app, "discover_engines", lambda: [{"id": "whisper", "available": True}]
+    )
+    monkeypatch.setattr(server_app, "get_engine_manager", lambda: _EngineManager())
+    monkeypatch.setattr(config, "_persist_settings", lambda _settings: (_ for _ in ()).throw(OSError("disk unavailable")))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _settings_handler()({"partial_emission_interval": 0.5})
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Could not save settings. Please try again."
+    assert config.get_settings() is committed
+    assert settings_file.read_text(encoding="utf-8") == before

--- a/server/tests/test_settings_transactions.py
+++ b/server/tests/test_settings_transactions.py
@@ -1,0 +1,210 @@
+"""Regression tests for transactional reload settings updates."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import app as server_app
+import config
+from config import Settings
+from engine_compatibility import ComputeCapability, RuntimeCapabilities
+
+
+class _EngineManager:
+    def __init__(self, current: str = "whisper", failure: Exception | None = None) -> None:
+        self.current = current
+        self.failure = failure
+        self.calls: list[Settings] = []
+
+    async def swap_engine(self, settings: Settings) -> None:
+        self.calls.append(settings)
+        if self.failure:
+            raise self.failure
+        self.current = settings.engine
+
+    def get_status(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            current=self.current, status="ready", info=None, pending=None, message=None
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_state(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setenv("MURMUR_SETTINGS_FILE", str(tmp_path / "settings.json"))
+    monkeypatch.setattr(
+        config,
+        "get_runtime_capabilities",
+        lambda: RuntimeCapabilities(
+            whisper_cpu=ComputeCapability(frozenset({"int8", "float32"})),
+            whisper_cuda=ComputeCapability(
+                None, "CTranslate2 did not find a usable CUDA device."
+            ),
+            nemotron_cuda_available=False,
+            nemotron_cuda_reason="PyTorch did not find a usable CUDA device.",
+        ),
+    )
+    monkeypatch.setattr(config, "_settings", None)
+    server_app._settings_preparation_pending = False
+    yield
+    config._settings = None
+    server_app._settings_preparation_pending = False
+
+
+def _committed_settings() -> Settings:
+    return config.commit_settings(
+        Settings(
+            engine="whisper",
+            whisper_model="small",
+            whisper_device="cpu",
+            whisper_compute_type="int8",
+        )
+    )
+
+
+def _settings_handler():
+    return next(
+        route.endpoint
+        for route in server_app.create_app().routes
+        if getattr(route, "path", None) == "/settings" and "PATCH" in route.methods
+    )
+
+
+def test_candidate_validation_does_not_mutate_committed_memory_or_file() -> None:
+    committed = _committed_settings()
+    settings_file = config.get_settings_file_path()
+    before = settings_file.read_text(encoding="utf-8")
+
+    candidate = config.build_settings_candidate({"whisper_model": "medium"})
+
+    assert candidate.whisper_model == "medium"
+    assert config.get_settings() is committed
+    assert settings_file.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.asyncio
+async def test_reload_patch_schedules_candidate_while_committed_settings_stay_current(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    committed = _committed_settings()
+    settings_file = config.get_settings_file_path()
+    before = settings_file.read_text(encoding="utf-8")
+    manager = _EngineManager()
+    scheduled: list[tuple[Settings, bool]] = []
+    monkeypatch.setattr(
+        server_app, "discover_engines", lambda: [{"id": "whisper", "available": True}]
+    )
+    monkeypatch.setattr(server_app, "get_engine_manager", lambda: manager)
+    monkeypatch.setattr(
+        server_app,
+        "_schedule_engine_swap",
+        lambda _manager, candidate, *, commit_on_success: scheduled.append(
+            (candidate, commit_on_success)
+        ),
+    )
+
+    response = await _settings_handler()(
+        {"whisper_model": "medium", "partial_emission_interval": 0.5}
+    )
+
+    assert len(scheduled) == 1
+    candidate, commit_on_success = scheduled[0]
+    assert candidate.whisper_model == "medium"
+    assert candidate.partial_emission_interval == 0.5
+    assert commit_on_success is True
+    assert response["settings"]["whisper_model"]["value"] == "small"
+    assert response["settings"]["partial_emission_interval"]["value"] == 0.25
+    assert response["reload_started"] is True
+    assert config.get_settings() is committed
+    assert settings_file.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.asyncio
+async def test_successful_mixed_reload_commits_complete_candidate_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _committed_settings()
+    candidate = config.build_settings_candidate(
+        {"whisper_model": "medium", "partial_emission_interval": 0.5}
+    )
+    manager = _EngineManager()
+    commits: list[Settings] = []
+    original_commit = config.commit_settings
+
+    def record_commit(settings: Settings) -> Settings:
+        commits.append(settings)
+        return original_commit(settings)
+
+    monkeypatch.setattr(server_app, "commit_settings", record_commit)
+    server_app._settings_preparation_pending = True
+
+    await server_app._swap_engine_background(
+        manager, candidate, commit_on_success=True
+    )
+
+    assert manager.calls == [candidate]
+    assert commits == [candidate]
+    assert config.get_settings() == candidate
+    assert config.get_settings().partial_emission_interval == 0.5
+    assert server_app._settings_preparation_pending is False
+
+
+@pytest.mark.asyncio
+async def test_failed_mixed_reload_commits_nothing_and_keeps_live_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    committed = _committed_settings()
+    candidate = config.build_settings_candidate(
+        {"whisper_model": "medium", "partial_emission_interval": 0.5}
+    )
+    manager = _EngineManager(failure=RuntimeError("preparation failed"))
+    commits: list[Settings] = []
+    monkeypatch.setattr(server_app, "commit_settings", lambda settings: commits.append(settings))
+    server_app._settings_preparation_pending = True
+
+    await server_app._swap_engine_background(
+        manager, candidate, commit_on_success=True
+    )
+
+    assert manager.current == "whisper"
+    assert manager.calls == [candidate]
+    assert commits == []
+    assert config.get_settings() is committed
+    assert config.get_settings().partial_emission_interval == 0.25
+    assert server_app._settings_preparation_pending is False
+
+
+@pytest.mark.asyncio
+async def test_pending_reload_rejects_new_updates_without_overwriting_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    committed = _committed_settings()
+    monkeypatch.setattr(
+        server_app, "discover_engines", lambda: [{"id": "whisper", "available": True}]
+    )
+    server_app._settings_preparation_pending = True
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _settings_handler()({"partial_emission_interval": 0.5})
+
+    assert exc_info.value.status_code == 409
+    assert config.get_settings() is committed
+    assert config.get_settings().partial_emission_interval == 0.25
+
+
+@pytest.mark.asyncio
+async def test_non_reload_patch_commits_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    _committed_settings()
+    manager = _EngineManager()
+    monkeypatch.setattr(
+        server_app, "discover_engines", lambda: [{"id": "whisper", "available": True}]
+    )
+    monkeypatch.setattr(server_app, "get_engine_manager", lambda: manager)
+
+    response = await _settings_handler()({"partial_emission_interval": 0.5})
+
+    assert response["reload_started"] is False
+    assert response["settings"]["partial_emission_interval"]["value"] == 0.5
+    assert config.get_settings().partial_emission_interval == 0.5


### PR DESCRIPTION
## Summary
- validate full settings candidates before mutating committed configuration
- commit reload settings only after the background engine swap succeeds
- keep renderer candidates staged through preparation, retry, and factual refresh/revert

## Tests
- server focused transaction/recovery/compatibility tests
- app focused transactional settings tests and production build
- full server and app test matrices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Engine-affecting settings now apply transactionally after a successful reload.
  * Added preparation-aware Retry and Revert controls for speech-model and compatibility settings.
  * Non-engine settings continue to apply immediately.

* **Bug Fixes**
  * Failed or in-progress reloads no longer overwrite active settings.
  * Reverting engine changes now clears all pending selections.
  * Prevented conflicting settings updates during an active reload.
  * Failed engine activation now restores the previously active engine safely.
  * Settings are preserved when saving or reloading fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->