### PR TITLE
Fix Windows Hugging Face snapshot fallback

### DIFF
--- a/server/src/transcription/engines/whisper.py
+++ b/server/src/transcription/engines/whisper.py
@@ -14,7 +14,8 @@ try:
 except ImportError:
     pass
 
-from faster_whisper import WhisperModel, download_model
+from faster_whisper import WhisperModel
+from huggingface_hub import snapshot_download
 from numpy.typing import NDArray
 import numpy as np
 
@@ -46,6 +47,13 @@ _PUBLIC_BUILTIN_MODELS = {
     "small": "Systran/faster-whisper-small",
     "tiny": "Systran/faster-whisper-tiny",
 }
+_WHISPER_MODEL_ALLOW_PATTERNS = (
+    "config.json",
+    "preprocessor_config.json",
+    "model.bin",
+    "tokenizer.json",
+    "vocabulary.*",
+)
 
 
 @dataclass(frozen=True)
@@ -107,16 +115,22 @@ def _resolve_repo_id(model: str) -> str | None:
 
 
 def _download_repo(repo_id: str) -> str:
-    """Download curated public models anonymously and preserve custom auth.
+    """Download a Whisper repository with deterministic Windows cache fallback.
 
     ``huggingface_hub`` otherwise sends a saved token implicitly. A stale token
     can make a public repository return 401, so Eve's fixed curated catalog uses
-    explicit anonymous access. Advanced/custom identifiers retain the library's
-    existing authentication behavior.
+    explicit anonymous access. Its symlink-capability probe is process-global;
+    serializing this small snapshot prevents a Windows privilege race from
+    attempting a symlink after fallback was selected. Advanced/custom
+    identifiers retain the library's existing authentication behavior.
     """
+    kwargs: dict[str, object] = {
+        "allow_patterns": list(_WHISPER_MODEL_ALLOW_PATTERNS),
+        "max_workers": 1,
+    }
     if repo_id in _PUBLIC_BUILTIN_MODELS.values():
-        return download_model(repo_id, use_auth_token=False)
-    return download_model(repo_id)
+        kwargs["token"] = False
+    return snapshot_download(repo_id, **kwargs)
 
 
 def _get_cuda_active(device: str) -> bool:

--- a/server/tests/test_backend_hardening.py
+++ b/server/tests/test_backend_hardening.py
@@ -133,7 +133,7 @@ def test_whisper_uncached_model_reports_downloading(
     monkeypatch.setattr(whisper, "get_repo_cache_status", lambda _repo: cache_status)
     monkeypatch.setattr(whisper, "WhisperModel", FakeWhisperModel)
     monkeypatch.setattr(
-        whisper, "download_model", lambda _repo, **_kwargs: "cache/snapshot"
+        whisper, "snapshot_download", lambda _repo, **_kwargs: "cache/snapshot"
     )
     monkeypatch.setattr(whisper, "_get_cuda_active", lambda _device: False)
 

--- a/server/tests/test_public_model_auth.py
+++ b/server/tests/test_public_model_auth.py
@@ -81,16 +81,31 @@ def test_public_whisper_builtin_models_resolve_to_registered_upstreams(
 def test_curated_whisper_presets_force_anonymous_download(
     repo_id: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    calls: list[tuple[str, object]] = []
+    calls: list[tuple[str, dict[str, object]]] = []
 
-    def fake_download(requested_repo: str, **kwargs: object) -> str:
-        calls.append((requested_repo, kwargs.get("use_auth_token")))
+    def fake_snapshot_download(requested_repo: str, **kwargs: object) -> str:
+        calls.append((requested_repo, kwargs))
         return "cache/snapshot"
 
-    monkeypatch.setattr(whisper, "download_model", fake_download)
+    monkeypatch.setattr(whisper, "snapshot_download", fake_snapshot_download)
 
     assert whisper._download_repo(repo_id) == "cache/snapshot"
-    assert calls == [(repo_id, False)]
+    assert calls == [
+        (
+            repo_id,
+            {
+                "allow_patterns": [
+                    "config.json",
+                    "preprocessor_config.json",
+                    "model.bin",
+                    "tokenizer.json",
+                    "vocabulary.*",
+                ],
+                "max_workers": 1,
+                "token": False,
+            },
+        )
+    ]
 
 
 def test_custom_whisper_model_preserves_existing_authentication(
@@ -98,16 +113,47 @@ def test_custom_whisper_model_preserves_existing_authentication(
 ) -> None:
     calls: list[tuple[str, dict[str, object]]] = []
 
-    def fake_download(requested_repo: str, **kwargs: object) -> str:
+    def fake_snapshot_download(requested_repo: str, **kwargs: object) -> str:
         calls.append((requested_repo, kwargs))
         return "cache/private-snapshot"
 
-    monkeypatch.setattr(whisper, "download_model", fake_download)
+    monkeypatch.setattr(whisper, "snapshot_download", fake_snapshot_download)
 
     assert whisper._download_repo("private-org/custom-whisper") == (
         "cache/private-snapshot"
     )
-    assert calls == [("private-org/custom-whisper", {})]
+    assert calls == [
+        (
+            "private-org/custom-whisper",
+            {
+                "allow_patterns": [
+                    "config.json",
+                    "preprocessor_config.json",
+                    "model.bin",
+                    "tokenizer.json",
+                    "vocabulary.*",
+                ],
+                "max_workers": 1,
+            },
+        )
+    ]
+
+
+def test_whisper_snapshot_download_serializes_windows_symlink_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public download boundary avoids concurrent Windows link creation."""
+
+    def fake_snapshot_download(_repo_id: str, **kwargs: object) -> str:
+        if kwargs.get("max_workers") != 1:
+            raise OSError(1314, "A required privilege is not held by the client")
+        return "cache/serialized-snapshot"
+
+    monkeypatch.setattr(whisper, "snapshot_download", fake_snapshot_download)
+
+    assert whisper._download_repo("Systran/faster-whisper-large-v3") == (
+        "cache/serialized-snapshot"
+    )
 
 
 def test_local_whisper_path_skips_hub_resolution_and_download(
@@ -125,7 +171,7 @@ def test_local_whisper_path_skips_hub_resolution_and_download(
         raise AssertionError("local paths must not access the Hub")
 
     monkeypatch.setattr(whisper, "get_repo_cache_status", unexpected_hub_access)
-    monkeypatch.setattr(whisper, "download_model", unexpected_hub_access)
+    monkeypatch.setattr(whisper, "snapshot_download", unexpected_hub_access)
     monkeypatch.setattr(whisper, "WhisperModel", FakeWhisperModel)
     monkeypatch.setattr(whisper, "_get_cuda_active", lambda _device: False)
 


### PR DESCRIPTION
## Summary
- Use the public `huggingface_hub.snapshot_download` API for resolved Whisper repositories.
- Preserve Faster-Whisper's required file allow-patterns and serialize downloads with `max_workers=1`.
- Keep built-in public models explicitly anonymous (`token=False`) while leaving custom/private model authentication untouched.

## Root cause and evidence
Isolated validation of `Systran/faster-whisper-large-v3` downloaded 3,090,835,742 bytes, then failed on Windows without Developer Mode with `OSError [WinError 1314]` during `huggingface_hub.snapshot_download` cache snapshot symlink creation. In huggingface-hub 0.36.2, concurrent file work can race the process-global symlink capability fallback. Serializing the public snapshot boundary avoids that race without dependency changes, private Hub internals, elevated privileges, or cache/profile changes.

## Validation
- `server/tests/test_public_model_auth.py server/tests/test_backend_hardening.py`: 36 passed
- Full server matrix: 195 passed
- No model download was run during source development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Whisper model downloads by retrieving only the required files.
  * Added safer download behavior for Windows environments.
  * Preserved authentication support for custom model repositories while enabling anonymous access for curated public models.
  * Local model usage no longer triggers an unnecessary download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->