### PR TITLE
Fix packaged server cold-start PID timeout

### DIFF
--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -21,13 +21,16 @@ import {
   type HealthState,
   type ServerProcessSnapshot,
 } from './server-health.js';
+import {
+  START_HEALTH_TIMEOUT_MS,
+  START_PID_TIMEOUT_MS,
+  waitForPidFile,
+} from './server-startup.js';
 
 const log = createLogger('ServerManager');
 
 const MAX_LOG_ENTRIES = 500;
 const HEALTH_POLL_INTERVAL_MS = 3000;
-const START_PID_TIMEOUT_MS = 30000;
-const START_HEALTH_TIMEOUT_MS = 180000;
 const STOP_TIMEOUT_MS = 10000;
 const execFileAsync = promisify(execFile);
 
@@ -584,7 +587,11 @@ export class ServerManager {
       });
 
       // Wait for PID file to appear (indicates server is ready)
-      const pidData = await this.waitForPidFile(START_PID_TIMEOUT_MS, spawnStartedAt);
+      const pidData = await waitForPidFile(
+        () => this.readPidFile(false),
+        START_PID_TIMEOUT_MS,
+        spawnStartedAt,
+      );
       if (!pidData) {
         throw new Error('Server did not write PID file within timeout');
       }
@@ -615,27 +622,6 @@ export class ServerManager {
         this.childProcess = null;
       }
     }
-  }
-
-  /**
-   * Wait for the PID file to appear.
-   */
-  private async waitForPidFile(
-    timeoutMs: number,
-    expectedStartedAfterMs?: number
-  ): Promise<ServerPidFile | null> {
-    const startTime = Date.now();
-    while (Date.now() - startTime < timeoutMs) {
-      const pidData = this.readPidFile(false);
-      if (
-        pidData &&
-        (expectedStartedAfterMs === undefined || pidData.startedAt >= expectedStartedAfterMs)
-      ) {
-        return pidData;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    }
-    return null;
   }
 
   /**

--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -596,6 +596,10 @@ export class ServerManager {
         throw new Error('Server did not write PID file within timeout');
       }
 
+      if (!(await this.isOwnedServerProcess(pidData.pid, pidData.startedAt))) {
+        throw new Error('Server process ownership could not be verified');
+      }
+
       // Wait for health check to pass
       const health = await this.waitForHealth(pidData.port, START_HEALTH_TIMEOUT_MS);
       if (!health) {

--- a/app/src/main/services/server-startup.ts
+++ b/app/src/main/services/server-startup.ts
@@ -1,0 +1,40 @@
+import type { ServerPidFile } from '../../shared/types.js';
+
+/**
+ * Bundled Windows servers may spend over 30 seconds importing CTranslate2/Torch
+ * and discovering capabilities before they can write their PID file on a cold start.
+ * Keep this bounded PID wait separate from the health-readiness allowance below.
+ */
+export const START_PID_TIMEOUT_MS = 180_000;
+export const START_HEALTH_TIMEOUT_MS = 180_000;
+
+export interface PidWaitClock {
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+export async function waitForPidFile(
+  readPidFile: () => ServerPidFile | null,
+  timeoutMs: number,
+  expectedStartedAfterMs?: number,
+  clock: PidWaitClock = {},
+): Promise<ServerPidFile | null> {
+  const now = clock.now ?? Date.now;
+  const sleep = clock.sleep ?? ((milliseconds: number) => new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  }));
+  const startedAt = now();
+
+  while (now() - startedAt < timeoutMs) {
+    const pidData = readPidFile();
+    if (
+      pidData &&
+      (expectedStartedAfterMs === undefined || pidData.startedAt >= expectedStartedAfterMs)
+    ) {
+      return pidData;
+    }
+    await sleep(200);
+  }
+
+  return null;
+}

--- a/app/src/main/services/server-startup.ts
+++ b/app/src/main/services/server-startup.ts
@@ -25,7 +25,10 @@ export async function waitForPidFile(
   }));
   const startedAt = now();
 
-  while (now() - startedAt < timeoutMs) {
+  while (true) {
+    const remaining = timeoutMs - (now() - startedAt);
+    if (remaining <= 0) break;
+
     const pidData = readPidFile();
     if (
       pidData &&
@@ -33,7 +36,7 @@ export async function waitForPidFile(
     ) {
       return pidData;
     }
-    await sleep(200);
+    await sleep(Math.min(200, remaining));
   }
 
   return null;

--- a/app/tests/server-startup.test.ts
+++ b/app/tests/server-startup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  START_HEALTH_TIMEOUT_MS,
+  START_PID_TIMEOUT_MS,
+  waitForPidFile,
+} from '../src/main/services/server-startup.js';
+
+const PID_FILE = {
+  pid: 19736,
+  port: 63328,
+  startedAt: 30_001,
+};
+
+function fakeClock() {
+  let elapsed = 0;
+  return {
+    now: () => elapsed,
+    sleep: async (milliseconds: number) => {
+      elapsed += milliseconds;
+    },
+    elapsed: () => elapsed,
+  };
+}
+
+describe('packaged server startup timing', () => {
+  test('accepts a PID file that appears after the former 30-second boundary', async () => {
+    const clock = fakeClock();
+    const result = await waitForPidFile(
+      () => (clock.elapsed() > 30_000 ? PID_FILE : null),
+      START_PID_TIMEOUT_MS,
+      0,
+      clock,
+    );
+
+    expect(result).toEqual(PID_FILE);
+    expect(clock.elapsed()).toBeGreaterThan(30_000);
+    expect(clock.elapsed()).toBeLessThanOrEqual(START_PID_TIMEOUT_MS);
+  });
+
+  test('remains bounded at the cold-start PID allowance while health stays separate', async () => {
+    const clock = fakeClock();
+    const result = await waitForPidFile(() => null, START_PID_TIMEOUT_MS, undefined, clock);
+
+    expect(result).toBeNull();
+    expect(clock.elapsed()).toBe(START_PID_TIMEOUT_MS);
+    expect(START_HEALTH_TIMEOUT_MS).toBe(180_000);
+  });
+});

--- a/app/tests/server-startup.test.ts
+++ b/app/tests/server-startup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import {
   START_HEALTH_TIMEOUT_MS,
   START_PID_TIMEOUT_MS,
@@ -37,12 +38,32 @@ describe('packaged server startup timing', () => {
     expect(clock.elapsed()).toBeLessThanOrEqual(START_PID_TIMEOUT_MS);
   });
 
-  test('remains bounded at the cold-start PID allowance while health stays separate', async () => {
+  test('caps a non-aligned timeout without extending the bounded wait', async () => {
     const clock = fakeClock();
-    const result = await waitForPidFile(() => null, START_PID_TIMEOUT_MS, undefined, clock);
+    const result = await waitForPidFile(() => null, 30_001, undefined, clock);
 
     expect(result).toBeNull();
-    expect(clock.elapsed()).toBe(START_PID_TIMEOUT_MS);
+    expect(clock.elapsed()).toBe(30_001);
     expect(START_HEALTH_TIMEOUT_MS).toBe(180_000);
+  });
+
+  test('checks PID ownership before health readiness in ServerManager startup', () => {
+    const source = readFileSync(
+      new URL('../src/main/services/server-manager.ts', import.meta.url),
+      'utf8',
+    );
+    const pidWait = source.indexOf('const pidData = await waitForPidFile');
+    const ownership = source.indexOf(
+      'await this.isOwnedServerProcess(pidData.pid, pidData.startedAt)',
+      pidWait,
+    );
+    const health = source.indexOf('const health = await this.waitForHealth', ownership);
+
+    expect(pidWait).toBeGreaterThanOrEqual(0);
+    expect(ownership).toBeGreaterThan(pidWait);
+    expect(health).toBeGreaterThan(ownership);
+    expect(source.slice(ownership, health)).toContain(
+      "throw new Error('Server process ownership could not be verified')",
+    );
   });
 });

--- a/app/tests/server-startup.test.ts
+++ b/app/tests/server-startup.test.ts
@@ -44,6 +44,7 @@ describe('packaged server startup timing', () => {
 
     expect(result).toBeNull();
     expect(clock.elapsed()).toBe(30_001);
+    expect(START_PID_TIMEOUT_MS).toBe(180_000);
     expect(START_HEALTH_TIMEOUT_MS).toBe(180_000);
   });
 


### PR DESCRIPTION
## Summary
- Extend packaged server PID-file readiness from 30 seconds to the existing bounded 180-second cold-start allowance.
- Keep health readiness separately bounded at 180 seconds.
- Add a pure clock-injectable wait seam with deterministic coverage for the former 30-second boundary and the bounded timeout.

## Root cause and lifecycle evidence
The sealed candidate-2 lifecycle run spawned the bundled Python server but timed out before its PID file appeared. ServerManager then terminated the child at the old 30-second boundary. The packaged server performs settings validation and bundled CTranslate2/Torch capability discovery before writing its PID; the previously accepted isolated packaged-server control remained healthy. This is a cold Windows startup timing defect, not a model, cache, identity, or release-artifact change.

Sanitized supervisor evidence (retained locally; no personal data): [failure disposition](E:/EveRelease/v0.8.1-394b0ef-lifecycle-2/phase1-candidate2-install/restart-diagnosis/failure-disposition.json) and [sanitized restart log](E:/EveRelease/v0.8.1-394b0ef-lifecycle-2/phase1-candidate2-install/restart-diagnosis/sanitized-log-lines.txt).

## Validation
- Focused server/profile tests: 33 passed, 0 failed.
- Full deterministic app TypeScript matrix: 173 passed, 0 failed.
- un run build:main: passed.
- Default rendered/Electron matrix reached its 300-second harness bound; worktree-scoped processes were cleaned. No source failure was observed in the deterministic matrix.
- No packaging, model download, lifecycle, profile/cache, or release mutation was performed.

## Scope
Source-only change to the app server startup wait and deterministic tests. Capability validation, PID ordering after settings/port resolution, stale-PID timestamp filtering, health timeout, and Eve identity/update boundaries are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup monitoring to reliably detect the correct server process within configured time limits.
  * Added separate timeout handling for process startup and health checks.
  * Prevented startup checks from waiting indefinitely when server information is unavailable.
  * Improved handling of delayed process information during startup.

* **Tests**
  * Added coverage for delayed process detection, timeout behavior, and process ownership verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->