### PR TITLE
docs: track post-v0.8.1 quality backlog

### DIFF
--- a/docs/plans/2026-08-09-post-v0.8.1-quality-backlog.md
+++ b/docs/plans/2026-08-09-post-v0.8.1-quality-backlog.md
@@ -1,0 +1,286 @@
+# Eve post-v0.8.1 quality backlog
+
+Status: Open  
+Created: 2026-08-09  
+Baseline: public v0.8.1, source `7c35a0bc1f8dcb33aef248bae31f9dd1b27fd199`
+
+## Purpose
+
+Track the runtime, interaction, layout, and visual-quality issues found during hands-on use of v0.8.1. An item is complete only when its behavior, failure handling, accessibility, and packaged Windows behavior have been verified. A visually plausible fixture alone is not acceptance.
+
+## Evidence supplied
+
+The following local captures motivated this backlog. They are not committed artifacts and may be moved or deleted independently of the repository.
+
+| Capture | Observation |
+| --- | --- |
+| `codex-clipboard-ca17dda1-5095-41f9-a19b-7a48f812a79f.png` | Nemotron preparation shows “Step 2 of 3” and “Estimating time remaining…” without byte progress or a progress bar. |
+| `pasted-text.txt` | Nemotron downloads, then the native process terminates with `Could not load symbol cudnnGetLibConfig. Error code 127`; Whisper recovers successfully. |
+| `codex-clipboard-bb2a1f53-baf6-45f1-9a14-a98ec51e025c.png` | Settings geometry does not align consistently with the other primary pages. |
+| `codex-clipboard-7666669a-c2d5-4185-96bd-e1ff96676788.png` | Scroll ownership and long Settings/server-log content produce an oversized, awkward viewport with competing scroll behavior. |
+| `codex-clipboard-8cc3cd36-6965-4977-9215-1ea3d8a338c7.png` | Settings controls need consistent spacing, width, and neutral visual treatment. |
+| `codex-clipboard-b83aecc2-a33f-4b9e-b31b-ad437ecf4e09.png` | The native Dictation mode dropdown opens with operating-system styling and a blue selection color outside Eve's palette. |
+
+## Priority summary
+
+| ID | Priority | Area | State |
+| --- | --- | --- | --- |
+| RUNTIME-01 | P0 | Nemotron download progress | [ ] Open |
+| RUNTIME-02 | P0 | Nemotron cuDNN crash | [ ] Open |
+| RUNTIME-03 | P0 | Transactional model switching and recovery | [ ] Open |
+| HISTORY-01 | P1 | Batch-select and delete history | [ ] Open |
+| LAYOUT-01 | P1 | Shared page width and edge margins | [ ] Open |
+| LAYOUT-02 | P1 | Single vertical scroll owner | [ ] Open |
+| LAYOUT-03 | P2 | Server-log panel sizing | [ ] Open |
+| INSIGHTS-01 | P1 | Meaningful, deterministic charts | [ ] Open |
+| VISUAL-01 | P1 | Neutral palette enforcement | [ ] Open |
+| VISUAL-02 | P1 | Eve-styled accessible dropdown | [ ] Open |
+| QA-01 | P0 | Packaged behavior and edge-case matrix | [ ] Open |
+
+## Runtime and model management
+
+### RUNTIME-01 — Report real Nemotron download progress
+
+**Problem**
+
+The shared progress card renders a determinate bar only when `progress_percent` is present. The Whisper path starts and wraps the Hugging Face byte tracker, but the Nemotron path currently reports only the coarse `downloading` phase. Users therefore see no bytes, percentage, speed, or ETA.
+
+**Required behavior**
+
+- Start byte tracking before Nemotron begins any remote transfer.
+- Bridge the actual NeMo/Hugging Face transfer path into the existing model-download state contract.
+- Report downloaded bytes, total bytes, percentage, current file category, transfer rate, and ETA when the source exposes enough information.
+- Show an explicitly indeterminate progress bar when a determinate total is genuinely unavailable; never leave an empty gap where the bar is expected.
+- Preserve resume behavior for partial caches without double-counting existing bytes.
+- Move to “Step 3 of 3” only after all required files are locally complete.
+
+**Acceptance**
+
+- [ ] A cold Nemotron download visibly advances from 0–99%, then enters loading at 100%.
+- [ ] A resumed download begins at the correct cached-byte position.
+- [ ] The UI remains accurate when transfer rate is temporarily zero or ETA cannot be calculated.
+- [ ] Whisper progress behavior remains unchanged.
+- [ ] Unit tests cover no-total, partial-cache, stalled-rate, completion, failure, and retry states.
+
+### RUNTIME-02 — Fix packaged Nemotron CUDA/cuDNN compatibility
+
+**Problem**
+
+On the packaged v0.8.1 Windows build, Nemotron terminates the native server while entering CUDA initialization with `Could not load symbol cudnnGetLibConfig. Error code 127`. The installed runtime contains cuDNN 9.1.0.70 and PyTorch 2.6.0+cu124. The first attempt spent roughly 21 minutes downloading before failing; a second cached attempt failed again in about 10 seconds. This is deterministic runtime incompatibility, not a network failure or an out-of-memory exception.
+
+The missing `hf_xet` package only causes a slower regular-HTTP fallback. The ffmpeg/pydub message is also a warning. Neither should be presented as the cause of the cuDNN crash.
+
+**Required behavior**
+
+- Identify the exact DLL consumer and incompatible cuDNN component/version or DLL search-order conflict.
+- Lock one tested NeMo, PyTorch, CUDA, and cuDNN combination for Windows packaging.
+- Verify every required cuDNN sub-library is present, mutually compatible, and resolved from the packaged runtime rather than an unrelated system installation.
+- Add a packaged preflight that exercises the required Nemotron CUDA operation, not merely `torch.cuda.is_available()`.
+- Convert a detected incompatibility into an actionable engine-preparation error without terminating the managed server.
+- Decide explicitly whether `hf_xet` should be bundled for performance; do not treat its absence as correctness failure.
+- Suppress or resolve the pydub ffmpeg warning if that path is not used by Eve.
+
+**Acceptance**
+
+- [ ] Nemotron loads from a cold cache and a warm cache on the supported Windows GPU baseline.
+- [ ] The packaged test proves a real CUDA forward/inference path.
+- [ ] A missing or mismatched DLL produces a recoverable UI error and leaves the previous engine usable.
+- [ ] No system-wide CUDA/cuDNN installation is required.
+- [ ] The packaged runtime records the exact dependency versions used by the accepted candidate.
+
+### RUNTIME-03 — Preserve transactional model-switch behavior
+
+**Invariant**
+
+The current engine, persisted settings, and usable transcription path remain intact until the candidate model has been downloaded, constructed, validated, and committed successfully.
+
+**Required cases**
+
+- [ ] Same-model selection is an idempotent no-op.
+- [ ] Rapid selection changes and repeated Apply clicks cannot start competing preparations.
+- [ ] Revert is disabled only while preparation is genuinely active and is restored on every terminal path.
+- [ ] Download, disk-space, TLS, offline, native-runtime, CUDA, OOM, and model-construction failures retain the old engine and old persisted settings.
+- [ ] Persistence failure before activation retains both old in-memory and on-disk state.
+- [ ] Managed-server death is detected; the UI does not remain stuck on “Preparing”.
+- [ ] App restart during a partial download recovers to a truthful state.
+- [ ] Dictation active during a swap is either safely completed or the switch is rejected with a clear explanation.
+- [ ] Successful activation updates Settings, Home readiness, diagnostics, and persisted settings consistently.
+
+## History
+
+### HISTORY-01 — Batch-select and delete history entries
+
+**User flow**
+
+- Add a visible selection mode to History.
+- Allow selecting individual entries and selecting all entries in the current filtered result set.
+- Show the selected count and clear actions for Select all, Clear selection, and Delete selected.
+- Require confirmation that includes the exact number of entries to be deleted.
+- Keep ordinary single-entry deletion available.
+
+**Data and safety requirements**
+
+- Perform one bulk IPC/database transaction for the selected IDs rather than issuing one independent delete per row.
+- Treat missing/already-deleted IDs deterministically and report the actual deleted count.
+- Never delete entries outside the explicit selected ID set.
+- Refresh History and Insights from the committed database result.
+- Clear selection after success, cancellation, navigation away, or a material filter/query change.
+- Disable the bulk action while it is executing and prevent double submission.
+
+**Accessibility and acceptance**
+
+- [ ] Selection controls have accessible names and visible keyboard focus.
+- [ ] Keyboard users can enter selection mode, toggle rows, select all filtered results, cancel, and confirm deletion.
+- [ ] Confirmation describes destructive impact and returns focus correctly.
+- [ ] Tests cover zero, one, many, filtered, stale-ID, database-failure, and double-submit cases.
+- [ ] Insights recomputes from the remaining records after deletion.
+
+## Layout and scrolling
+
+### LAYOUT-01 — Use one shared content geometry across primary pages
+
+**Problem**
+
+Home, History, Insights, and Settings currently use different maximum widths and padding rules. Their content edges move when changing tabs, making Settings appear wider than History/Insights and producing inconsistent page borders.
+
+**Required behavior**
+
+- Define one shared primary-page container token/component for maximum width, horizontal padding, centering, and responsive breakpoints.
+- Make Home, History, Insights, and Settings align to the same left and right content edges at the same window size.
+- Allow a deliberate narrower reading column only inside the shared outer geometry; do not change the page boundary itself.
+- Align headings, cards, empty states, status banners, and bottom padding to the same grid.
+
+**Acceptance**
+
+- [ ] Tab switching at every supported window width produces no horizontal jump.
+- [ ] Primary card borders align across all four pages.
+- [ ] Minimum-width and maximized-window screenshots are covered by deterministic visual checks.
+
+### LAYOUT-02 — Remove the outer/duplicate scrollbar
+
+**Problem**
+
+More than one ancestor can currently become vertically scrollable. Long Settings content can expose an outer scrollbar in addition to the intended page scrollbar.
+
+**Required behavior**
+
+- The application shell/document must not scroll.
+- Exactly one primary vertical scroll owner exists for each page.
+- Header/navigation remains fixed without creating another scrollable ancestor.
+- Nested scrolling is permitted only for bounded content that needs it, such as a long log viewer or dropdown list.
+- Prevent horizontal overflow at minimum supported width.
+- Preserve focus visibility and scroll-to-error behavior.
+
+**Acceptance**
+
+- [ ] Only one page scrollbar is visible on Home, History, Insights, and Settings.
+- [ ] Mouse wheel, touchpad, Page Up/Down, Home/End, and keyboard focus scrolling target the correct owner.
+- [ ] Opening and closing dialogs/dropdowns neither shifts page width nor creates a second scrollbar.
+
+### LAYOUT-03 — Size the server-log region to its content
+
+- Avoid a near-window-height empty log surface when little or no output exists.
+- Use an intentional minimum and maximum height; allow the log body, not the whole page, to scroll after the maximum is reached.
+- Preserve the local-path privacy warning and copy affordance.
+- Provide useful empty, loading, unavailable, and error states.
+- Do not let the log region obscure About/version information or produce nested full-page scrolling.
+
+## Insights
+
+### INSIGHTS-01 — Make charts meaningful and deterministic
+
+**Problem**
+
+Charts must communicate real persisted history, not visually random, malformed, or misleading progress shapes.
+
+**Required behavior**
+
+- Every plotted value must derive from persisted history through a named aggregation with a documented time range and unit.
+- Sort time buckets chronologically and fill missing buckets explicitly with zero or a visible gap according to the metric's meaning.
+- Never generate placeholder/random values in production.
+- Label the metric, period, axes or scale, units, and current total clearly enough to interpret the chart.
+- Handle empty history, one record, identical values, sparse periods, deleted records, clock boundaries, and very large values without NaN, Infinity, negative widths, or broken paths.
+- Use honest scales; do not exaggerate tiny differences through an unexplained truncated baseline.
+- Recompute after history additions and batch deletions.
+
+**Acceptance**
+
+- [ ] Known fixture records produce exact expected buckets and chart geometry.
+- [ ] Empty and sparse states are useful and visually stable.
+- [ ] No chart element is emitted with non-finite coordinates or dimensions.
+- [ ] Totals shown beside charts reconcile with History for the same filter and period.
+
+## Visual system
+
+### VISUAL-01 — Enforce Eve's neutral palette
+
+**Palette rule**
+
+The default application chrome and controls use Eve's black, zinc/gray, and white palette. Color is reserved for a small, documented semantic set: destructive/error, warning/preparation, success/ready, and focus/selection where necessary for accessibility. Decorative blue, cyan, green, amber, or platform-default colors must not leak into ordinary controls.
+
+**Required behavior**
+
+- Centralize surface, border, text, hover, active, disabled, focus, and semantic-state tokens.
+- Audit navigation, buttons, toggles, radios, inputs, selects, progress, charts, badges, dialogs, and scrollbars.
+- Maintain WCAG-compatible contrast and do not encode state by color alone.
+- Ensure enabled/disabled toggles and destructive actions remain unmistakable in the neutral system.
+
+### VISUAL-02 — Replace mismatched native dropdown presentation
+
+**Problem**
+
+The closed Dictation mode field is styled, but its opened native `<select>` menu uses Windows styling and a blue selection highlight outside Eve's palette.
+
+**Required behavior**
+
+- Introduce one reusable Eve dropdown/listbox component for settings that need consistent opened-menu styling.
+- Use neutral surfaces, borders, selected state, hover state, and focus ring from the shared palette.
+- Support Arrow keys, Home/End, Enter/Space, Escape, typeahead, click-outside dismissal, and correct focus restoration.
+- Expose correct accessible name, role, expanded state, active option, and selected option semantics.
+- Position the popup without clipping or causing document overflow; flip or constrain it near viewport edges.
+- Apply it consistently rather than fixing only Dictation mode.
+
+**Acceptance**
+
+- [ ] The open and closed dropdown match Eve on packaged Windows.
+- [ ] No operating-system blue selection surface is visible.
+- [ ] Keyboard and screen-reader behavior passes component tests.
+- [ ] Opening the menu does not create a second scrollbar or move surrounding content.
+
+## QA and release gate
+
+### QA-01 — Verify real behavior, not only appearance
+
+**Automated layers**
+
+- Unit tests for progress math, Insights aggregation, bulk deletion, and model-switch state transitions.
+- Renderer/component tests for selection mode, confirmation, shared geometry, scroll ownership, dropdown keyboard behavior, and chart empty/sparse states.
+- Server tests for Nemotron progress bridging, dependency preflight, failure recovery, and transactional activation.
+- Full relevant app and server matrices at a stable exact head.
+
+**Packaged Windows layers**
+
+- Build one immutable exact-head candidate only after source review acceptance.
+- Verify Home, History, Insights, and Settings at minimum, normal, and maximized window sizes.
+- Exercise cold and cached model preparation, successful Whisper↔Nemotron switching, failure rollback, restart recovery, and subsequent Quick/Long dictation.
+- Verify the real Nemotron CUDA inference path on supported hardware.
+- Verify history single delete, filtered bulk delete, Insights recomputation, and persistence across restart.
+- Confirm one scrollbar, consistent content edges, neutral dropdowns, and meaningful charts in the packaged app.
+- Preserve user profiles/caches during install, repair, rollback, uninstall, and reinstall validation.
+
+**Review and completion gates**
+
+- [ ] Each issue is linked to its implementation PR and exact accepted head.
+- [ ] Hosted CI and a real review run on the stable head.
+- [ ] Supervisor audits the exact diff and the invariants above independently.
+- [ ] No issue is marked complete solely because its happy path works.
+- [ ] Release notes identify the Nemotron runtime fix, progress reporting, batch deletion, and visible UX changes.
+
+## Recommended delivery order
+
+1. Fix and package-validate RUNTIME-01, RUNTIME-02, and RUNTIME-03 first; Nemotron correctness is the release blocker.
+2. Establish LAYOUT-01, LAYOUT-02, VISUAL-01, and VISUAL-02 as shared foundations.
+3. Implement HISTORY-01 against a bulk transactional data contract.
+4. Correct INSIGHTS-01 and verify it reacts to the new bulk-delete flow.
+5. Complete LAYOUT-03 and remaining visual audit items.
+6. Run QA-01 as one exact-head packaged lifecycle before publication.


### PR DESCRIPTION
## Summary
- Recreate the post-v0.8.1 quality backlog tracking specification from issue #57.
- Preserve the exact 16,725-byte issue/canonical content and hash.

## Scope
- One file only: `docs/plans/2026-08-09-post-v0.8.1-quality-backlog.md`
- Base: `7c35a0bc1f8dcb33aef248bae31f9dd1b27fd199`
- Head: `9a39aba22fc0886dbb44e5f3021cabadbb75e077`
- SHA-256: `30f5cce9204ac0a4f9248f82f0d7cc6b8d347835fbe675bf468eb0a52d914825`

## Validation
- `server/tests/test_docs_consistency.py`: 2 passed.
- Exact byte/hash equality verified against issue #57 and the protected canonical duplicate.
- No source, packaging, release, profile, or candidate changes.

Refs #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a post-v0.8.1 quality backlog covering runtime and model management, history deletion, layout and scrolling, charts, visual styling, dropdown accessibility, and Windows packaging QA.
  * Documented priorities, expected behavior, acceptance criteria, testing expectations, release gates, and recommended delivery order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->