### PR TITLE
Add shared layout and accessible dropdown foundation

### DIFF
--- a/app/src/renderer/app/app.css
+++ b/app/src/renderer/app/app.css
@@ -15,6 +15,17 @@
   :root {
     color-scheme: dark;
     font-family: "Segoe UI Variable", "Segoe UI", system-ui, sans-serif;
+    /* Production surfaces stay neutral; status accents are reserved for state and focus cues. */
+    --eve-surface-0: #08090a;
+    --eve-surface-1: #111214;
+    --eve-surface-2: #18181b;
+    --eve-border: rgb(255 255 255 / 0.1);
+    --eve-text: #f4f4f5;
+    --eve-muted-text: #a1a1aa;
+    --eve-focus: #f4f4f5;
+    --eve-status-success: #86efac;
+    --eve-status-warning: #fcd34d;
+    --eve-status-error: #fca5a5;
   }
 
   html,
@@ -24,6 +35,7 @@
     height: 100%;
     min-height: 100%;
     background: #08090a;
+    overflow: hidden;
   }
 
   *, *::before, *::after {

--- a/app/src/renderer/app/components/EveDropdown.svelte
+++ b/app/src/renderer/app/components/EveDropdown.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    calculateDropdownPosition,
+    findFirstEnabledIndex,
+    findLastEnabledIndex,
+    findNextEnabledIndex,
+    findTypeaheadIndex,
+  } from './eve-dropdown';
+
+  export interface EveDropdownOption {
+    value: string;
+    label: string;
+    disabled?: boolean;
+    description?: string;
+  }
+
+  interface Props {
+    label: string;
+    value: string;
+    options: EveDropdownOption[];
+    onchange: (value: string) => void;
+    disabled?: boolean;
+    id?: string;
+    class?: string;
+  }
+
+  let {
+    label,
+    value,
+    options,
+    onchange,
+    disabled = false,
+    id,
+    class: className = '',
+  }: Props = $props();
+
+  const componentId = $props.id();
+  let buttonId = $derived(id ?? `eve-dropdown-${componentId}`);
+  let listboxId = $derived(`${buttonId}-listbox`);
+
+  let root: HTMLDivElement | undefined = $state(undefined);
+  let button: HTMLButtonElement | undefined = $state(undefined);
+  let open = $state(false);
+  let activeIndex = $state(-1);
+  let typeahead = $state('');
+  let typeaheadTimer: ReturnType<typeof setTimeout> | undefined = $state(undefined);
+  let listboxStyle = $state('top: 8px; left: 8px; width: 176px; max-height: 280px;');
+
+  let selectedIndex = $derived(options.findIndex((option) => option.value === value));
+  let selectedOption = $derived(options[selectedIndex] ?? options.find((option) => !option.disabled));
+  let activeOptionId = $derived(activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined);
+
+  function clearTypeahead(): void {
+    typeahead = '';
+    if (typeaheadTimer) clearTimeout(typeaheadTimer);
+    typeaheadTimer = undefined;
+  }
+
+  function queueTypeaheadReset(): void {
+    if (typeaheadTimer) clearTimeout(typeaheadTimer);
+    typeaheadTimer = setTimeout(clearTypeahead, 700);
+  }
+
+  function setActive(index: number): void {
+    if (index >= 0) activeIndex = index;
+  }
+
+  function positionListbox(): void {
+    if (!button) return;
+    const rect = button.getBoundingClientRect();
+    const position = calculateDropdownPosition({
+      top: rect.top,
+      bottom: rect.bottom,
+      left: rect.left,
+      width: rect.width,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      optionCount: options.length,
+    });
+    listboxStyle = `top: ${position.top}px; left: ${position.left}px; width: ${position.width}px; max-height: ${position.maxHeight}px;`;
+  }
+
+  function close(restoreFocus = false): void {
+    open = false;
+    clearTypeahead();
+    if (restoreFocus) {
+      queueMicrotask(() => button?.focus({ preventScroll: true }));
+    }
+  }
+
+  function openMenu(index = selectedIndex): void {
+    if (disabled || options.length === 0) return;
+    const nextIndex = index >= 0 && !options[index]?.disabled ? index : findFirstEnabledIndex(options);
+    if (nextIndex < 0) return;
+    activeIndex = nextIndex;
+    open = true;
+    queueMicrotask(positionListbox);
+  }
+
+  function choose(index: number): void {
+    const option = options[index];
+    if (!option || option.disabled) return;
+    onchange(option.value);
+    close(true);
+  }
+
+  function move(direction: 1 | -1): void {
+    const nextIndex = findNextEnabledIndex(options, activeIndex >= 0 ? activeIndex : selectedIndex, direction);
+    setActive(nextIndex);
+  }
+
+  function typeaheadKey(key: string): void {
+    const nextQuery = `${typeahead}${key}`;
+    const nextIndex = findTypeaheadIndex(options, nextQuery, activeIndex >= 0 ? activeIndex : selectedIndex);
+    typeahead = nextIndex >= 0 ? nextQuery : key;
+    if (nextIndex >= 0) {
+      setActive(nextIndex);
+      if (!open) openMenu(nextIndex);
+    }
+    queueTypeaheadReset();
+  }
+
+  function handleButtonKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Tab') {
+      if (open) close();
+      return;
+    }
+
+    if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey && event.key !== ' ') {
+      event.preventDefault();
+      typeaheadKey(event.key);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      if (!open) return;
+      event.preventDefault();
+      close(true);
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (!open) openMenu(findFirstEnabledIndex(options));
+      else move(1);
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!open) openMenu(findLastEnabledIndex(options));
+      else move(-1);
+      return;
+    }
+
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault();
+      const targetIndex = event.key === 'Home' ? findFirstEnabledIndex(options) : findLastEnabledIndex(options);
+      if (!open) openMenu(targetIndex);
+      else setActive(targetIndex);
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      if (!open) openMenu();
+      else choose(activeIndex);
+    }
+  }
+
+  function handleOptionClick(index: number): void {
+    choose(index);
+  }
+
+  $effect(() => {
+    if (!open) return;
+    queueMicrotask(positionListbox);
+    const handleViewportChange = () => positionListbox();
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('scroll', handleViewportChange, true);
+    return () => {
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('scroll', handleViewportChange, true);
+    };
+  });
+
+  $effect(() => {
+    if (!open) {
+      activeIndex = selectedIndex >= 0 ? selectedIndex : findFirstEnabledIndex(options);
+    } else if (activeIndex < 0 || options[activeIndex]?.disabled) {
+      activeIndex = selectedIndex >= 0 && !options[selectedIndex]?.disabled
+        ? selectedIndex
+        : findFirstEnabledIndex(options);
+    }
+  });
+
+  onMount(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      if (open && !root?.contains(event.target as Node)) close(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      clearTypeahead();
+    };
+  });
+</script>
+
+<div bind:this={root} data-eve-dropdown class="relative min-w-0 w-full max-w-full sm:w-auto {className}">
+  <button
+    bind:this={button}
+    id={buttonId}
+    type="button"
+    role="combobox"
+    aria-label={label}
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    aria-controls={listboxId}
+    aria-activedescendant={open ? activeOptionId : undefined}
+    {disabled}
+    class="flex min-h-9 min-w-0 w-full max-w-full items-center justify-between gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-left text-xs text-zinc-200 transition-colors hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:min-w-32 sm:w-auto"
+    onclick={() => open ? close() : openMenu()}
+    onkeydown={handleButtonKeydown}
+  >
+    <span class="min-w-0 truncate">{selectedOption?.label ?? 'Choose an option'}</span>
+    <svg viewBox="0 0 12 12" class="h-3 w-3 shrink-0 text-zinc-400" aria-hidden="true">
+      <path d="M3 4.5 6 7.5l3-3" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  </button>
+
+  {#if open}
+    <div
+      id={listboxId}
+      role="listbox"
+      aria-label={label}
+      aria-labelledby={buttonId}
+      class="fixed z-50 overflow-x-hidden overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-950 p-1 shadow-[0_16px_40px_rgba(0,0,0,0.55)] focus:outline-none"
+      style={listboxStyle}
+    >
+      {#each options as option, index}
+        <button
+          id={`${listboxId}-option-${index}`}
+          type="button"
+          role="option"
+          tabindex="-1"
+          aria-selected={option.value === value}
+          aria-disabled={option.disabled || undefined}
+          aria-describedby={option.description ? `${listboxId}-option-${index}-description` : undefined}
+          disabled={option.disabled}
+          class="flex min-h-9 w-full min-w-0 items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-45 {option.value === value ? 'bg-white/[0.09] text-zinc-100' : 'text-zinc-400 hover:bg-white/[0.06] hover:text-zinc-100'}"
+          onclick={() => handleOptionClick(index)}
+        >
+          <span class="min-w-0 truncate">{option.label}</span>
+          {#if option.description}<span id={`${listboxId}-option-${index}-description`} class="sr-only">{option.description}</span>{/if}
+          {#if option.value === value}<span aria-hidden="true" class="shrink-0 text-zinc-200">✓</span>{/if}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/app/src/renderer/app/components/EveDropdown.svelte
+++ b/app/src/renderer/app/components/EveDropdown.svelte
@@ -248,7 +248,7 @@
           aria-disabled={option.disabled || undefined}
           aria-describedby={option.description ? `${listboxId}-option-${index}-description` : undefined}
           disabled={option.disabled}
-          class="flex min-h-9 w-full min-w-0 items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-45 {option.value === value ? 'bg-white/[0.09] text-zinc-100' : 'text-zinc-400 hover:bg-white/[0.06] hover:text-zinc-100'}"
+          class="flex min-h-9 w-full min-w-0 items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-45 {option.value === value ? 'bg-white/[0.09] text-zinc-100' : 'text-zinc-400 hover:bg-white/[0.06] hover:text-zinc-100'} {index === activeIndex ? 'ring-1 ring-inset ring-zinc-300/70' : ''}"
           onclick={() => handleOptionClick(index)}
         >
           <span class="min-w-0 truncate">{option.label}</span>

--- a/app/src/renderer/app/components/PrimaryPage.svelte
+++ b/app/src/renderer/app/components/PrimaryPage.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type PrimaryPageName = 'home' | 'history' | 'insights' | 'settings';
+
+  interface Props {
+    page: PrimaryPageName;
+    scrollOwner?: string;
+    contentClass?: string;
+    children: Snippet;
+  }
+
+  let {
+    page,
+    scrollOwner = page,
+    contentClass = '',
+    children,
+  }: Props = $props();
+</script>
+
+<div data-primary-page={page} class="h-full min-h-0 min-w-0 overflow-hidden">
+  <div
+    data-primary-page-scroll
+    data-scroll-owner={scrollOwner}
+    data-home-scroll-owner={page === 'home' ? 'true' : undefined}
+    class="h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto overscroll-contain [overflow-anchor:none] [scroll-behavior:auto] [scrollbar-gutter:stable]"
+  >
+    <div
+      data-primary-page-content
+      class="mx-auto min-h-full min-w-0 w-full max-w-4xl px-4 py-4 sm:px-6 sm:py-6 {contentClass}"
+    >
+      {@render children()}
+    </div>
+  </div>
+</div>

--- a/app/src/renderer/app/components/SettingsRow.svelte
+++ b/app/src/renderer/app/components/SettingsRow.svelte
@@ -26,11 +26,12 @@
   <div
     data-settings-control
     class="flex min-w-0 w-full max-w-full items-center justify-end justify-self-end
-      [&>button]:max-w-full [&>div]:max-w-full [&>input]:max-w-full [&>select]:max-w-full [&>textarea]:max-w-full
+      [&>button]:max-w-full [&>div]:max-w-full [&>input]:max-w-full [&>select]:max-w-full [&>textarea]:max-w-full [&>[data-eve-dropdown]]:max-w-full
       [&>div]:min-w-0
       [&_button]:focus-visible:outline-none [&_button]:focus-visible:ring-2 [&_button]:focus-visible:ring-zinc-100
       [&_input]:focus-visible:outline-none [&_input]:focus-visible:ring-2 [&_input]:focus-visible:ring-zinc-100
       [&_select]:focus-visible:outline-none [&_select]:focus-visible:ring-2 [&_select]:focus-visible:ring-zinc-100
+      [&_[data-eve-dropdown] button]:focus-visible:outline-none [&_[data-eve-dropdown] button]:focus-visible:ring-2 [&_[data-eve-dropdown] button]:focus-visible:ring-zinc-100
       [&_textarea]:focus-visible:outline-none [&_textarea]:focus-visible:ring-2 [&_textarea]:focus-visible:ring-zinc-100"
   >
     {@render children()}

--- a/app/src/renderer/app/components/eve-dropdown.ts
+++ b/app/src/renderer/app/components/eve-dropdown.ts
@@ -1,0 +1,92 @@
+export interface DropdownPositionInput {
+  top: number;
+  bottom: number;
+  left: number;
+  width: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  optionCount: number;
+  optionHeight?: number;
+  maxHeight?: number;
+  viewportPadding?: number;
+}
+
+export interface DropdownPosition {
+  top: number;
+  left: number;
+  width: number;
+  maxHeight: number;
+  placement: 'above' | 'below';
+}
+
+export function findNextEnabledIndex<T extends { disabled?: boolean }>(
+  options: readonly T[],
+  startIndex: number,
+  direction: 1 | -1,
+): number {
+  if (options.length === 0) return -1;
+
+  let index = startIndex;
+  for (let count = 0; count < options.length; count += 1) {
+    index = (index + direction + options.length) % options.length;
+    if (!options[index]?.disabled) return index;
+  }
+  return -1;
+}
+
+export function findFirstEnabledIndex<T extends { disabled?: boolean }>(options: readonly T[]): number {
+  return options.findIndex((option) => !option.disabled);
+}
+
+export function findLastEnabledIndex<T extends { disabled?: boolean }>(options: readonly T[]): number {
+  for (let index = options.length - 1; index >= 0; index -= 1) {
+    if (!options[index]?.disabled) return index;
+  }
+  return -1;
+}
+
+export function findTypeaheadIndex<T extends { label: string; disabled?: boolean }>(
+  options: readonly T[],
+  query: string,
+  startIndex = -1,
+): number {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (!normalized || options.length === 0) return -1;
+
+  for (let offset = 1; offset <= options.length; offset += 1) {
+    const index = (startIndex + offset + options.length) % options.length;
+    const option = options[index];
+    if (!option?.disabled && option.label.toLocaleLowerCase().startsWith(normalized)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+export function calculateDropdownPosition(input: DropdownPositionInput): DropdownPosition {
+  const padding = input.viewportPadding ?? 8;
+  const optionHeight = input.optionHeight ?? 36;
+  const requestedMaxHeight = input.maxHeight ?? 280;
+  const availableWidth = Math.max(1, input.viewportWidth - padding * 2);
+  const width = Math.min(Math.max(input.width, 176), availableWidth);
+  const left = Math.min(
+    Math.max(input.left, padding),
+    Math.max(padding, input.viewportWidth - width - padding),
+  );
+  const desiredHeight = Math.min(
+    requestedMaxHeight,
+    Math.max(optionHeight, input.optionCount * optionHeight + padding),
+  );
+  const belowSpace = Math.max(1, input.viewportHeight - input.bottom - padding);
+  const aboveSpace = Math.max(1, input.top - padding);
+  const placement = belowSpace < Math.min(desiredHeight, optionHeight * 4) && aboveSpace > belowSpace
+    ? 'above'
+    : 'below';
+  const availableHeight = placement === 'above' ? aboveSpace : belowSpace;
+  const maxHeight = Math.max(1, Math.min(desiredHeight, availableHeight));
+  const top = placement === 'above'
+    ? Math.max(padding, input.top - maxHeight - 4)
+    : Math.max(padding, Math.min(input.viewportHeight - padding - maxHeight, input.bottom + 4));
+
+  return { top, left, width, maxHeight, placement };
+}

--- a/app/src/renderer/app/fixtures/SettingsLayoutFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsLayoutFixture.svelte
@@ -3,6 +3,7 @@
   import SettingsRow from '../components/SettingsRow.svelte';
   import SettingsSection from '../components/SettingsSection.svelte';
   import Toggle from '../components/Toggle.svelte';
+  import EveDropdown from '../components/EveDropdown.svelte';
 
   const modelDownload = {
     model: 'large-v3-turbo',
@@ -53,9 +54,12 @@
 
           <SettingsSection title="Dictation/output">
             <SettingsRow label="Dictation mode" description="Local rule-based cleanup before copy or paste">
-              <select aria-label="Dictation mode" class="w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 sm:w-auto">
-                <option>Clean Prompt</option>
-              </select>
+              <EveDropdown
+                label="Dictation mode"
+                value="clean_prompt"
+                options={[{ value: 'clean_prompt', label: 'Clean Prompt' }]}
+                onchange={() => undefined}
+              />
             </SettingsRow>
             <SettingsRow label="Append space" description="Add a trailing space after transcriptions">
               <Toggle enabled={false} label="Append space" />

--- a/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
@@ -6,6 +6,7 @@
   import SettingsSection from '../components/SettingsSection.svelte';
   import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
   import Toggle from '../components/Toggle.svelte';
+  import EveDropdown from '../components/EveDropdown.svelte';
 
   type FixtureState = 'ready' | 'preparing' | 'error' | 'external';
 
@@ -103,9 +104,7 @@
 
                 <SettingsGroup title="Audio">
                   <SettingsRow label="Input device" description="Select microphone for recording">
-                    <select aria-label="Input device" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto">
-                      <option>Default</option>
-                    </select>
+                    <EveDropdown label="Input device" value="default" options={[{ value: 'default', label: 'Default' }]} onchange={() => undefined} />
                   </SettingsRow>
                 </SettingsGroup>
 
@@ -114,9 +113,7 @@
                     <Toggle enabled={false} label="Append period" />
                   </SettingsRow>
                   <SettingsRow label="Dictation mode" description="Local rule-based cleanup before copy or paste">
-                    <select aria-label="Dictation mode" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 sm:w-auto">
-                      <option>Clean Prompt</option>
-                    </select>
+                    <EveDropdown label="Dictation mode" value="clean_prompt" options={[{ value: 'clean_prompt', label: 'Clean Prompt' }]} onchange={() => undefined} />
                   </SettingsRow>
                 </SettingsGroup>
 
@@ -202,10 +199,10 @@
                   </button>
                 </div>
                 <div id="fixture-compatibility-controls" data-fixture-compatibility-controls hidden={!compatibilityOpen} class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2">
-                    <SettingsRow label="Whisper model" description="Raw compatibility model"><select aria-label="Whisper model" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>large-v3-turbo</option><option>large-v3</option></select></SettingsRow>
-                    <SettingsRow label="Compute type" description="Precision used by Faster-Whisper"><select aria-label="Compute type" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>int8</option><option>float16</option></select></SettingsRow>
+                    <SettingsRow label="Whisper model" description="Raw compatibility model"><EveDropdown label="Whisper model" value="large-v3-turbo" options={[{ value: 'large-v3-turbo', label: 'large-v3-turbo' }, { value: 'large-v3', label: 'large-v3' }]} onchange={() => undefined} /></SettingsRow>
+                    <SettingsRow label="Compute type" description="Precision used by Faster-Whisper"><EveDropdown label="Compute type" value="int8" options={[{ value: 'int8', label: 'int8' }, { value: 'float16', label: 'float16' }]} onchange={() => undefined} /></SettingsRow>
                     <SettingsRow label="Language" description="Language hint for compatibility"><input aria-label="Whisper language" value="auto" class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-28" /></SettingsRow>
-                    <SettingsRow label="Device" description="Hardware device for inference"><select aria-label="Whisper device" class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 sm:w-auto"><option>cuda</option><option>cpu</option></select></SettingsRow>
+                    <SettingsRow label="Device" description="Hardware device for inference"><EveDropdown label="Whisper device" value="cuda" options={[{ value: 'cuda', label: 'cuda' }, { value: 'cpu', label: 'cpu' }]} onchange={() => undefined} /></SettingsRow>
                     <SettingsRow label="Unload before swap" description="Free VRAM before loading a new engine"><Toggle enabled label="Unload before swap" /></SettingsRow>
                 </div>
                 <div data-fixture-compatibility-footer class="mt-4 border-t border-white/[0.08] pt-4">

--- a/app/src/renderer/app/views/HistoryView.svelte
+++ b/app/src/renderer/app/views/HistoryView.svelte
@@ -4,6 +4,7 @@
   import { quintOut } from 'svelte/easing';
   import { toast } from '$lib/toast.svelte';
   import type { HistoryEntryWithGroup, HistoryFilters } from '$shared/types';
+  import PrimaryPage from '../components/PrimaryPage.svelte';
 
   const BATCH_SIZE = 30;
 
@@ -368,7 +369,8 @@
 
 <svelte:window onkeydown={handleWindowKeydown} />
 
-<div class="mx-auto flex h-full w-full max-w-[560px] flex-col px-4 py-4 pr-2">
+<PrimaryPage page="history" scrollOwner="history" contentClass="pb-4">
+<div class="mx-auto flex min-h-full w-full max-w-[560px] flex-col">
   <!-- Search Bar -->
   <div class="pb-3 pr-3">
     <div class="relative">
@@ -398,7 +400,7 @@
         aria-label="Toggle history filters"
         aria-expanded={showFilters}
         class="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-full transition-colors cursor-pointer
-          {showFilters || hasActiveFilters ? 'text-blue-400 bg-blue-950/50' : 'text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800'}"
+          {showFilters || hasActiveFilters ? 'text-zinc-200 bg-white/[0.08]' : 'text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800'}"
         title="Filters"
       >
         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -484,8 +486,8 @@
                 type="checkbox"
                 bind:checked={editedOnly}
                 onchange={handleFilterChange}
-                class="w-4 h-4 rounded border-zinc-700 bg-zinc-800 text-blue-500
-                  focus:ring-blue-500 focus:ring-offset-0 cursor-pointer"
+                class="w-4 h-4 rounded border-zinc-700 bg-zinc-800 text-zinc-200
+                  focus:ring-zinc-200 focus:ring-offset-0 cursor-pointer"
               />
               <span class="text-sm text-zinc-300">Edited only</span>
             </label>
@@ -508,7 +510,7 @@
   </div>
 
   <!-- History List -->
-  <div class="flex-1 overflow-y-auto pr-3">
+  <div class="flex-1 pr-3">
     {#if loadError}
       <div class="rounded-[10px] border border-red-400/40 bg-red-950/30 p-4" role="alert">
         <p class="text-sm text-red-200">{loadError}</p>
@@ -567,7 +569,7 @@
                   <p class="mt-1 text-[11px] text-zinc-500">
                     {formatTime(item.timestamp)}
                     {#if item.editedAt}
-                      <span class="ml-2 text-blue-400/70">edited</span>
+                      <span class="ml-2 text-zinc-500">edited</span>
                     {/if}
                   </p>
                 </button>
@@ -678,6 +680,7 @@
     {/if}
   </div>
 </div>
+</PrimaryPage>
 
 <!-- Delete Confirmation Dialog -->
 {#if deleteConfirmId}

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import type { ServerStatusPhase } from '../server-status';
   import { getServerManagementMode, retryManagedServer, serverStatusState } from '../server-status';
+  import PrimaryPage from '../components/PrimaryPage.svelte';
 
   interface Props {
     onNavigate: (view: 'history' | 'insights' | 'settings') => void;
@@ -77,15 +78,14 @@
   }
 </script>
 
-<div data-home-scroll-owner class="h-full overflow-y-auto overscroll-contain px-4 py-5 sm:px-6 sm:py-7">
-  <div class="mx-auto flex max-w-4xl flex-col gap-4 pb-5">
+<PrimaryPage page="home" scrollOwner="home" contentClass="flex flex-col gap-4 pb-5">
     <section
       data-home-hero
-      class="relative min-w-0 overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_82%_18%,rgba(56,189,248,0.14),transparent_34%),radial-gradient(circle_at_22%_90%,rgba(16,185,129,0.10),transparent_38%),linear-gradient(145deg,rgba(255,255,255,0.055),rgba(255,255,255,0.018))] px-5 py-6 sm:px-7 sm:py-7"
+      class="relative min-w-0 overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_82%_18%,rgba(255,255,255,0.08),transparent_34%),radial-gradient(circle_at_22%_90%,rgba(161,161,170,0.08),transparent_38%),linear-gradient(145deg,rgba(255,255,255,0.055),rgba(255,255,255,0.018))] px-5 py-6 sm:px-7 sm:py-7"
       aria-labelledby="home-readiness-heading"
     >
-      <div aria-hidden="true" class="pointer-events-none absolute -right-20 -top-24 h-64 w-64 rounded-full border border-sky-300/10"></div>
-      <div aria-hidden="true" class="pointer-events-none absolute -right-8 -top-12 h-40 w-40 rounded-full border border-sky-300/10"></div>
+      <div aria-hidden="true" class="pointer-events-none absolute -right-20 -top-24 h-64 w-64 rounded-full border border-white/10"></div>
+      <div aria-hidden="true" class="pointer-events-none absolute -right-8 -top-12 h-40 w-40 rounded-full border border-white/10"></div>
 
       <div class="relative grid min-w-0 gap-7 md:grid-cols-[minmax(0,1fr)_220px] md:items-center">
         <div class="min-w-0">
@@ -127,8 +127,8 @@
         </div>
 
         <div data-home-voice-orb class="relative mx-auto flex h-44 w-44 items-center justify-center md:h-48 md:w-48" aria-hidden="true">
-          <div class="absolute inset-0 rounded-full border border-white/10 bg-white/[0.025] shadow-[0_20px_80px_rgba(14,165,233,0.10)]"></div>
-          <div class="absolute inset-5 rounded-full border border-sky-300/15 bg-gradient-to-br from-sky-300/10 via-transparent to-emerald-300/10 {snapshot.phase === 'ready' ? 'motion-safe:animate-pulse' : ''}"></div>
+          <div class="absolute inset-0 rounded-full border border-white/10 bg-white/[0.025] shadow-[0_20px_80px_rgba(255,255,255,0.04)]"></div>
+          <div class="absolute inset-5 rounded-full border border-white/10 bg-gradient-to-br from-white/10 via-transparent to-zinc-500/10 {snapshot.phase === 'ready' ? 'motion-safe:animate-pulse' : ''}"></div>
           <div class="relative flex h-20 w-24 items-center justify-center gap-1 rounded-full border border-white/10 bg-black/25 shadow-inner">
             {#each ['h-1.5', 'h-2.5', 'h-4', 'h-6', 'h-4', 'h-2.5', 'h-1.5'] as heightClass}
               <span class="w-1 rounded-full {heightClass} {phaseAccent === 'emerald' ? 'bg-emerald-300/80' : phaseAccent === 'red' ? 'bg-red-300/70' : phaseAccent === 'amber' ? 'bg-amber-300/75' : 'bg-zinc-500'} {snapshot.phase === 'ready' ? 'motion-safe:animate-pulse' : ''}"></span>
@@ -165,25 +165,25 @@
     </section>
 
     <section data-home-modes class="grid gap-3 sm:grid-cols-2" aria-label="Dictation shortcuts and guidance">
-      <article class="group min-w-0 rounded-2xl border border-white/[0.08] bg-white/[0.025] p-4 transition-colors hover:border-sky-300/20 hover:bg-sky-300/[0.035]">
+      <article class="group min-w-0 rounded-2xl border border-white/[0.08] bg-white/[0.025] p-4 transition-colors hover:border-white/20 hover:bg-white/[0.04]">
         <div class="flex min-w-0 items-start justify-between gap-3">
           <div class="min-w-0">
-            <p class="text-xs font-medium text-sky-300">Quick</p>
+            <p class="text-xs font-medium text-zinc-300">Quick</p>
             <h2 class="mt-1 text-base font-semibold text-zinc-100">Say it. Send it.</h2>
             <p class="mt-1 text-xs leading-5 text-zinc-500">Short, immediate speech-to-text input.</p>
           </div>
-          <span aria-hidden="true" class="text-lg text-zinc-600 transition-transform group-hover:translate-x-0.5 group-hover:text-sky-300">→</span>
+          <span aria-hidden="true" class="text-lg text-zinc-600 transition-transform group-hover:translate-x-0.5 group-hover:text-zinc-200">→</span>
         </div>
         <p class="mt-4 inline-flex max-w-full rounded-lg bg-black/25 px-2.5 py-1.5 font-mono text-xs text-zinc-300 [overflow-wrap:anywhere]">{quickHotkey}</p>
       </article>
-      <article class="group min-w-0 rounded-2xl border border-white/[0.08] bg-white/[0.025] p-4 transition-colors hover:border-violet-300/20 hover:bg-violet-300/[0.035]">
+      <article class="group min-w-0 rounded-2xl border border-white/[0.08] bg-white/[0.025] p-4 transition-colors hover:border-white/20 hover:bg-white/[0.04]">
         <div class="flex min-w-0 items-start justify-between gap-3">
           <div class="min-w-0">
-            <p class="text-xs font-medium text-violet-300">Long</p>
+            <p class="text-xs font-medium text-zinc-300">Long</p>
             <h2 class="mt-1 text-base font-semibold text-zinc-100">Keep the thought flowing.</h2>
             <p class="mt-1 text-xs leading-5 text-zinc-500">Longer recordings are processed after capture.</p>
           </div>
-          <span aria-hidden="true" class="text-lg text-zinc-600 transition-transform group-hover:translate-x-0.5 group-hover:text-violet-300">→</span>
+          <span aria-hidden="true" class="text-lg text-zinc-600 transition-transform group-hover:translate-x-0.5 group-hover:text-zinc-200">→</span>
         </div>
         <p class="mt-4 inline-flex max-w-full rounded-lg bg-black/25 px-2.5 py-1.5 font-mono text-xs text-zinc-300 [overflow-wrap:anywhere]">{longHotkey}</p>
       </article>
@@ -208,5 +208,4 @@
     {#if engine && reportedLanguages.length > 0}
       <p class="sr-only">Languages reported by the current engine: {reportedLanguages.join(', ')}.</p>
     {/if}
-  </div>
-</div>
+</PrimaryPage>

--- a/app/src/renderer/app/views/InsightsView.svelte
+++ b/app/src/renderer/app/views/InsightsView.svelte
@@ -8,6 +8,8 @@
     InsightsWordStat,
   } from '$shared/types';
   import { createLatestRequestGuard } from '../latest-request';
+  import PrimaryPage from '../components/PrimaryPage.svelte';
+  import EveDropdown from '../components/EveDropdown.svelte';
 
   const ranges: Array<{ id: InsightsRange; label: string }> = [
     { id: 'today', label: 'Today' },
@@ -21,10 +23,6 @@
   let loading = $state(false);
   let error = $state<string | null>(null);
   let scrollContainer: HTMLDivElement | undefined = $state(undefined);
-  let rangeMenuContainer: HTMLDivElement | undefined = $state(undefined);
-  let rangeMenu: HTMLDivElement | undefined = $state(undefined);
-  let rangeButton: HTMLButtonElement | undefined = $state(undefined);
-  let rangeMenuOpen = $state(false);
   const insightRequests = createLatestRequestGuard();
 
   async function loadInsights() {
@@ -48,60 +46,9 @@
   }
 
   function selectRange(nextRange: InsightsRange) {
-    rangeMenuOpen = false;
-    rangeButton?.focus();
     if (range === nextRange) return;
     range = nextRange;
     loadInsights();
-  }
-
-  function openRangeMenu(focus: 'first' | 'selected' | 'last' = 'selected') {
-    rangeMenuOpen = true;
-    queueMicrotask(() => {
-      const options = Array.from(rangeMenu?.querySelectorAll<HTMLButtonElement>('[role="option"]') ?? []);
-      const selectedIndex = ranges.findIndex((option) => option.id === range);
-      const targetIndex = focus === 'first' ? 0 : focus === 'last' ? options.length - 1 : selectedIndex;
-      options[Math.max(0, targetIndex)]?.focus();
-    });
-  }
-
-  function handleRangeButtonKeydown(event: KeyboardEvent) {
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-      openRangeMenu(event.key === 'ArrowDown' ? 'first' : 'last');
-    }
-  }
-
-  function handleRangeMenuKeydown(event: KeyboardEvent) {
-    const options = Array.from(rangeMenu?.querySelectorAll<HTMLButtonElement>('[role="option"]') ?? []);
-    const currentIndex = options.indexOf(document.activeElement as HTMLButtonElement);
-
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      rangeMenuOpen = false;
-      rangeButton?.focus();
-      return;
-    }
-
-    if (event.key === 'Home' || event.key === 'End') {
-      event.preventDefault();
-      options[event.key === 'Home' ? 0 : options.length - 1]?.focus();
-      return;
-    }
-
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-      const direction = event.key === 'ArrowDown' ? 1 : -1;
-      const nextIndex = (currentIndex + direction + options.length) % options.length;
-      options[nextIndex]?.focus();
-    }
-  }
-
-  function handleRangeMenuFocusout(event: FocusEvent) {
-    const nextTarget = event.relatedTarget;
-    if (!(nextTarget instanceof Node) || !rangeMenuContainer?.contains(nextTarget)) {
-      rangeMenuOpen = false;
-    }
   }
 
   function formatInteger(value: number): string {
@@ -141,6 +88,7 @@
   }
 
   onMount(() => {
+    scrollContainer = document.querySelector<HTMLDivElement>('[data-scroll-owner="insights"]') ?? undefined;
     queueMicrotask(() => scrollContainer?.scrollTo({ top: 0, behavior: 'auto' }));
     loadInsights();
 
@@ -149,16 +97,7 @@
         loadInsights();
       }
     };
-    const handlePointerDown = (event: PointerEvent) => {
-      if (rangeMenuOpen && !rangeMenuContainer?.contains(event.target as Node)) {
-        rangeMenuOpen = false;
-        if (rangeMenu?.contains(document.activeElement)) {
-          rangeButton?.focus({ preventScroll: true });
-        }
-      }
-    };
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    document.addEventListener('pointerdown', handlePointerDown);
 
     const unsubscribeNewHistoryEntry = window.murmurMain.onNewHistoryEntry(() => {
       loadInsights();
@@ -167,69 +106,25 @@
     return () => {
       insightRequests.invalidate();
       document.removeEventListener('visibilitychange', handleVisibilityChange);
-      document.removeEventListener('pointerdown', handlePointerDown);
       unsubscribeNewHistoryEntry();
     };
   });
 </script>
 
-<div class="mx-auto flex h-full w-full max-w-[560px] flex-col px-4 py-4 pr-2">
-  <div bind:this={scrollContainer} class="flex-1 overflow-y-auto pr-3">
-    <div class="mx-auto w-full">
+<PrimaryPage page="insights" scrollOwner="insights" contentClass="pb-4">
+  <div class="mx-auto flex min-h-full w-full max-w-[560px] flex-col pr-3">
     <div class="mb-4 flex items-center justify-between gap-3">
       <div class="min-w-0">
         <h1 class="sr-only">Insights</h1>
         <p class="text-[11px] text-zinc-500">Local insights from your transcription history</p>
       </div>
 
-      <div bind:this={rangeMenuContainer} class="relative shrink-0">
-        <button
-          bind:this={rangeButton}
-          type="button"
-          aria-label="Insights time range"
-          aria-haspopup="listbox"
-          aria-expanded={rangeMenuOpen}
-          aria-controls="insights-range-listbox"
-          class="flex min-w-[76px] items-center justify-between gap-2 rounded-[8px] border border-white/10 bg-white/[0.025] px-2.5 py-1.5 text-[11px] text-zinc-200 transition-colors hover:border-white/20 hover:bg-white/[0.055] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-200"
-          onclick={() => rangeMenuOpen ? (rangeMenuOpen = false) : openRangeMenu()}
-          onkeydown={handleRangeButtonKeydown}
-        >
-          <span>{ranges.find((option) => option.id === range)?.label}</span>
-          <svg viewBox="0 0 12 12" class="h-3 w-3 text-zinc-500" aria-hidden="true">
-            <path d="M3 4.5 6 7.5l3-3" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </button>
-
-        {#if rangeMenuOpen}
-          <div
-            bind:this={rangeMenu}
-            id="insights-range-listbox"
-            role="listbox"
-            tabindex="-1"
-            aria-label="Insights time range"
-            class="absolute right-0 z-30 mt-1.5 w-28 overflow-hidden rounded-[9px] border border-white/12 bg-zinc-950/98 p-1 shadow-[0_16px_40px_rgba(0,0,0,0.55)] backdrop-blur-xl"
-            onkeydown={handleRangeMenuKeydown}
-            onfocusout={handleRangeMenuFocusout}
-          >
-            {#each ranges as option}
-              <button
-                type="button"
-                role="option"
-                tabindex="-1"
-                aria-selected={option.id === range}
-                class="flex w-full items-center justify-between rounded-[6px] px-2.5 py-2 text-left text-[11px] transition-colors
-                  {option.id === range ? 'bg-white/[0.09] text-zinc-100' : 'text-zinc-400 hover:bg-white/[0.055] hover:text-zinc-200'}"
-                onclick={() => selectRange(option.id)}
-              >
-                <span>{option.label}</span>
-                {#if option.id === range}
-                  <span class="text-zinc-400" aria-hidden="true">✓</span>
-                {/if}
-              </button>
-            {/each}
-          </div>
-        {/if}
-      </div>
+      <EveDropdown
+        label="Insights time range"
+        value={range}
+        options={ranges.map((option) => ({ value: option.id, label: option.label }))}
+        onchange={(value) => selectRange(value as InsightsRange)}
+      />
     </div>
 
     {#if error}
@@ -351,9 +246,8 @@
         )}
       </div>
     {/if}
-    </div>
   </div>
-</div>
+</PrimaryPage>
 
 {#snippet MiniBars(points: InsightsTrendPoint[], metric: 'dictations' | 'words' | 'audioSeconds' | 'processingMs')}
   {@const peak = Math.max(...points.map((point) => point[metric]), 1)}

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -4,6 +4,8 @@
   import SettingsRow from '../components/SettingsRow.svelte';
   import SettingsGroup from '../components/SettingsGroup.svelte';
   import SettingsSection from '../components/SettingsSection.svelte';
+  import PrimaryPage from '../components/PrimaryPage.svelte';
+  import EveDropdown, { type EveDropdownOption } from '../components/EveDropdown.svelte';
   import HotkeyCaptureModal from '../components/HotkeyCaptureModal.svelte';
   import SettingsSkeleton from '../components/SettingsSkeleton.svelte';
   import ServerView from './ServerView.svelte';
@@ -20,6 +22,18 @@
   const DEFAULT_SERVER_HOST = 'localhost';
   const DEFAULT_SERVER_PORT = 51717;
   const TRANSCRIBE_PATH = '/transcribe';
+
+  const DICTATION_MODE_OPTIONS: EveDropdownOption[] = [
+    { value: 'raw', label: 'Raw Dictation' },
+    { value: 'clean_prompt', label: 'Clean Prompt' },
+    { value: 'codex_prompt', label: 'Codex Prompt' },
+    { value: 'message_rewrite', label: 'Message Rewrite' },
+    { value: 'command', label: 'Command Mode' },
+  ];
+  const PASTE_METHOD_OPTIONS: EveDropdownOption[] = [
+    { value: 'sendinput', label: 'SendInput' },
+    { value: 'vbscript', label: 'VBScript' },
+  ];
 
   // Local settings state - loaded from main process on mount
   let settings = $state<Settings>({
@@ -143,6 +157,15 @@
       getOptions('whisper_compute_type'),
       draftWhisperDevice,
     );
+  }
+
+  function toDropdownOptions(options: Array<ServerSettingOption<unknown>>): EveDropdownOption[] {
+    return options.map((option) => ({
+      value: String(option.value),
+      label: option.label,
+      disabled: option.disabled,
+      description: option.reason,
+    }));
   }
 
   function isEngineAvailable(engineId: unknown): boolean {
@@ -550,8 +573,8 @@
   }
 </script>
 
-<div class="mx-auto flex h-full min-h-0 min-w-0 w-full max-w-[640px] flex-col px-4 py-4 sm:px-6">
-  <div data-scroll-owner="settings-page" class="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pr-2 [overflow-anchor:none] [scroll-behavior:auto]">
+<PrimaryPage page="settings" scrollOwner="settings-page" contentClass="pb-6">
+  <div class="mx-auto min-h-full min-w-0 w-full max-w-[640px] space-y-7">
     {#if settingsLoaded}
     <div class="space-y-7 pb-6">
 
@@ -645,18 +668,14 @@
             label="Input device"
             description={audioDeviceError || 'Select microphone for recording'}
           >
-            <select
-              aria-label="Input device"
+            <EveDropdown
+              label="Input device"
               value={settings.selectedDeviceId}
-              onchange={(e) => updateSetting('selectedDeviceId', e.currentTarget.value)}
+              options={inputDevices.map((device) => ({ value: device.id, label: device.label }))}
+              onchange={(value) => updateSetting('selectedDeviceId', value)}
               disabled={isLoadingDevices}
-              title={inputDevices.find(d => d.id === settings.selectedDeviceId)?.label ?? 'Default'}
-              class="min-h-9 w-full max-w-full truncate rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:max-w-[280px]"
-            >
-              {#each inputDevices as device}
-                <option value={device.id}>{device.label}</option>
-              {/each}
-            </select>
+              class="sm:max-w-[280px]"
+            />
           </SettingsRow>
         </SettingsGroup>
 
@@ -678,18 +697,12 @@
           </SettingsRow>
 
           <SettingsRow label="Dictation mode" description="Local rule-based cleanup before copy or paste">
-            <select
-              aria-label="Dictation mode"
+            <EveDropdown
+              label="Dictation mode"
               value={settings.dictationMode}
-              onchange={(e) => updateSetting('dictationMode', e.currentTarget.value as Settings['dictationMode'])}
-              class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
-            >
-              <option value="raw">Raw Dictation</option>
-              <option value="clean_prompt">Clean Prompt</option>
-              <option value="codex_prompt">Codex Prompt</option>
-              <option value="message_rewrite">Message Rewrite</option>
-              <option value="command">Command Mode</option>
-            </select>
+              options={DICTATION_MODE_OPTIONS}
+              onchange={(value) => updateSetting('dictationMode', value as Settings['dictationMode'])}
+            />
           </SettingsRow>
         </SettingsGroup>
 
@@ -795,15 +808,12 @@
           </SettingsRow>
 
           <SettingsRow label="Paste method" description="Use native SendInput first, or force VBScript fallback">
-            <select
-              aria-label="Paste method"
+            <EveDropdown
+              label="Paste method"
               value={settings.pasteMethod}
-              onchange={(e) => updateSetting('pasteMethod', e.currentTarget.value as Settings['pasteMethod'])}
-              class="min-h-9 w-full max-w-full cursor-pointer rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 sm:w-auto"
-            >
-              <option value="sendinput">SendInput</option>
-              <option value="vbscript">VBScript</option>
-            </select>
+              options={PASTE_METHOD_OPTIONS}
+              onchange={(value) => updateSetting('pasteMethod', value as Settings['pasteMethod'])}
+            />
           </SettingsRow>
 
           <SettingsRow label="Launch on boot" description="Start application when system starts">
@@ -849,7 +859,7 @@
             {/if}
             {#if stagedPreset && !externalMode}
               <div class="mt-3 flex flex-wrap items-center gap-2">
-                <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
+                <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
                 <button type="button" onclick={revertEngineSettings} disabled={engineApplying || engineRevertDisabled} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying || engineRevertDisabled ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
               </div>
               {#if engineApplyError}<p class="mt-2 text-xs text-red-300">{engineApplyError}</p>{/if}
@@ -910,32 +920,24 @@
         <div id="compatibility-controls" hidden={!compatibilityControlsOpen} class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2 {externalMode ? 'opacity-60' : ''}">
         {#if serverSettings.whisper_model}
           <SettingsRow label={serverSettings.whisper_model.label} description="Raw Whisper compatibility model, including Medium and Tiny">
-            <select
-              aria-label={serverSettings.whisper_model.label}
-              value={getSettingValue('whisper_model') ?? serverSettings.whisper_model.value}
-              onchange={(e) => updateEngineSetting('whisper_model', e.currentTarget.value)}
+            <EveDropdown
+              label={serverSettings.whisper_model.label}
+              value={String(getSettingValue('whisper_model') ?? serverSettings.whisper_model.value)}
+              options={toDropdownOptions(getOptions('whisper_model'))}
+              onchange={(value) => updateEngineSetting('whisper_model', value)}
               disabled={externalMode}
-              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-            >
-              {#each getOptions('whisper_model') as option}
-                <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
-              {/each}
-            </select>
+            />
           </SettingsRow>
         {/if}
         {#if serverSettings.whisper_compute_type}
           <SettingsRow label={serverSettings.whisper_compute_type.label} description={serverSettings.whisper_compute_type.description}>
-            <select
-              aria-label={serverSettings.whisper_compute_type.label}
-              value={getSettingValue('whisper_compute_type') ?? serverSettings.whisper_compute_type.value}
-              onchange={(e) => updateEngineSetting('whisper_compute_type', e.currentTarget.value)}
+            <EveDropdown
+              label={serverSettings.whisper_compute_type.label}
+              value={String(getSettingValue('whisper_compute_type') ?? serverSettings.whisper_compute_type.value)}
+              options={toDropdownOptions(getWhisperComputeOptions())}
+              onchange={(value) => updateEngineSetting('whisper_compute_type', value)}
               disabled={externalMode}
-              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-            >
-              {#each getWhisperComputeOptions() as option}
-                <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
-              {/each}
-            </select>
+            />
             {#each disabledOptionReasons(getWhisperComputeOptions()) as reason}
               <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
             {/each}
@@ -966,17 +968,13 @@
         {/if}
         {#if serverSettings.nemotron_device && isVisible(serverSettings.nemotron_device)}
           <SettingsRow label="Device" description="Hardware device for inference">
-            <select
-              aria-label="Nemotron device"
-              value={getSettingValue('nemotron_device') ?? serverSettings.nemotron_device.value}
-              onchange={(e) => updateEngineSetting('nemotron_device', e.currentTarget.value)}
+            <EveDropdown
+              label="Nemotron device"
+              value={String(getSettingValue('nemotron_device') ?? serverSettings.nemotron_device.value)}
+              options={toDropdownOptions(getOptions('nemotron_device'))}
+              onchange={(value) => updateEngineSetting('nemotron_device', value)}
               disabled={externalMode}
-              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-            >
-              {#each getOptions('nemotron_device') as option}
-                <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
-              {/each}
-            </select>
+            />
             {#each disabledOptionReasons(getOptions('nemotron_device')) as reason}
               <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
             {/each}
@@ -984,17 +982,13 @@
         {/if}
         {#if serverSettings.whisper_device && isVisible(serverSettings.whisper_device)}
           <SettingsRow label="Device" description="Hardware device for inference">
-            <select
-              aria-label="Whisper device"
-              value={getSettingValue('whisper_device') ?? serverSettings.whisper_device.value}
-              onchange={(e) => updateEngineSetting('whisper_device', e.currentTarget.value)}
+            <EveDropdown
+              label="Whisper device"
+              value={String(getSettingValue('whisper_device') ?? serverSettings.whisper_device.value)}
+              options={toDropdownOptions(getOptions('whisper_device'))}
+              onchange={(value) => updateEngineSetting('whisper_device', value)}
               disabled={externalMode}
-              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 py-2 pl-3 pr-8 text-xs text-zinc-300 hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-            >
-              {#each getOptions('whisper_device') as option}
-                <option value={option.value} disabled={option.disabled} title={option.reason}>{option.label}</option>
-              {/each}
-            </select>
+            />
             {#each disabledOptionReasons(getOptions('whisper_device')) as reason}
               <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
             {/each}
@@ -1025,7 +1019,7 @@
                     class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
                       {engineApplying || externalMode
                         ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed'
-                        : 'bg-emerald-600 text-white hover:bg-emerald-500 cursor-pointer'}"
+                        : 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer'}"
                   >
                     {#if engineApplying}
                       Preparing…
@@ -1205,7 +1199,7 @@
       <SettingsSkeleton />
     {/if}
   </div>
-</div>
+</PrimaryPage>
 
 <HotkeyCaptureModal
   isOpen={isHotkeyModalOpen}

--- a/app/tests/renderer-visual-guards.test.ts
+++ b/app/tests/renderer-visual-guards.test.ts
@@ -13,6 +13,10 @@ const insightsView = readFileSync(
   new URL('../src/renderer/app/views/InsightsView.svelte', import.meta.url),
   'utf8'
 );
+const eveDropdown = readFileSync(
+  new URL('../src/renderer/app/components/EveDropdown.svelte', import.meta.url),
+  'utf8'
+);
 const settingsSection = readFileSync(
   new URL('../src/renderer/app/components/SettingsSection.svelte', import.meta.url),
   'utf8'
@@ -57,19 +61,19 @@ describe('renderer visual regression guards', () => {
     expect(insightsView).toContain('point.audioSeconds / point.dictations');
     expect(insightsView).toContain('formatDuration(averages[index])');
     expect(insightsView).toContain('insights.trends.slice(-7)');
-    expect(insightsView).toContain('aria-haspopup="listbox"');
-    expect(insightsView).toContain('aria-controls="insights-range-listbox"');
-    expect(insightsView).toContain('id="insights-range-listbox"');
-    expect(insightsView).toContain('role="listbox"');
-    expect(insightsView).toContain('role="option"');
-    expect(insightsView).toMatch(/role="option"\s+tabindex="-1"/);
-    expect(insightsView).toContain("event.key === 'Escape'");
-    expect(insightsView).toContain("event.key === 'ArrowDown' || event.key === 'ArrowUp'");
-    expect(insightsView).toContain("event.key === 'Home' || event.key === 'End'");
-    expect(insightsView).toContain('onfocusout={handleRangeMenuFocusout}');
-    expect(insightsView).toContain('rangeButton?.focus({ preventScroll: true })');
-    expect(insightsView).toContain('onclick={() => selectRange(option.id)}');
-    expect(insightsView).toMatch(/function selectRange[\s\S]*?loadInsights\(\);[\s\S]*?\n  }/);
+    expect(insightsView).toContain('<EveDropdown');
+    expect(eveDropdown).toContain('role="combobox"');
+    expect(eveDropdown).toContain('aria-haspopup="listbox"');
+    expect(eveDropdown).toContain('role="listbox"');
+    expect(eveDropdown).toContain('role="option"');
+    expect(eveDropdown).toMatch(/role="option"\s+tabindex="-1"/);
+    expect(eveDropdown).toContain("event.key === 'Escape'");
+    expect(eveDropdown).toContain("event.key === 'ArrowDown'");
+    expect(eveDropdown).toContain("event.key === 'ArrowUp'");
+    expect(eveDropdown).toContain("event.key === 'Home' || event.key === 'End'");
+    expect(eveDropdown).toContain('document.addEventListener(\'pointerdown\'');
+    expect(eveDropdown).toContain('button?.focus({ preventScroll: true })');
+    expect(eveDropdown).toContain('findTypeaheadIndex');
     expect(insightsView).not.toContain('<select');
     expect(insightsView).not.toContain('gpt-4o-transcribe');
   });

--- a/app/tests/server-setting-options.test.ts
+++ b/app/tests/server-setting-options.test.ts
@@ -55,8 +55,17 @@ describe('Server setting option compatibility metadata', () => {
       new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url),
       'utf8',
     );
+    const dropdown = readFileSync(
+      new URL('../src/renderer/app/components/EveDropdown.svelte', import.meta.url),
+      'utf8',
+    );
 
-    expect(settingsView).toContain('disabled={option.disabled}');
+    expect(settingsView).toContain('<EveDropdown');
+    expect(settingsView).toContain('toDropdownOptions');
+    expect(dropdown).toContain('disabled={option.disabled}');
+    expect(dropdown).toContain('aria-disabled={option.disabled || undefined}');
+    expect(dropdown).toContain('aria-describedby={option.description ?');
+    expect(dropdown).toContain('if (!option || option.disabled) return;');
     expect(settingsView).toContain('data-setting-option-reason');
     expect(settingsView).toContain('getWhisperComputeOptions()');
     expect(settingsView).toContain("disabledOptionReasons(getWhisperComputeOptions())");

--- a/app/tests/settings-layout.test.ts
+++ b/app/tests/settings-layout.test.ts
@@ -12,6 +12,8 @@ const settingsView = source('../src/renderer/app/views/SettingsView.svelte');
 const settingsGroup = source('../src/renderer/app/components/SettingsGroup.svelte');
 const settingsSection = source('../src/renderer/app/components/SettingsSection.svelte');
 const settingsRow = source('../src/renderer/app/components/SettingsRow.svelte');
+const primaryPage = source('../src/renderer/app/components/PrimaryPage.svelte');
+const eveDropdown = source('../src/renderer/app/components/EveDropdown.svelte');
 const statusBanner = source('../src/renderer/app/components/ModelProgressBanner.svelte');
 const statusCard = source('../src/renderer/app/components/ModelProgressCard.svelte');
 const serverView = source('../src/renderer/app/views/ServerView.svelte');
@@ -40,9 +42,10 @@ describe('Phase 1 Settings layout contracts', () => {
   });
 
   test('keeps Settings as the single page scroll owner while logs remain bounded', () => {
-    expect(settingsView.match(/overflow-y-auto/g)?.length).toBe(1);
-    expect(settingsView).toContain('data-scroll-owner="settings-page"');
-    expect(settingsView).toContain('min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain');
+    expect(settingsView).not.toContain('overflow-y-auto');
+    expect(primaryPage).toContain('data-scroll-owner={scrollOwner}');
+    expect(primaryPage).toContain('overflow-x-hidden overflow-y-auto overscroll-contain');
+    expect(settingsView).toContain('<PrimaryPage page="settings" scrollOwner="settings-page"');
     expect(settingsView).not.toContain('h-screen');
     expect(serverView).toContain("embedded ? 'min-w-0 space-y-6'");
     expect(serverView).toContain('max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain');
@@ -54,15 +57,16 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(settingsRow).toContain('items-center justify-end justify-self-end');
     expect(settingsRow).toContain('min-w-0 w-full max-w-full items-center justify-end justify-self-end');
     expect(settingsRow).toContain('[&>input]:max-w-full');
-    expect(settingsRow).toContain('[&>select]:max-w-full');
+    expect(settingsRow).toContain('[&>[data-eve-dropdown]]:max-w-full');
+    expect(eveDropdown).toContain('data-eve-dropdown');
     expect(settingsRow).toContain('[&_textarea]:focus-visible:ring-2');
     expect(settingsView).toContain('w-full max-w-full');
-    expect(settingsView).toContain('sm:w-auto');
+    expect(eveDropdown).toContain('sm:w-auto');
   });
 
   test('disables page scroll anchoring and avoids programmatic scroll jumps', () => {
-    expect(settingsView).toContain('[overflow-anchor:none]');
-    expect(settingsView).toContain('[scroll-behavior:auto]');
+    expect(primaryPage).toContain('[overflow-anchor:none]');
+    expect(primaryPage).toContain('[scroll-behavior:auto]');
     expect(settingsView).not.toContain('scrollIntoView');
     expect(settingsView).not.toContain('startViewTransition');
   });
@@ -73,9 +77,9 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(settingsSection).toContain('id={descriptionId}');
     expect(settingsSection).toContain('<h2 id={headingId}');
     expect(settingsView).toContain('<h1 class="sr-only">Settings</h1>');
-    expect(settingsView).toContain('aria-label="Input device"');
-    expect(settingsView).toContain('aria-label="Dictation mode"');
-    expect(settingsView).toContain('aria-label="Paste method"');
+    expect(settingsView).toContain('label="Input device"');
+    expect(settingsView).toContain('label="Dictation mode"');
+    expect(settingsView).toContain('label="Paste method"');
     expect(settingsView).toContain('aria-describedby="hotwords-help"');
     expect(settingsView).toContain('aria-expanded={compatibilityControlsOpen}');
     expect(settingsView).toContain('aria-controls="compatibility-controls"');
@@ -94,7 +98,7 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(settingsView).toContain('aria-pressed={settings.holdToTalk}');
     expect(settingsView).toContain('aria-pressed={!settings.holdToTalk}');
     expect(settingsView).toContain('data-hotwords-editor');
-    expect(settingsView.match(/<select[\s\S]*?cursor-pointer/g)?.length).toBe(7);
+    expect(settingsView.match(/<EveDropdown\b/g)?.length).toBe(7);
   });
 
   test('keeps the Phase 2 General subgroup foundation aligned with the row primitive', () => {
@@ -115,7 +119,7 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(appCss).toContain('@media (prefers-reduced-motion: reduce)');
     expect(appCss).toContain(':focus-visible');
     expect(settingsRow).toContain('focus-visible:ring-2');
-    expect(settingsView).toContain('[scroll-behavior:auto]');
+    expect(primaryPage).toContain('[scroll-behavior:auto]');
     expect(statusCard).not.toContain('animate-');
   });
 });

--- a/app/tests/settings-server-cohesion.test.ts
+++ b/app/tests/settings-server-cohesion.test.ts
@@ -10,6 +10,7 @@ const serverView = source('../src/renderer/app/views/ServerView.svelte');
 const serverFixture = source('../src/renderer/app/fixtures/SettingsServerFixture.svelte');
 const settingsRow = source('../src/renderer/app/components/SettingsRow.svelte');
 const appCss = source('../src/renderer/app/app.css');
+const primaryPage = source('../src/renderer/app/components/PrimaryPage.svelte');
 
 describe('Phase 3 Server and diagnostics cohesion contracts', () => {
   test('uses one cohesive Server & diagnostics section without nested SettingsSection composition', () => {
@@ -77,8 +78,10 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
   });
 
   test('keeps the Settings page as the only page-level scroll owner and wraps long controls', () => {
-    expect(settingsView.match(/overflow-y-auto/g)?.length).toBe(1);
-    expect(settingsView).toContain('data-scroll-owner="settings-page"');
+    expect(settingsView).not.toContain('overflow-y-auto');
+    expect(settingsView).toContain('<PrimaryPage page="settings" scrollOwner="settings-page"');
+    expect(primaryPage).toContain('data-scroll-owner={scrollOwner}');
+    expect(primaryPage).toContain('overflow-x-hidden overflow-y-auto overscroll-contain');
     expect(settingsView).toContain('min-h-9 w-full max-w-full rounded-lg border border-zinc-700');
     expect(settingsView).toContain('[overflow-wrap:anywhere]');
     expect(serverView).toContain('[overflow-wrap:anywhere]');

--- a/app/tests/shared-layout-dropdown.test.ts
+++ b/app/tests/shared-layout-dropdown.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import {
+  calculateDropdownPosition,
+  findFirstEnabledIndex,
+  findLastEnabledIndex,
+  findNextEnabledIndex,
+  findTypeaheadIndex,
+} from '../src/renderer/app/components/eve-dropdown';
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+const primaryPage = source('../src/renderer/app/components/PrimaryPage.svelte');
+const dropdown = source('../src/renderer/app/components/EveDropdown.svelte');
+const dropdownHelpers = source('../src/renderer/app/components/eve-dropdown.ts');
+const appCss = source('../src/renderer/app/app.css');
+const home = source('../src/renderer/app/views/HomeView.svelte');
+const history = source('../src/renderer/app/views/HistoryView.svelte');
+const insights = source('../src/renderer/app/views/InsightsView.svelte');
+const settings = source('../src/renderer/app/views/SettingsView.svelte');
+const layoutFixture = source('../src/renderer/app/fixtures/SettingsLayoutFixture.svelte');
+const speechFixture = source('../src/renderer/app/fixtures/SettingsSpeechFixture.svelte');
+
+const options = [
+  { label: 'Alpha' },
+  { label: 'Beta', disabled: true },
+  { label: 'Gamma' },
+  { label: 'Delta' },
+];
+
+describe('shared primary-page and dropdown foundation', () => {
+  test('gives every primary page the same outer geometry and one page scroll owner', () => {
+    for (const view of [home, history, insights, settings]) {
+      expect(view).toContain("import PrimaryPage from '../components/PrimaryPage.svelte'");
+      expect(view).toContain('<PrimaryPage');
+    }
+    expect(primaryPage).toContain('data-primary-page-content');
+    expect(primaryPage).toContain('max-w-4xl');
+    expect(primaryPage).toContain('overflow-x-hidden overflow-y-auto overscroll-contain');
+    expect(primaryPage).toContain('[scrollbar-gutter:stable]');
+    expect(primaryPage).toContain('data-scroll-owner={scrollOwner}');
+    expect(appCss).toMatch(/html,\s*body,\s*#app\s*\{[\s\S]*?overflow: hidden;/);
+    expect(history).not.toContain('flex-1 overflow-y-auto');
+    expect(insights).not.toContain('flex-1 overflow-y-auto');
+    expect(insights).toContain("document.querySelector<HTMLDivElement>('[data-scroll-owner=\"insights\"]')");
+  });
+
+  test('keeps the production palette neutral and reserves color for semantic state/focus cues', () => {
+    expect(appCss).toContain('--eve-surface-0: #08090a;');
+    expect(appCss).toContain('--eve-focus: #f4f4f5;');
+    expect(appCss).toContain('--eve-status-success: #86efac;');
+    expect(appCss).toContain('--eve-status-warning: #fcd34d;');
+    expect(appCss).toContain('--eve-status-error: #fca5a5;');
+    expect(home).not.toMatch(/\b(?:sky|violet|purple|cyan)-/);
+    expect(history).not.toMatch(/\b(?:blue|sky|violet|purple|cyan)-/);
+    expect(dropdown).not.toMatch(/\b(?:blue|sky|cyan|violet|purple)-/);
+    expect(dropdown).toContain('focus-visible:ring-zinc-100');
+  });
+
+  test('covers accessible dropdown semantics and interaction ownership in one reusable component', () => {
+    expect(settings).not.toContain('<select');
+    expect(layoutFixture).not.toContain('<select');
+    expect(speechFixture).not.toContain('<select');
+    expect(dropdown).toContain('role="combobox"');
+    expect(dropdown).toContain('role="listbox"');
+    expect(dropdown).toContain('role="option"');
+    expect(dropdown).toContain('aria-activedescendant');
+    expect(dropdown).toContain('aria-disabled={option.disabled || undefined}');
+    expect(dropdown).toContain('aria-describedby={option.description ?');
+    expect(dropdown).toContain('disabled={option.disabled}');
+    expect(dropdown).toContain('if (!option || option.disabled) return;');
+    expect(dropdown).toContain("event.key === 'Enter' || event.key === ' '");
+    expect(dropdown).toContain("event.key === 'Tab'");
+    expect(dropdown).toContain('document.addEventListener(\'pointerdown\'');
+    expect(dropdown).toContain('findTypeaheadIndex');
+    expect(dropdown).toContain('calculateDropdownPosition');
+    expect(dropdown).toContain('button?.focus({ preventScroll: true })');
+  });
+
+  test('moves through enabled options and wraps typeahead deterministically', () => {
+    expect(findFirstEnabledIndex(options)).toBe(0);
+    expect(findLastEnabledIndex(options)).toBe(3);
+    expect(findNextEnabledIndex(options, 0, 1)).toBe(2);
+    expect(findNextEnabledIndex(options, 2, 1)).toBe(3);
+    expect(findNextEnabledIndex(options, 3, 1)).toBe(0);
+    expect(findNextEnabledIndex(options, 0, -1)).toBe(3);
+    expect(findTypeaheadIndex(options, 'ga')).toBe(2);
+    expect(findTypeaheadIndex(options, 'a', 0)).toBe(0);
+    expect(findTypeaheadIndex(options, 'd', 2)).toBe(3);
+    expect(findTypeaheadIndex(options, 'missing')).toBe(-1);
+  });
+
+  test('constrains the listbox to the viewport and flips above near the bottom edge', () => {
+    const below = calculateDropdownPosition({
+      top: 80,
+      bottom: 116,
+      left: 900,
+      width: 160,
+      viewportWidth: 1024,
+      viewportHeight: 768,
+      optionCount: 3,
+    });
+    expect(below.placement).toBe('below');
+    expect(below.left + below.width).toBeLessThanOrEqual(1016);
+    expect(below.top).toBeGreaterThanOrEqual(0);
+    expect(below.top + below.maxHeight).toBeLessThanOrEqual(768);
+
+    const above = calculateDropdownPosition({
+      top: 700,
+      bottom: 736,
+      left: 4,
+      width: 240,
+      viewportWidth: 320,
+      viewportHeight: 768,
+      optionCount: 12,
+    });
+    expect(above.placement).toBe('above');
+    expect(above.left).toBeGreaterThanOrEqual(8);
+    expect(above.left + above.width).toBeLessThanOrEqual(312);
+    expect(above.top + above.maxHeight).toBeLessThanOrEqual(700);
+  });
+
+  test('keeps helper and component contracts together so behavior cannot drift', () => {
+    expect(dropdown).toContain("import {");
+    expect(dropdown).toContain("from './eve-dropdown'");
+    expect(dropdownHelpers).toContain('export function findTypeaheadIndex');
+    expect(dropdownHelpers).toContain('export function calculateDropdownPosition');
+  });
+});

--- a/app/tests/shared-layout-dropdown.test.ts
+++ b/app/tests/shared-layout-dropdown.test.ts
@@ -79,6 +79,12 @@ describe('shared primary-page and dropdown foundation', () => {
     expect(dropdown).toContain('button?.focus({ preventScroll: true })');
   });
 
+  test('visibly marks the keyboard-active option without replacing selected or hover styling', () => {
+    expect(dropdown).toContain("option.value === value ? 'bg-white/[0.09] text-zinc-100' : 'text-zinc-400 hover:bg-white/[0.06] hover:text-zinc-100'");
+    expect(dropdown).toContain("index === activeIndex ? 'ring-1 ring-inset ring-zinc-300/70' : ''");
+    expect(dropdown).toContain('aria-activedescendant={open ? activeOptionId : undefined}');
+  });
+
   test('moves through enabled options and wraps typeahead deterministically', () => {
     expect(findFirstEnabledIndex(options)).toBe(0);
     expect(findLastEnabledIndex(options)).toBe(3);


### PR DESCRIPTION
## Summary
- add a shared PrimaryPage geometry with one page-level scroll owner for Home, History, Insights, and Settings
- add the reusable accessible EveDropdown/listbox with keyboard navigation, typeahead, disabled reasons, focus restoration, and viewport-aware positioning
- apply the neutral palette/layout foundation to the in-scope views and fixtures without changing History bulk or Insights aggregation

## Validation
- focused renderer/layout/dropdown contracts: 50 passed, 425 expectations
- full app suite: 200/200 passed, 1,885 expectations
- history insights aggregate check passed
- main/preload/Vite builds passed
- `git diff --check` clean; no manifest/lockfile or generated-file changes

Refs #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessible, keyboard-friendly dropdown controls with typeahead search, disabled options, descriptions, and responsive positioning.
  * Introduced a shared page layout for consistent scrolling and responsive content across primary views.
* **Enhancements**
  * Updated settings controls and history/insights filters to use the new dropdown experience.
  * Refreshed the interface with dark-theme styling, neutral accents, improved focus states, and constrained page scrolling.
* **Bug Fixes**
  * Improved dropdown focus restoration, outside-click handling, and viewport-aware placement.
* **Tests**
  * Added visual and interaction coverage for shared layouts and dropdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->