### PR TITLE
Add History selection and transactional bulk deletion

### DIFF
--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -155,12 +155,32 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
     }
   );
 
+  ipcMain.handle(
+    IPC_CHANNELS.HISTORY_GET_ENTRY_IDS,
+    (_event, filters?: HistoryFilters) => {
+      if (!historyServiceRef) {
+        return [];
+      }
+      return historyServiceRef.getEntryIds(filters);
+    }
+  );
+
   // Handle history delete
   ipcMain.handle(IPC_CHANNELS.HISTORY_DELETE, (_event, id: string) => {
     if (!historyServiceRef) {
       return;
     }
     historyServiceRef.delete(id);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.HISTORY_DELETE_BULK, (_event, ids: unknown) => {
+    if (!Array.isArray(ids) || ids.some((id) => typeof id !== 'string' || id.length === 0)) {
+      throw new TypeError('Invalid history entry IDs');
+    }
+    if (!historyServiceRef) {
+      throw new Error('History service is unavailable; try again.');
+    }
+    return historyServiceRef.deleteMany(ids);
   });
 
   ipcMain.handle(IPC_CHANNELS.INSIGHTS_GET, (_event, range: unknown) => {

--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { arch, release } from 'node:os';
 import { IPC_CHANNELS } from '../../shared/constants.js';
 import type { HistoryFilters, Settings, Hotkey } from '../../shared/types.js';
+import { isHistoryFilters } from '../../shared/history-validation.js';
 import { formatHotwordsCsl, parseHotwordsCsl } from '../../shared/hotwords.js';
 import { isInsightsRange } from '../../shared/insights.js';
 import { copyToClipboard } from '../services/clipboard.js';
@@ -157,7 +158,10 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
 
   ipcMain.handle(
     IPC_CHANNELS.HISTORY_GET_ENTRY_IDS,
-    (_event, filters?: HistoryFilters) => {
+    (_event, filters: unknown) => {
+      if (!isHistoryFilters(filters)) {
+        throw new TypeError('Invalid history filters');
+      }
       if (!historyServiceRef) {
         return [];
       }

--- a/app/src/main/preload/main.ts
+++ b/app/src/main/preload/main.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '../../shared/constants.js';
 import type {
   HistoryFilters,
+  HistoryDeleteResult,
   HistoryResponse,
   HistoryEntryWithGroup,
   InsightsRange,
@@ -73,8 +74,16 @@ const murmurMainAPI = {
     return ipcRenderer.invoke(IPC_CHANNELS.HISTORY_GET_ENTRIES, offset, limit, filters);
   },
 
+  getHistoryEntryIds: (filters?: HistoryFilters): Promise<string[]> => {
+    return ipcRenderer.invoke(IPC_CHANNELS.HISTORY_GET_ENTRY_IDS, filters);
+  },
+
   deleteHistoryEntry: (id: string): Promise<void> => {
     return ipcRenderer.invoke(IPC_CHANNELS.HISTORY_DELETE, id);
+  },
+
+  deleteHistoryEntries: (ids: string[]): Promise<HistoryDeleteResult> => {
+    return ipcRenderer.invoke(IPC_CHANNELS.HISTORY_DELETE_BULK, ids);
   },
 
   getInsights: (range: InsightsRange): Promise<InsightsResponse | null> => {

--- a/app/src/main/services/history.ts
+++ b/app/src/main/services/history.ts
@@ -29,6 +29,7 @@ import type {
 } from '../../shared/types.js';
 
 const INSIGHTS_PHRASE_ENTRY_LIMIT = 5000;
+const HISTORY_ID_CHUNK_SIZE = 500;
 
 function computeDateGroup(timestamp: number): string {
   const now = new Date();
@@ -290,17 +291,15 @@ export class HistoryService {
       const missingIds = selectedIds.filter((id) => !existingIds.has(id));
       let deletedCount = 0;
 
-      for (let offset = 0; offset < selectedIds.length; offset += 500) {
-        const chunk = selectedIds.slice(offset, offset + 500);
+      for (let offset = 0; offset < selectedIds.length; offset += HISTORY_ID_CHUNK_SIZE) {
+        const chunk = selectedIds.slice(offset, offset + HISTORY_ID_CHUNK_SIZE);
         const result = this.db!.prepare(
           `DELETE FROM transcriptions WHERE id IN (${buildIdPlaceholders(chunk)})`
         ).run(buildIdParams(chunk));
         deletedCount += result.changes;
       }
 
-      for (const entry of existing) {
-        this.removeEntryFromInsightsWithinTransaction(entry);
-      }
+      this.removeEntriesFromInsightsWithinTransaction(existing);
 
       const deletedIds = selectedIds.filter((id) => existingIds.has(id));
       return {
@@ -311,7 +310,7 @@ export class HistoryService {
       };
     });
 
-    return remove(requestedIds);
+    return remove.immediate(requestedIds);
   }
 
   getById(id: string): TranscriptionEntry | null {
@@ -346,8 +345,8 @@ export class HistoryService {
     if (!this.db || ids.length === 0) return [];
     const entries: TranscriptionEntry[] = [];
 
-    for (let offset = 0; offset < ids.length; offset += 500) {
-      const chunk = ids.slice(offset, offset + 500);
+    for (let offset = 0; offset < ids.length; offset += HISTORY_ID_CHUNK_SIZE) {
+      const chunk = ids.slice(offset, offset + HISTORY_ID_CHUNK_SIZE);
       const rows = this.db.prepare(`
         SELECT
           id,
@@ -590,19 +589,15 @@ export class HistoryService {
     });
   }
 
-  private removeEntryFromInsightsWithinTransaction(entry: TranscriptionEntry): void {
+  private removeEntriesFromInsightsWithinTransaction(entries: TranscriptionEntry[]): void {
     if (!this.db) throw new Error('Database not initialized');
+    if (entries.length === 0) return;
+
     const wasProcessed = this.db.prepare(`
       SELECT 1 FROM insights_processed_entries WHERE id = @id
-    `).get({ id: entry.id });
-    if (!wasProcessed) return;
+    `);
 
-    const wordCount = entry.wordCount ?? countWords(entry.text);
-    const day = getLocalDayKey(entry.timestamp);
-    const confidence = Number.isFinite(entry.confidence) ? entry.confidence : 0;
-    const confidenceCount = Number.isFinite(entry.confidence) ? 1 : 0;
-
-    this.db.prepare(`
+    const updateRollup = this.db.prepare(`
       UPDATE insights_daily_rollups
       SET
         dictations = MAX(dictations - 1, 0),
@@ -612,19 +607,7 @@ export class HistoryService {
         confidenceSum = MAX(confidenceSum - @confidenceSum, 0),
         confidenceCount = MAX(confidenceCount - @confidenceCount, 0)
       WHERE day = @day
-    `).run({
-      day,
-      words: wordCount,
-      audioSeconds: entry.audioDuration || 0,
-      processingMs: entry.transcriptionTime || 0,
-      confidenceSum: confidence,
-      confidenceCount,
-    });
-
-    const counts = new Map<string, number>();
-    for (const word of tokenizeInsightWords(entry.text)) {
-      counts.set(word, (counts.get(word) ?? 0) + 1);
-    }
+    `);
 
     const decrementWord = this.db.prepare(`
       UPDATE insights_word_counts
@@ -632,13 +615,46 @@ export class HistoryService {
       WHERE day = @day AND word = @word
     `);
 
-    for (const [word, count] of counts) {
-      decrementWord.run({ day, word, count });
-    }
+    const deleteZeroWords = this.db.prepare(
+      'DELETE FROM insights_word_counts WHERE day = @day AND count <= 0'
+    );
+    const deleteZeroRollup = this.db.prepare(
+      'DELETE FROM insights_daily_rollups WHERE day = @day AND dictations <= 0'
+    );
+    const deleteProcessed = this.db.prepare(
+      'DELETE FROM insights_processed_entries WHERE id = @id'
+    );
 
-    this.db.prepare('DELETE FROM insights_word_counts WHERE count <= 0').run();
-    this.db.prepare('DELETE FROM insights_daily_rollups WHERE day = @day AND dictations <= 0').run({ day });
-    this.db.prepare('DELETE FROM insights_processed_entries WHERE id = @id').run({ id: entry.id });
+    for (const entry of entries) {
+      if (!wasProcessed.get({ id: entry.id })) continue;
+
+      const wordCount = entry.wordCount ?? countWords(entry.text);
+      const day = getLocalDayKey(entry.timestamp);
+      const confidence = Number.isFinite(entry.confidence) ? entry.confidence : 0;
+      const confidenceCount = Number.isFinite(entry.confidence) ? 1 : 0;
+
+      updateRollup.run({
+        day,
+        words: wordCount,
+        audioSeconds: entry.audioDuration || 0,
+        processingMs: entry.transcriptionTime || 0,
+        confidenceSum: confidence,
+        confidenceCount,
+      });
+
+      const counts = new Map<string, number>();
+      for (const word of tokenizeInsightWords(entry.text)) {
+        counts.set(word, (counts.get(word) ?? 0) + 1);
+      }
+
+      for (const [word, count] of counts) {
+        decrementWord.run({ day, word, count });
+      }
+
+      deleteZeroWords.run({ day });
+      deleteZeroRollup.run({ day });
+      deleteProcessed.run({ id: entry.id });
+    }
   }
 
   private processPendingInsights(limit: number): number {

--- a/app/src/main/services/history.ts
+++ b/app/src/main/services/history.ts
@@ -14,6 +14,7 @@ import {
   tokenizeInsightWords,
 } from '../../shared/insights.js';
 import type {
+  HistoryDeleteResult,
   HistoryFilters,
   HistoryEntryWithGroup,
   HistoryResponse,
@@ -40,6 +41,57 @@ function computeDateGroup(timestamp: number): string {
   if (date >= yesterday) return 'Yesterday';
   if (date >= weekAgo) return 'This Week';
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+interface HistoryQuery {
+  whereClause: string;
+  params: Record<string, unknown>;
+}
+
+function buildHistoryQuery(filters?: HistoryFilters): HistoryQuery {
+  const conditions: string[] = [];
+  const params: Record<string, unknown> = {};
+
+  if (filters?.text) {
+    conditions.push('text LIKE @textSearch');
+    params.textSearch = `%${filters.text}%`;
+  }
+  if (filters?.dateFrom !== undefined) {
+    conditions.push('timestamp >= @dateFrom');
+    params.dateFrom = filters.dateFrom;
+  }
+  if (filters?.dateTo !== undefined) {
+    conditions.push('timestamp <= @dateTo');
+    params.dateTo = filters.dateTo;
+  }
+  if (filters?.minDuration !== undefined) {
+    conditions.push('audioDuration >= @minDuration');
+    params.minDuration = filters.minDuration;
+  }
+  if (filters?.maxDuration !== undefined) {
+    conditions.push('audioDuration <= @maxDuration');
+    params.maxDuration = filters.maxDuration;
+  }
+  if (filters?.minConfidence !== undefined) {
+    conditions.push('confidence >= @minConfidence');
+    params.minConfidence = filters.minConfidence;
+  }
+  if (filters?.editedOnly) {
+    conditions.push('editedAt IS NOT NULL');
+  }
+
+  return {
+    whereClause: conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '',
+    params,
+  };
+}
+
+function buildIdParams(ids: string[]): Record<string, string> {
+  return Object.fromEntries(ids.map((id, index) => [`id${index}`, id]));
+}
+
+function buildIdPlaceholders(ids: string[]): string {
+  return ids.map((_id, index) => `@id${index}`).join(', ');
 }
 
 export class HistoryService {
@@ -155,40 +207,7 @@ export class HistoryService {
 
   getEntries(offset: number, limit: number, filters?: HistoryFilters): HistoryResponse {
     if (!this.db) throw new Error('Database not initialized');
-
-    const conditions: string[] = [];
-    const params: Record<string, unknown> = {};
-
-    // Build WHERE clause from filters
-    if (filters?.text) {
-      conditions.push('text LIKE @textSearch');
-      params.textSearch = `%${filters.text}%`;
-    }
-    if (filters?.dateFrom !== undefined) {
-      conditions.push('timestamp >= @dateFrom');
-      params.dateFrom = filters.dateFrom;
-    }
-    if (filters?.dateTo !== undefined) {
-      conditions.push('timestamp <= @dateTo');
-      params.dateTo = filters.dateTo;
-    }
-    if (filters?.minDuration !== undefined) {
-      conditions.push('audioDuration >= @minDuration');
-      params.minDuration = filters.minDuration;
-    }
-    if (filters?.maxDuration !== undefined) {
-      conditions.push('audioDuration <= @maxDuration');
-      params.maxDuration = filters.maxDuration;
-    }
-    if (filters?.minConfidence !== undefined) {
-      conditions.push('confidence >= @minConfidence');
-      params.minConfidence = filters.minConfidence;
-    }
-    if (filters?.editedOnly) {
-      conditions.push('editedAt IS NOT NULL');
-    }
-
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const { whereClause, params } = buildHistoryQuery(filters);
 
     // Fetch one extra to determine if there are more entries
     const query = `
@@ -236,15 +255,63 @@ export class HistoryService {
     };
   }
 
+  getEntryIds(filters?: HistoryFilters): string[] {
+    if (!this.db) throw new Error('Database not initialized');
+    const { whereClause, params } = buildHistoryQuery(filters);
+    const rows = this.db.prepare(`
+      SELECT id
+      FROM transcriptions
+      ${whereClause}
+      ORDER BY timestamp DESC
+    `).all(params) as Array<{ id: string }>;
+    return rows.map((row) => row.id);
+  }
+
   delete(id: string): void {
+    this.deleteMany([id]);
+  }
+
+  deleteMany(ids: string[]): HistoryDeleteResult {
     if (!this.db) throw new Error('Database not initialized');
 
-    const existing = this.getById(id);
-    const stmt = this.db.prepare('DELETE FROM transcriptions WHERE id = @id');
-    const result = stmt.run({ id });
-    if (result.changes > 0 && existing) {
-      this.removeEntryFromInsights(existing);
+    const requestedIds = [...new Set(ids.filter((id) => id.length > 0))];
+    if (requestedIds.length === 0) {
+      return {
+        requestedCount: 0,
+        deletedCount: 0,
+        deletedIds: [],
+        missingIds: [],
+      };
     }
+
+    const remove = this.db.transaction((selectedIds: string[]): HistoryDeleteResult => {
+      const existing = this.getEntriesByIds(selectedIds);
+      const existingIds = new Set(existing.map((entry) => entry.id));
+      const missingIds = selectedIds.filter((id) => !existingIds.has(id));
+      let deletedCount = 0;
+
+      for (let offset = 0; offset < selectedIds.length; offset += 500) {
+        const chunk = selectedIds.slice(offset, offset + 500);
+        const result = this.db!.prepare(
+          `DELETE FROM transcriptions WHERE id IN (${buildIdPlaceholders(chunk)})`
+        ).run(buildIdParams(chunk));
+        deletedCount += result.changes;
+      }
+
+      for (const entry of existing) {
+        this.removeEntryFromInsightsWithinTransaction(entry);
+      }
+
+      const deletedIds = selectedIds.filter((id) => existingIds.has(id));
+      return {
+        requestedCount: selectedIds.length,
+        deletedCount,
+        deletedIds,
+        missingIds,
+      };
+    });
+
+    return remove(requestedIds);
   }
 
   getById(id: string): TranscriptionEntry | null {
@@ -273,6 +340,38 @@ export class HistoryService {
 
     const row = stmt.get({ id });
     return row ? mapTranscriptionEntry(row) : null;
+  }
+
+  private getEntriesByIds(ids: string[]): TranscriptionEntry[] {
+    if (!this.db || ids.length === 0) return [];
+    const entries: TranscriptionEntry[] = [];
+
+    for (let offset = 0; offset < ids.length; offset += 500) {
+      const chunk = ids.slice(offset, offset + 500);
+      const rows = this.db.prepare(`
+        SELECT
+          id,
+          timestamp,
+          text,
+          confidence,
+          audioDuration,
+          transcriptionTime,
+          wordCount,
+          sessionMode,
+          engine,
+          model,
+          device,
+          computeType,
+          cudaActive,
+          editedAt,
+          originalText
+        FROM transcriptions
+        WHERE id IN (${buildIdPlaceholders(chunk)})
+      `).all(buildIdParams(chunk));
+      entries.push(...rows.map(mapTranscriptionEntry));
+    }
+
+    return entries;
   }
 
   getInsights(range: InsightsRange): InsightsResponse {
@@ -491,7 +590,7 @@ export class HistoryService {
     });
   }
 
-  private removeEntryFromInsights(entry: TranscriptionEntry): void {
+  private removeEntryFromInsightsWithinTransaction(entry: TranscriptionEntry): void {
     if (!this.db) throw new Error('Database not initialized');
     const wasProcessed = this.db.prepare(`
       SELECT 1 FROM insights_processed_entries WHERE id = @id
@@ -503,47 +602,43 @@ export class HistoryService {
     const confidence = Number.isFinite(entry.confidence) ? entry.confidence : 0;
     const confidenceCount = Number.isFinite(entry.confidence) ? 1 : 0;
 
-    const remove = this.db.transaction(() => {
-      this.db!.prepare(`
-        UPDATE insights_daily_rollups
-        SET
-          dictations = MAX(dictations - 1, 0),
-          words = MAX(words - @words, 0),
-          audioSeconds = MAX(audioSeconds - @audioSeconds, 0),
-          processingMs = MAX(processingMs - @processingMs, 0),
-          confidenceSum = MAX(confidenceSum - @confidenceSum, 0),
-          confidenceCount = MAX(confidenceCount - @confidenceCount, 0)
-        WHERE day = @day
-      `).run({
-        day,
-        words: wordCount,
-        audioSeconds: entry.audioDuration || 0,
-        processingMs: entry.transcriptionTime || 0,
-        confidenceSum: confidence,
-        confidenceCount,
-      });
-
-      const counts = new Map<string, number>();
-      for (const word of tokenizeInsightWords(entry.text)) {
-        counts.set(word, (counts.get(word) ?? 0) + 1);
-      }
-
-      const decrementWord = this.db!.prepare(`
-        UPDATE insights_word_counts
-        SET count = MAX(count - @count, 0)
-        WHERE day = @day AND word = @word
-      `);
-
-      for (const [word, count] of counts) {
-        decrementWord.run({ day, word, count });
-      }
-
-      this.db!.prepare('DELETE FROM insights_word_counts WHERE count <= 0').run();
-      this.db!.prepare('DELETE FROM insights_daily_rollups WHERE day = @day AND dictations <= 0').run({ day });
-      this.db!.prepare('DELETE FROM insights_processed_entries WHERE id = @id').run({ id: entry.id });
+    this.db.prepare(`
+      UPDATE insights_daily_rollups
+      SET
+        dictations = MAX(dictations - 1, 0),
+        words = MAX(words - @words, 0),
+        audioSeconds = MAX(audioSeconds - @audioSeconds, 0),
+        processingMs = MAX(processingMs - @processingMs, 0),
+        confidenceSum = MAX(confidenceSum - @confidenceSum, 0),
+        confidenceCount = MAX(confidenceCount - @confidenceCount, 0)
+      WHERE day = @day
+    `).run({
+      day,
+      words: wordCount,
+      audioSeconds: entry.audioDuration || 0,
+      processingMs: entry.transcriptionTime || 0,
+      confidenceSum: confidence,
+      confidenceCount,
     });
 
-    remove();
+    const counts = new Map<string, number>();
+    for (const word of tokenizeInsightWords(entry.text)) {
+      counts.set(word, (counts.get(word) ?? 0) + 1);
+    }
+
+    const decrementWord = this.db.prepare(`
+      UPDATE insights_word_counts
+      SET count = MAX(count - @count, 0)
+      WHERE day = @day AND word = @word
+    `);
+
+    for (const [word, count] of counts) {
+      decrementWord.run({ day, word, count });
+    }
+
+    this.db.prepare('DELETE FROM insights_word_counts WHERE count <= 0').run();
+    this.db.prepare('DELETE FROM insights_daily_rollups WHERE day = @day AND dictations <= 0').run({ day });
+    this.db.prepare('DELETE FROM insights_processed_entries WHERE id = @id').run({ id: entry.id });
   }
 
   private processPendingInsights(limit: number): number {

--- a/app/src/renderer/app/views/HistoryView.svelte
+++ b/app/src/renderer/app/views/HistoryView.svelte
@@ -122,6 +122,13 @@
     else enterSelectionMode();
   }
 
+  function removeEntryFromSelection(id: string): void {
+    if (!selectedIds.has(id)) return;
+    const next = new Set(selectedIds);
+    next.delete(id);
+    selectedIds = next;
+  }
+
   function toggleEntrySelection(id: string, selected: boolean): void {
     const next = new Set(selectedIds);
     if (selected) next.add(id);
@@ -274,10 +281,11 @@
 
   async function confirmDelete() {
     if (!deleteConfirmId) return;
+    const id = deleteConfirmId;
     try {
-      await window.murmurMain.deleteHistoryEntry(deleteConfirmId);
-      history = history.filter((item) => item.id !== deleteConfirmId);
-      exitSelectionMode();
+      await window.murmurMain.deleteHistoryEntry(id);
+      history = history.filter((item) => item.id !== id);
+      removeEntryFromSelection(id);
       toast('Transcription deleted', 'info');
     } catch (err) {
       console.error('Failed to delete:', err);
@@ -420,7 +428,6 @@
 
     // Listen for new entries
     const unsubscribeNewHistoryEntry = window.murmurMain.onNewHistoryEntry((entry) => {
-      if (selectionMode || selectedIds.size > 0) exitSelectionMode();
       // Prepend new entry if it passes current filters
       const filters = buildFilters();
       let shouldAdd = true;

--- a/app/src/renderer/app/views/HistoryView.svelte
+++ b/app/src/renderer/app/views/HistoryView.svelte
@@ -31,9 +31,27 @@
   let deleteConfirmId: string | null = $state(null);
   let deleteDialog: HTMLDivElement | undefined = $state(undefined);
   let deleteTrigger: HTMLElement | null = null;
+  let bulkDeleteConfirmOpen = $state(false);
+  let bulkDeleteDialog: HTMLDivElement | undefined = $state(undefined);
+  let bulkDeleteTrigger: HTMLElement | null = null;
+  let selectionToggle: HTMLButtonElement | undefined;
+
+  // Selection mode
+  let selectionMode = $state(false);
+  let selectedIds = $state<Set<string>>(new Set());
+  let selectingAll = $state(false);
+  let bulkDeleting = $state(false);
+  let selectionFeedback = $state('');
+  let selectionGeneration = 0;
+  let selectedCount = $derived(selectedIds.size);
+  let hasSelection = $derived(selectedCount > 0);
 
   $effect(() => {
     if (deleteConfirmId) queueMicrotask(() => deleteDialog?.focus());
+  });
+
+  $effect(() => {
+    if (bulkDeleteConfirmOpen) queueMicrotask(() => bulkDeleteDialog?.focus());
   });
 
   // Expanded item
@@ -83,9 +101,58 @@
     return hasFilters ? filters : undefined;
   }
 
+  function clearSelection(): void {
+    selectionGeneration += 1;
+    selectedIds = new Set();
+    selectionFeedback = '';
+  }
+
+  function enterSelectionMode(): void {
+    selectionMode = true;
+    clearSelection();
+  }
+
+  function exitSelectionMode(): void {
+    selectionMode = false;
+    clearSelection();
+  }
+
+  function toggleSelectionMode(): void {
+    if (selectionMode) exitSelectionMode();
+    else enterSelectionMode();
+  }
+
+  function toggleEntrySelection(id: string, selected: boolean): void {
+    const next = new Set(selectedIds);
+    if (selected) next.add(id);
+    else next.delete(id);
+    selectedIds = next;
+    selectionFeedback = '';
+  }
+
+  async function selectAllCurrentFilter(): Promise<void> {
+    if (selectingAll || bulkDeleting) return;
+    const generation = ++selectionGeneration;
+    selectingAll = true;
+    selectionFeedback = '';
+    try {
+      const ids = await window.murmurMain.getHistoryEntryIds(buildFilters());
+      if (generation !== selectionGeneration) return;
+      selectedIds = new Set(ids);
+      if (ids.length === 0) selectionFeedback = 'No entries match the current filters.';
+    } catch (err) {
+      if (generation !== selectionGeneration) return;
+      console.error('Failed to select history entries:', err);
+      selectionFeedback = 'History could not be selected. Try again.';
+    } finally {
+      selectingAll = false;
+    }
+  }
+
   // Load entries
   async function loadEntries(reset = false) {
     if (reset) {
+      if (selectionMode || selectedIds.size > 0) exitSelectionMode();
       requestGeneration += 1;
       offset = 0;
       hasMore = true;
@@ -133,6 +200,7 @@
   // Debounced search
   let searchTimeout: ReturnType<typeof setTimeout> | null = null;
   function handleSearchInput() {
+    clearSelection();
     if (searchTimeout) clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
       loadEntries(true);
@@ -141,6 +209,7 @@
 
   // Filter changes
   function handleFilterChange() {
+    clearSelection();
     loadEntries(true);
   }
 
@@ -151,6 +220,7 @@
     maxDuration = '';
     minConfidence = '';
     editedOnly = false;
+    clearSelection();
     loadEntries(true);
   }
 
@@ -207,6 +277,7 @@
     try {
       await window.murmurMain.deleteHistoryEntry(deleteConfirmId);
       history = history.filter((item) => item.id !== deleteConfirmId);
+      exitSelectionMode();
       toast('Transcription deleted', 'info');
     } catch (err) {
       console.error('Failed to delete:', err);
@@ -219,22 +290,75 @@
     closeDeleteDialog();
   }
 
+  function openBulkDeleteDialog(): void {
+    if (!hasSelection || bulkDeleting) return;
+    bulkDeleteTrigger = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    selectionFeedback = '';
+    bulkDeleteConfirmOpen = true;
+  }
+
+  function closeBulkDeleteDialog(): void {
+    bulkDeleteConfirmOpen = false;
+    const trigger = bulkDeleteTrigger;
+    bulkDeleteTrigger = null;
+    queueMicrotask(() => {
+      if (trigger?.isConnected) trigger.focus();
+      else selectionToggle?.focus();
+    });
+  }
+
+  function cancelBulkDelete(): void {
+    exitSelectionMode();
+    closeBulkDeleteDialog();
+  }
+
+  async function confirmBulkDelete(): Promise<void> {
+    if (bulkDeleting || !hasSelection) return;
+    const ids = [...selectedIds];
+    const requestedCount = ids.length;
+    bulkDeleting = true;
+    selectionFeedback = '';
+    try {
+      const result = await window.murmurMain.deleteHistoryEntries(ids);
+      exitSelectionMode();
+      closeBulkDeleteDialog();
+      await loadEntries(true);
+      if (result.missingIds.length > 0) {
+        toast(`Deleted ${result.deletedCount} of ${requestedCount} selected entries; ${result.missingIds.length} were already gone.`, 'info');
+      } else {
+        toast(`Deleted ${result.deletedCount} selected ${result.deletedCount === 1 ? 'entry' : 'entries'}.`, 'info');
+      }
+    } catch (err) {
+      console.error('Failed to delete selected history:', err);
+      selectionFeedback = 'History could not be deleted. Nothing was removed. Try again.';
+      toast('Failed to delete selected entries', 'error');
+    } finally {
+      bulkDeleting = false;
+    }
+  }
+
+  function getActiveConfirmationDialog(): HTMLDivElement | undefined {
+    return deleteConfirmId ? deleteDialog : bulkDeleteConfirmOpen ? bulkDeleteDialog : undefined;
+  }
+
   function handleWindowKeydown(event: KeyboardEvent) {
-    if (!deleteConfirmId) return;
+    const activeDialog = getActiveConfirmationDialog();
+    if (!activeDialog) return;
     if (event.key === 'Escape') {
       event.preventDefault();
-      cancelDelete();
+      if (deleteConfirmId) cancelDelete();
+      else if (!bulkDeleting) cancelBulkDelete();
       return;
     }
-    if (event.key === 'Tab' && deleteDialog) {
+    if (event.key === 'Tab') {
       const focusable = Array.from(
-        deleteDialog.querySelectorAll<HTMLElement>(
+        activeDialog.querySelectorAll<HTMLElement>(
           'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
         )
       );
       if (focusable.length === 0) {
         event.preventDefault();
-        deleteDialog.focus();
+        activeDialog.focus();
         return;
       }
       const first = focusable[0];
@@ -296,6 +420,7 @@
 
     // Listen for new entries
     const unsubscribeNewHistoryEntry = window.murmurMain.onNewHistoryEntry((entry) => {
+      if (selectionMode || selectedIds.size > 0) exitSelectionMode();
       // Prepend new entry if it passes current filters
       const filters = buildFilters();
       let shouldAdd = true;
@@ -507,6 +632,64 @@
       </div>
     {/if}
 
+    <div data-history-selection-toolbar class="mt-3 flex min-w-0 flex-col gap-2 rounded-xl border border-white/[0.08] bg-white/[0.018] p-3 sm:flex-row sm:items-center sm:justify-between">
+      <div class="min-w-0">
+        {#if selectionMode}
+          <p data-history-selection-count class="text-xs text-zinc-200" aria-live="polite">{selectedCount} selected</p>
+          <p class="mt-1 text-[11px] text-zinc-500">Selection applies to the current filters.</p>
+        {:else}
+          <p class="text-xs text-zinc-500">Select entries to delete more than one at a time.</p>
+        {/if}
+        {#if selectionFeedback && !bulkDeleteConfirmOpen}
+          <p data-history-selection-feedback class="mt-1 text-xs text-red-300" role="alert">{selectionFeedback}</p>
+        {/if}
+      </div>
+      <div class="flex min-w-0 flex-wrap items-center gap-2">
+        <button
+          type="button"
+          data-history-selection-toggle
+          bind:this={selectionToggle}
+          aria-pressed={selectionMode}
+          onclick={toggleSelectionMode}
+          class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
+        >
+          {selectionMode ? 'Exit selection' : 'Select entries'}
+        </button>
+        {#if selectionMode}
+          <button
+            type="button"
+            data-history-select-all
+            aria-label="Select all entries in the current filter"
+            aria-busy={selectingAll}
+            disabled={selectingAll || bulkDeleting}
+            onclick={selectAllCurrentFilter}
+            class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {selectingAll ? 'Selecting…' : 'Select all'}
+          </button>
+          <button
+            type="button"
+            data-history-clear-selection
+            disabled={!hasSelection || selectingAll || bulkDeleting}
+            onclick={clearSelection}
+            class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Clear selection
+          </button>
+          <button
+            type="button"
+            data-history-delete-selected
+            disabled={!hasSelection || selectingAll || bulkDeleting}
+            aria-busy={bulkDeleting}
+            onclick={openBulkDeleteDialog}
+            class="min-h-9 rounded-lg bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-950 transition-colors hover:bg-white cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {bulkDeleting ? 'Deleting…' : 'Delete selected'}
+          </button>
+        {/if}
+      </div>
+    </div>
+
   </div>
 
   <!-- History List -->
@@ -557,6 +740,18 @@
             <!-- Collapsed/Preview State -->
             <div class="px-3 py-3">
               <div class="flex items-center gap-3">
+                {#if selectionMode}
+                  <label class="flex shrink-0 items-center">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(item.id)}
+                      disabled={selectingAll || bulkDeleting}
+                      aria-label={`Select transcription from ${formatFullDate(item.timestamp)}`}
+                      onchange={(event) => toggleEntrySelection(item.id, event.currentTarget.checked)}
+                      class="h-4 w-4 cursor-pointer rounded border-zinc-700 bg-zinc-800 text-zinc-200 focus:ring-2 focus:ring-zinc-200 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                  </label>
+                {/if}
                 <button
                   type="button"
                   onclick={() => toggleExpand(item.id)}
@@ -710,6 +905,47 @@
           class="px-4 py-2 text-sm font-medium bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors cursor-pointer"
         >
           Delete
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+{#if bulkDeleteConfirmOpen}
+  <div class="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+    <div
+      bind:this={bulkDeleteDialog}
+      tabindex="-1"
+      class="bg-zinc-900 border border-zinc-800 rounded-2xl p-6 max-w-sm mx-4 shadow-xl"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bulk-delete-dialog-title"
+      aria-describedby="bulk-delete-dialog-description"
+    >
+      <h3 id="bulk-delete-dialog-title" class="text-lg font-medium text-zinc-100 mb-2">Delete {selectedCount} selected {selectedCount === 1 ? 'entry' : 'entries'}?</h3>
+      <p id="bulk-delete-dialog-description" class="text-sm text-zinc-400 mb-4">
+        This action cannot be undone. Exactly {selectedCount} selected {selectedCount === 1 ? 'entry will' : 'entries will'} be permanently removed from your history.
+      </p>
+      {#if selectionFeedback}
+        <p data-bulk-delete-error class="mb-4 text-sm text-red-300" role="alert">{selectionFeedback}</p>
+      {/if}
+      <div class="flex gap-3 justify-end">
+        <button
+          type="button"
+          onclick={cancelBulkDelete}
+          disabled={bulkDeleting}
+          class="px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onclick={confirmBulkDelete}
+          disabled={bulkDeleting}
+          aria-busy={bulkDeleting}
+          class="px-4 py-2 text-sm font-medium bg-zinc-100 hover:bg-white text-zinc-950 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {bulkDeleting ? 'Deleting…' : `Delete ${selectedCount}`}
         </button>
       </div>
     </div>

--- a/app/src/renderer/global.d.ts
+++ b/app/src/renderer/global.d.ts
@@ -4,6 +4,7 @@ import type {
   ConnectionStatePayload,
   EngineStatus,
   HistoryEntryWithGroup,
+  HistoryDeleteResult,
   HistoryFilters,
   HistoryResponse,
   Hotkey,
@@ -35,7 +36,9 @@ declare global {
       cancelHotkeyCapture: () => Promise<void>;
       getHotkeyDisplayName: (hotkey: Hotkey) => Promise<string>;
       getHistoryEntries: (offset: number, limit: number, filters?: HistoryFilters) => Promise<HistoryResponse>;
+      getHistoryEntryIds: (filters?: HistoryFilters) => Promise<string[]>;
       deleteHistoryEntry: (id: string) => Promise<void>;
+      deleteHistoryEntries: (ids: string[]) => Promise<HistoryDeleteResult>;
       getInsights: (range: InsightsRange) => Promise<InsightsResponse | null>;
       rebuildInsights: () => Promise<void>;
       onNewHistoryEntry: (callback: (entry: HistoryEntryWithGroup) => void) => () => void;

--- a/app/src/shared/constants.ts
+++ b/app/src/shared/constants.ts
@@ -38,7 +38,9 @@ export const IPC_CHANNELS = {
 
   // History
   HISTORY_GET_ENTRIES: 'history:get-entries',
+  HISTORY_GET_ENTRY_IDS: 'history:get-entry-ids',
   HISTORY_DELETE: 'history:delete',
+  HISTORY_DELETE_BULK: 'history:delete-bulk',
   HISTORY_NEW_ENTRY: 'history:new-entry',
 
   // Insights

--- a/app/src/shared/history-validation.ts
+++ b/app/src/shared/history-validation.ts
@@ -1,0 +1,34 @@
+import type { HistoryFilters } from './types.js';
+
+const HISTORY_FILTER_KEYS = new Set([
+  'text',
+  'dateFrom',
+  'dateTo',
+  'minDuration',
+  'maxDuration',
+  'minConfidence',
+  'editedOnly',
+]);
+
+const NUMERIC_HISTORY_FILTER_KEYS = [
+  'dateFrom',
+  'dateTo',
+  'minDuration',
+  'maxDuration',
+  'minConfidence',
+] as const;
+
+export function isHistoryFilters(value: unknown): value is HistoryFilters | undefined {
+  if (value === undefined) return true;
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+
+  const filters = value as Record<string, unknown>;
+  if (Object.keys(filters).some((key) => !HISTORY_FILTER_KEYS.has(key))) return false;
+  if (filters.text !== undefined && typeof filters.text !== 'string') return false;
+  if (filters.editedOnly !== undefined && typeof filters.editedOnly !== 'boolean') return false;
+
+  return NUMERIC_HISTORY_FILTER_KEYS.every((key) => {
+    const candidate = filters[key];
+    return candidate === undefined || (typeof candidate === 'number' && Number.isFinite(candidate));
+  });
+}

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -187,6 +187,13 @@ export interface HistoryResponse {
   hasMore: boolean;
 }
 
+export interface HistoryDeleteResult {
+  requestedCount: number;
+  deletedCount: number;
+  deletedIds: string[];
+  missingIds: string[];
+}
+
 export interface InsightSourceEntry {
   id: string;
   timestamp: number;

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -187,6 +187,7 @@ export interface HistoryResponse {
   hasMore: boolean;
 }
 
+// requestedCount counts the deduplicated, non-empty IDs supplied by the caller.
 export interface HistoryDeleteResult {
   requestedCount: number;
   deletedCount: number;

--- a/app/tests/history-bulk-delete.test.ts
+++ b/app/tests/history-bulk-delete.test.ts
@@ -5,6 +5,10 @@ function source(path: string): string {
   return readFileSync(new URL(path, import.meta.url), 'utf8');
 }
 
+function normalized(sourceText: string): string {
+  return sourceText.replace(/\s+/g, ' ').trim();
+}
+
 const historyService = source('../src/main/services/history.ts');
 const handlers = source('../src/main/ipc/handlers.ts');
 const preload = source('../src/main/preload/main.ts');
@@ -13,9 +17,21 @@ const constants = source('../src/shared/constants.ts');
 const types = source('../src/shared/types.ts');
 const historyView = source('../src/renderer/app/views/HistoryView.svelte');
 
-const deleteManySection = historyService.match(
+const deleteManyMatch = historyService.match(
   /  deleteMany\(ids: string\[\]\): HistoryDeleteResult \{([\s\S]*?)\r?\n  \}\r?\n\r?\n  getById/
-)?.[1] ?? '';
+);
+if (!deleteManyMatch) {
+  throw new Error('HistoryService.deleteMany contract section was not found');
+}
+const deleteManySection = deleteManyMatch[1]!;
+const historyViewFlat = normalized(historyView);
+const newEntryHandlerMatch = historyView.match(
+  /const unsubscribeNewHistoryEntry = window\.murmurMain\.onNewHistoryEntry\(\(entry\) => \{([\s\S]*?)\r?\n    \}\);/
+);
+if (!newEntryHandlerMatch) {
+  throw new Error('HistoryView new-entry handler contract section was not found');
+}
+const newEntryHandler = normalized(newEntryHandlerMatch[1]!);
 
 describe('History selection and bulk deletion contracts', () => {
   test('exposes filtered IDs and one transactional bulk service operation', () => {
@@ -24,18 +40,25 @@ describe('History selection and bulk deletion contracts', () => {
     expect(types).toContain('export interface HistoryDeleteResult');
     expect(types).toContain('requestedCount: number');
     expect(types).toContain('missingIds: string[]');
+    expect(types).toContain('requestedCount counts the deduplicated, non-empty IDs');
     expect(historyService).toContain('getEntryIds(filters?: HistoryFilters): string[]');
     expect(historyService).toContain('const { whereClause, params } = buildHistoryQuery(filters);');
+    expect(historyService).toContain('const HISTORY_ID_CHUNK_SIZE = 500;');
     expect(deleteManySection).toContain('this.db.transaction');
+    expect(deleteManySection).toContain('return remove.immediate(requestedIds);');
     expect(deleteManySection).toContain('DELETE FROM transcriptions WHERE id IN');
     expect(deleteManySection).toContain('getEntriesByIds(selectedIds)');
-    expect(deleteManySection).toContain('removeEntryFromInsightsWithinTransaction(entry)');
+    expect(deleteManySection).toContain('removeEntriesFromInsightsWithinTransaction(existing)');
     expect(deleteManySection).toContain('missingIds');
     expect(deleteManySection).not.toContain('this.delete(');
+    expect(historyService).toContain('DELETE FROM insights_word_counts WHERE day = @day AND count <= 0');
+    expect(historyService).toContain('const deleteProcessed = this.db.prepare');
   });
 
   test('keeps IPC and preload boundaries typed, validated, and bulk-shaped', () => {
     expect(handlers).toContain('IPC_CHANNELS.HISTORY_GET_ENTRY_IDS');
+    expect(handlers).toContain('isHistoryFilters(filters)');
+    expect(handlers).toContain("throw new TypeError('Invalid history filters')");
     expect(handlers).toContain('historyServiceRef.getEntryIds(filters)');
     expect(handlers).toContain('IPC_CHANNELS.HISTORY_DELETE_BULK');
     expect(handlers).toContain('historyServiceRef.deleteMany(ids)');
@@ -48,47 +71,48 @@ describe('History selection and bulk deletion contracts', () => {
   });
 
   test('supports current-filter selection, exact counts, stale-result safety, and retryable deletion', () => {
-    expect(historyView).toContain('let selectedIds = $state<Set<string>>(new Set());');
-    expect(historyView).toContain('let selectedCount = $derived(selectedIds.size);');
-    expect(historyView).toContain('const ids = await window.murmurMain.getHistoryEntryIds(buildFilters());');
-    expect(historyView).toContain('const generation = ++selectionGeneration;');
-    expect(historyView).toContain('if (generation !== selectionGeneration) return;');
-    expect(historyView).toContain('data-history-selection-count');
-    expect(historyView).toContain('aria-live="polite"');
-    expect(historyView).toContain('data-history-selection-toggle');
-    expect(historyView).toContain('aria-pressed={selectionMode}');
-    expect(historyView).toContain('data-history-select-all');
-    expect(historyView).toContain('data-history-clear-selection');
-    expect(historyView).toContain('data-history-delete-selected');
-    expect(historyView).toContain('const result = await window.murmurMain.deleteHistoryEntries(ids);');
-    expect(historyView).toContain('result.deletedCount');
-    expect(historyView).toContain('result.missingIds.length');
-    expect(historyView).toContain('await loadEntries(true);');
-    expect(historyView).toContain('if (bulkDeleting || !hasSelection) return;');
-    expect(historyView).toContain('selectionFeedback = \'History could not be deleted. Nothing was removed. Try again.\';');
-    expect(historyView).toContain('{#if selectionFeedback && !bulkDeleteConfirmOpen}');
-    expect(historyView).toContain('function cancelBulkDelete(): void');
-    expect(historyView).toContain('exitSelectionMode();\n    closeBulkDeleteDialog();');
-    expect(historyView).toContain('clearSelection();\n    if (searchTimeout)');
-    expect(historyView).toContain('clearSelection();\n    loadEntries(true);');
-    expect(historyView).toContain('if (selectionMode || selectedIds.size > 0) exitSelectionMode();');
+    expect(historyViewFlat).toContain('let selectedIds = $state<Set<string>>(new Set());');
+    expect(historyViewFlat).toContain('let selectedCount = $derived(selectedIds.size);');
+    expect(historyViewFlat).toContain('const ids = await window.murmurMain.getHistoryEntryIds(buildFilters());');
+    expect(historyViewFlat).toContain('const generation = ++selectionGeneration;');
+    expect(historyViewFlat).toContain('if (generation !== selectionGeneration) return;');
+    expect(historyViewFlat).toContain('data-history-selection-count');
+    expect(historyViewFlat).toContain('aria-live="polite"');
+    expect(historyViewFlat).toContain('data-history-selection-toggle');
+    expect(historyViewFlat).toContain('aria-pressed={selectionMode}');
+    expect(historyViewFlat).toContain('data-history-select-all');
+    expect(historyViewFlat).toContain('data-history-clear-selection');
+    expect(historyViewFlat).toContain('data-history-delete-selected');
+    expect(historyViewFlat).toContain('const result = await window.murmurMain.deleteHistoryEntries(ids);');
+    expect(historyViewFlat).toContain('result.deletedCount');
+    expect(historyViewFlat).toContain('result.missingIds.length');
+    expect(historyViewFlat).toContain('await loadEntries(true);');
+    expect(historyViewFlat).toContain('if (bulkDeleting || !hasSelection) return;');
+    expect(historyViewFlat).toContain('selectionFeedback = \'History could not be deleted. Nothing was removed. Try again.\';');
+    expect(historyViewFlat).toContain('{#if selectionFeedback && !bulkDeleteConfirmOpen}');
+    expect(historyViewFlat).toContain('function cancelBulkDelete(): void { exitSelectionMode(); closeBulkDeleteDialog(); }');
+    expect(historyViewFlat).toContain('clearSelection(); if (searchTimeout)');
+    expect(historyViewFlat).toContain('clearSelection(); loadEntries(true);');
+    expect(historyViewFlat).toContain('function removeEntryFromSelection(id: string): void');
+    expect(historyViewFlat).toContain('removeEntryFromSelection(id);');
+    expect(newEntryHandler).not.toContain('exitSelectionMode()');
   });
 
   test('makes row selection and confirmation keyboard/screen-reader accessible', () => {
-    expect(historyView).toContain('type="checkbox"');
-    expect(historyView).toContain('aria-label={`Select transcription from ${formatFullDate(item.timestamp)}`}');
-    expect(historyView).toContain('<svelte:window onkeydown={handleWindowKeydown} />');
-    expect(historyView).toContain("if (event.key === 'Escape')");
-    expect(historyView).toContain('else if (!bulkDeleting) cancelBulkDelete();');
-    expect(historyView).toContain("if (event.key === 'Tab')");
-    expect(historyView).toContain('bulkDeleteTrigger = document.activeElement instanceof HTMLElement');
-    expect(historyView).toContain('if (trigger?.isConnected) trigger.focus();');
-    expect(historyView).toContain('else selectionToggle?.focus();');
-    expect(historyView).toContain('role="dialog"');
-    expect(historyView).toContain('aria-labelledby="bulk-delete-dialog-title"');
-    expect(historyView).toContain('aria-describedby="bulk-delete-dialog-description"');
-    expect(historyView).toContain('Exactly {selectedCount} selected');
-    expect(historyView).toContain('disabled={bulkDeleting}');
-    expect(historyView).toContain('aria-busy={bulkDeleting}');
+    expect(historyViewFlat).toContain('type="checkbox"');
+    expect(historyViewFlat).toContain('aria-label={`Select transcription from ${formatFullDate(item.timestamp)}`}');
+    expect(historyViewFlat).toContain('<svelte:window onkeydown={handleWindowKeydown} />');
+    expect(historyViewFlat).toContain("if (event.key === 'Escape')");
+    expect(historyViewFlat).toContain('else if (!bulkDeleting) cancelBulkDelete();');
+    expect(historyViewFlat).toContain("if (event.key === 'Tab')");
+    expect(historyViewFlat).toContain('bulkDeleteTrigger = document.activeElement instanceof HTMLElement');
+    expect(historyViewFlat).toContain('if (trigger?.isConnected) trigger.focus();');
+    expect(historyViewFlat).toContain('else selectionToggle?.focus();');
+    expect(historyViewFlat).toContain('role="dialog"');
+    expect(historyViewFlat).toContain('aria-labelledby="bulk-delete-dialog-title"');
+    expect(historyViewFlat).toContain('aria-describedby="bulk-delete-dialog-description"');
+    expect(historyViewFlat).toContain('Exactly {selectedCount} selected');
+    expect(historyViewFlat).toContain('disabled={bulkDeleting}');
+    expect(historyViewFlat).toContain('aria-busy={bulkDeleting}');
   });
 });

--- a/app/tests/history-bulk-delete.test.ts
+++ b/app/tests/history-bulk-delete.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+const historyService = source('../src/main/services/history.ts');
+const handlers = source('../src/main/ipc/handlers.ts');
+const preload = source('../src/main/preload/main.ts');
+const rendererTypes = source('../src/renderer/global.d.ts');
+const constants = source('../src/shared/constants.ts');
+const types = source('../src/shared/types.ts');
+const historyView = source('../src/renderer/app/views/HistoryView.svelte');
+
+const deleteManySection = historyService.match(
+  /  deleteMany\(ids: string\[\]\): HistoryDeleteResult \{([\s\S]*?)\r?\n  \}\r?\n\r?\n  getById/
+)?.[1] ?? '';
+
+describe('History selection and bulk deletion contracts', () => {
+  test('exposes filtered IDs and one transactional bulk service operation', () => {
+    expect(constants).toContain("HISTORY_GET_ENTRY_IDS: 'history:get-entry-ids'");
+    expect(constants).toContain("HISTORY_DELETE_BULK: 'history:delete-bulk'");
+    expect(types).toContain('export interface HistoryDeleteResult');
+    expect(types).toContain('requestedCount: number');
+    expect(types).toContain('missingIds: string[]');
+    expect(historyService).toContain('getEntryIds(filters?: HistoryFilters): string[]');
+    expect(historyService).toContain('const { whereClause, params } = buildHistoryQuery(filters);');
+    expect(deleteManySection).toContain('this.db.transaction');
+    expect(deleteManySection).toContain('DELETE FROM transcriptions WHERE id IN');
+    expect(deleteManySection).toContain('getEntriesByIds(selectedIds)');
+    expect(deleteManySection).toContain('removeEntryFromInsightsWithinTransaction(entry)');
+    expect(deleteManySection).toContain('missingIds');
+    expect(deleteManySection).not.toContain('this.delete(');
+  });
+
+  test('keeps IPC and preload boundaries typed, validated, and bulk-shaped', () => {
+    expect(handlers).toContain('IPC_CHANNELS.HISTORY_GET_ENTRY_IDS');
+    expect(handlers).toContain('historyServiceRef.getEntryIds(filters)');
+    expect(handlers).toContain('IPC_CHANNELS.HISTORY_DELETE_BULK');
+    expect(handlers).toContain('historyServiceRef.deleteMany(ids)');
+    expect(handlers).toContain("throw new TypeError('Invalid history entry IDs')");
+    expect(handlers).toContain("throw new Error('History service is unavailable; try again.')");
+    expect(preload).toContain('ipcRenderer.invoke(IPC_CHANNELS.HISTORY_GET_ENTRY_IDS, filters)');
+    expect(preload).toContain('ipcRenderer.invoke(IPC_CHANNELS.HISTORY_DELETE_BULK, ids)');
+    expect(rendererTypes).toContain('getHistoryEntryIds: (filters?: HistoryFilters) => Promise<string[]>');
+    expect(rendererTypes).toContain('deleteHistoryEntries: (ids: string[]) => Promise<HistoryDeleteResult>');
+  });
+
+  test('supports current-filter selection, exact counts, stale-result safety, and retryable deletion', () => {
+    expect(historyView).toContain('let selectedIds = $state<Set<string>>(new Set());');
+    expect(historyView).toContain('let selectedCount = $derived(selectedIds.size);');
+    expect(historyView).toContain('const ids = await window.murmurMain.getHistoryEntryIds(buildFilters());');
+    expect(historyView).toContain('const generation = ++selectionGeneration;');
+    expect(historyView).toContain('if (generation !== selectionGeneration) return;');
+    expect(historyView).toContain('data-history-selection-count');
+    expect(historyView).toContain('aria-live="polite"');
+    expect(historyView).toContain('data-history-selection-toggle');
+    expect(historyView).toContain('aria-pressed={selectionMode}');
+    expect(historyView).toContain('data-history-select-all');
+    expect(historyView).toContain('data-history-clear-selection');
+    expect(historyView).toContain('data-history-delete-selected');
+    expect(historyView).toContain('const result = await window.murmurMain.deleteHistoryEntries(ids);');
+    expect(historyView).toContain('result.deletedCount');
+    expect(historyView).toContain('result.missingIds.length');
+    expect(historyView).toContain('await loadEntries(true);');
+    expect(historyView).toContain('if (bulkDeleting || !hasSelection) return;');
+    expect(historyView).toContain('selectionFeedback = \'History could not be deleted. Nothing was removed. Try again.\';');
+    expect(historyView).toContain('{#if selectionFeedback && !bulkDeleteConfirmOpen}');
+    expect(historyView).toContain('function cancelBulkDelete(): void');
+    expect(historyView).toContain('exitSelectionMode();\n    closeBulkDeleteDialog();');
+    expect(historyView).toContain('clearSelection();\n    if (searchTimeout)');
+    expect(historyView).toContain('clearSelection();\n    loadEntries(true);');
+    expect(historyView).toContain('if (selectionMode || selectedIds.size > 0) exitSelectionMode();');
+  });
+
+  test('makes row selection and confirmation keyboard/screen-reader accessible', () => {
+    expect(historyView).toContain('type="checkbox"');
+    expect(historyView).toContain('aria-label={`Select transcription from ${formatFullDate(item.timestamp)}`}');
+    expect(historyView).toContain('<svelte:window onkeydown={handleWindowKeydown} />');
+    expect(historyView).toContain("if (event.key === 'Escape')");
+    expect(historyView).toContain('else if (!bulkDeleting) cancelBulkDelete();');
+    expect(historyView).toContain("if (event.key === 'Tab')");
+    expect(historyView).toContain('bulkDeleteTrigger = document.activeElement instanceof HTMLElement');
+    expect(historyView).toContain('if (trigger?.isConnected) trigger.focus();');
+    expect(historyView).toContain('else selectionToggle?.focus();');
+    expect(historyView).toContain('role="dialog"');
+    expect(historyView).toContain('aria-labelledby="bulk-delete-dialog-title"');
+    expect(historyView).toContain('aria-describedby="bulk-delete-dialog-description"');
+    expect(historyView).toContain('Exactly {selectedCount} selected');
+    expect(historyView).toContain('disabled={bulkDeleting}');
+    expect(historyView).toContain('aria-busy={bulkDeleting}');
+  });
+});

--- a/app/tests/history-filters.test.ts
+++ b/app/tests/history-filters.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { isHistoryFilters } from '../src/shared/history-validation.js';
+
+describe('History filter IPC validation', () => {
+  test('accepts the optional filter shape and finite numeric values', () => {
+    expect(isHistoryFilters(undefined)).toBe(true);
+    expect(isHistoryFilters({
+      text: 'planning',
+      dateFrom: 0,
+      dateTo: 1,
+      minDuration: 0,
+      maxDuration: 60.5,
+      minConfidence: 90,
+      editedOnly: true,
+    })).toBe(true);
+  });
+
+  test('rejects malformed, non-finite, and unknown filter payloads', () => {
+    expect(isHistoryFilters(null)).toBe(false);
+    expect(isHistoryFilters([])).toBe(false);
+    expect(isHistoryFilters({ text: 42 })).toBe(false);
+    expect(isHistoryFilters({ editedOnly: 'yes' })).toBe(false);
+    expect(isHistoryFilters({ minDuration: Number.NaN })).toBe(false);
+    expect(isHistoryFilters({ maxDuration: Number.POSITIVE_INFINITY })).toBe(false);
+    expect(isHistoryFilters({ unexpected: true })).toBe(false);
+  });
+});

--- a/app/tests/history-insights.node-check.mjs
+++ b/app/tests/history-insights.node-check.mjs
@@ -71,6 +71,7 @@ try {
   assert.equal(saved.summary.avgWpm, 7);
   assert.equal(saved.commonWords[0]?.text, 'project');
   assert.equal(saved.commonWords[0]?.count, 3);
+  assert.deepEqual(service.getEntryIds({ text: 'planning' }), ['a']);
 
   service.rebuildInsights();
   const rebuilt = service.getInsights('all');
@@ -88,8 +89,64 @@ try {
     { text: 'project', count: 1 },
     { text: 'review', count: 1 },
   ]);
-
   service.close();
+
+  const bulkDbPath = join(workDir, 'bulk-history.db');
+  const bulkService = new HistoryService(bulkDbPath);
+  bulkService.initialize();
+  assert.deepEqual(bulkService.deleteMany([]), {
+    requestedCount: 0,
+    deletedCount: 0,
+    deletedIds: [],
+    missingIds: [],
+  });
+  bulkService.save(transcription('bulk-a', now + 1000, 'Bulk alpha alpha', 5, 1000));
+  bulkService.save(transcription('bulk-b', now + 2000, 'Bulk beta notes', 6, 1200));
+  bulkService.save(transcription('bulk-fail', now + 3000, 'Bulk failure notes', 7, 1400));
+
+  assert.deepEqual(bulkService.getEntryIds({ text: 'alpha' }), ['bulk-a']);
+  const staleDelete = bulkService.deleteMany(['bulk-a', 'missing-entry', 'bulk-a']);
+  assert.deepEqual(staleDelete, {
+    requestedCount: 2,
+    deletedCount: 1,
+    deletedIds: ['bulk-a'],
+    missingIds: ['missing-entry'],
+  });
+  assert.equal(bulkService.getById('bulk-a'), null);
+  assert.equal(bulkService.getInsights('all').summary.totalDictations, 2);
+
+  const beforeFailedDelete = bulkService.getInsights('all').summary;
+  const triggerDb = new Database(bulkDbPath);
+  try {
+    triggerDb.exec(`
+      CREATE TRIGGER fail_bulk_delete
+      AFTER DELETE ON transcriptions
+      WHEN OLD.id = 'bulk-fail'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced bulk failure');
+      END;
+    `);
+    assert.throws(
+      () => bulkService.deleteMany(['bulk-fail', 'bulk-b']),
+      /forced bulk failure/
+    );
+    assert.ok(bulkService.getById('bulk-fail'));
+    assert.ok(bulkService.getById('bulk-b'));
+    assert.deepEqual(bulkService.getInsights('all').summary, beforeFailedDelete);
+  } finally {
+    triggerDb.exec('DROP TRIGGER fail_bulk_delete');
+    triggerDb.close();
+  }
+
+  const finalBulkDelete = bulkService.deleteMany(['bulk-fail', 'bulk-b']);
+  assert.deepEqual(finalBulkDelete, {
+    requestedCount: 2,
+    deletedCount: 2,
+    deletedIds: ['bulk-fail', 'bulk-b'],
+    missingIds: [],
+  });
+  assert.equal(bulkService.getInsights('all').summary.totalDictations, 0);
+  bulkService.close();
 
   const migrationDbPath = join(workDir, 'migration-history.db');
   const migrationDb = new Database(migrationDbPath);

--- a/app/tests/history-insights.node-check.mjs
+++ b/app/tests/history-insights.node-check.mjs
@@ -148,6 +148,51 @@ try {
   assert.equal(bulkService.getInsights('all').summary.totalDictations, 0);
   bulkService.close();
 
+  const cleanupDbPath = join(workDir, 'day-scoped-cleanup.db');
+  const cleanupService = new HistoryService(cleanupDbPath);
+  cleanupService.initialize();
+  cleanupService.save(transcription('cleanup-a', now + 4000, 'Cleanup day entry', 1, 100));
+  const cleanupDb = new Database(cleanupDbPath);
+  cleanupDb.prepare(`
+    INSERT INTO insights_word_counts (day, word, count)
+    VALUES ('2099-01-01', 'unrelated', 0)
+  `).run();
+  cleanupDb.close();
+  cleanupService.deleteMany(['cleanup-a']);
+  const cleanupCheckDb = new Database(cleanupDbPath);
+  assert.deepEqual(
+    cleanupCheckDb.prepare(`
+      SELECT count FROM insights_word_counts
+      WHERE day = '2099-01-01' AND word = 'unrelated'
+    `).get(),
+    { count: 0 },
+  );
+  cleanupCheckDb.close();
+  cleanupService.close();
+
+  const chunkDbPath = join(workDir, 'chunk-boundary-history.db');
+  const chunkService = new HistoryService(chunkDbPath);
+  chunkService.initialize();
+  for (let index = 0; index < 501; index += 1) {
+    chunkService.save(transcription(
+      `chunk-${index}`,
+      now + 5000 + index,
+      `Chunk boundary ${index}`,
+      1,
+      100,
+    ));
+  }
+  const chunkIds = chunkService.getEntryIds({ text: 'Chunk boundary' });
+  assert.equal(chunkIds.length, 501);
+  assert.deepEqual(chunkService.deleteMany(chunkIds), {
+    requestedCount: 501,
+    deletedCount: 501,
+    deletedIds: chunkIds,
+    missingIds: [],
+  });
+  assert.equal(chunkService.getInsights('all').summary.totalDictations, 0);
+  chunkService.close();
+
   const migrationDbPath = join(workDir, 'migration-history.db');
   const migrationDb = new Database(migrationDbPath);
   migrationDb.exec(`


### PR DESCRIPTION
## Summary

- Add accessible History selection mode with individual rows, select-all-current-filter, exact selected counts, and destructive confirmation.
- Add filtered ID retrieval and one transactional bulk-delete operation with deduplication, deterministic stale-ID results, and atomic Insights ledger updates.
- Preserve ordinary single-entry deletion and refresh History from the committed result.

## Validation

- Frozen install: 451 packages installed; native rebuild completed; no lockfile drift.
- Focused History contract tests: 4 passed.
- Real SQLite History/Insights check: passed, including zero/one/many, filtered, stale-ID, database rollback, and Insights consistency cases.
- Full non-rendered app matrix: 194 passed across 36 files; main/preload/Vite builds passed.
- `git diff --check`: passed.

The two Electron screenshot fixtures (`settings-server-rendered` and `settings-speech-rendered`) were retried once locally and both failed before assertions because `desktopCapturer.getSources` reported `Current display surface not available for capture`, despite an active interactive Windows session. No fixture code was changed; hosted CI should provide the authoritative rendered-fixture result.

Refs #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-selection mode for history entries, including select all, clear selection, and bulk deletion.
  * Added confirmation dialogs with deletion progress, partial-result reporting, and retry support.
  * History searches can now identify matching entries for bulk actions.

* **Bug Fixes**
  * Improved cleanup of related insights during history deletion.
  * Added handling for duplicate, missing, invalid, or unavailable history entries.

* **Accessibility**
  * Enhanced keyboard navigation, focus handling, and screen-reader support for deletion dialogs and selection controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Review dispositions for the correction

- Accepted the data-integrity, immediate-transaction, 500-ID chunking, fail-fast test extraction, CRLF-robust test, 501-ID rollback/boundary, and narrow finite `HistoryFilters` validation findings.
- Rejected the suggestion to preserve selection on cancellation: issue #57 explicitly requires cancellation to clear the selection. New incoming entries are not a material filter/query change, so selection is preserved there; ordinary single-entry deletion removes only that ID from the selection.
- Rejected the proposed `getEntryIds` cap/filter-delete redesign: issue #57 requires selecting the entire current filtered result set and deleting only explicit selected IDs, so a cap or filter-based deletion would violate the acceptance and change race/safety semantics.