### PR TITLE
Insights: deterministic daily dictation-time chart

### DIFF
--- a/app/src/main/services/history.ts
+++ b/app/src/main/services/history.ts
@@ -373,17 +373,17 @@ export class HistoryService {
     return entries;
   }
 
-  getInsights(range: InsightsRange): InsightsResponse {
+  getInsights(range: InsightsRange, now = Date.now()): InsightsResponse {
     if (!this.db) throw new Error('Database not initialized');
     if (this.processPendingInsights(this.queryCatchupLimit) >= this.queryCatchupLimit) {
       this.scheduleInsightsCatchup();
     }
 
-    const now = Date.now();
-    const rangeStart = getRangeStart(range, now);
+    const generatedAt = Number.isFinite(now) ? now : Date.now();
+    const rangeStart = getRangeStart(range, generatedAt);
     const dayStart = rangeStart === null ? null : getLocalDayKey(rangeStart);
     const rows = this.getDailyRows(dayStart);
-    const trends = this.buildTrends(rows, range, now);
+    const trends = this.buildTrends(rows, range, generatedAt);
     const summary = this.buildSummary(rows);
     const indexing = this.getIndexingStatus();
     const commonWords = this.getCommonWords(dayStart, 18);
@@ -394,7 +394,7 @@ export class HistoryService {
 
     return {
       range,
-      generatedAt: now,
+      generatedAt,
       hasData: summary.totalDictations > 0,
       indexing,
       summary,
@@ -744,7 +744,7 @@ export class HistoryService {
         SELECT day, dictations, words, audioSeconds, processingMs, confidenceSum, confidenceCount
         FROM insights_daily_rollups
         ORDER BY day ASC
-      `).all() as DailyRollupRow[];
+      `).all().map(normalizeDailyRow);
     }
 
     return this.db.prepare(`
@@ -752,13 +752,14 @@ export class HistoryService {
       FROM insights_daily_rollups
       WHERE day >= @dayStart
       ORDER BY day ASC
-    `).all({ dayStart }) as DailyRollupRow[];
+    `).all({ dayStart }).map(normalizeDailyRow);
   }
 
   private buildTrends(rows: DailyRollupRow[], range: InsightsRange, now: number): InsightsTrendPoint[] {
-    const rowMap = new Map(rows.map((row) => [row.day, row]));
+    const normalizedRows = rows.map(normalizeDailyRow);
+    const rowMap = new Map(normalizedRows.map((row) => [row.day, row]));
     const activeRows = range === 'all'
-      ? rows
+      ? normalizedRows
       : buildRangeDayKeys(range, now).map((day) => rowMap.get(day) ?? emptyDailyRow(day));
 
     return activeRows.map((row) => ({
@@ -769,26 +770,27 @@ export class HistoryService {
       audioSeconds: row.audioSeconds,
       processingMs: row.processingMs,
       avgWpm: calcWordsPerMinute(row.words, row.audioSeconds),
-      avgConfidence: row.confidenceCount > 0 ? row.confidenceSum / row.confidenceCount : 0,
+      avgConfidence: safeConfidence(row.confidenceSum, row.confidenceCount),
       avgProcessingRatio: calcProcessingRatio(row.audioSeconds, row.processingMs),
     }));
   }
 
   private buildSummary(rows: DailyRollupRow[]): InsightsSummary {
-    const totalDictations = rows.reduce((sum, row) => sum + row.dictations, 0);
-    const totalWords = rows.reduce((sum, row) => sum + row.words, 0);
-    const totalAudioSeconds = rows.reduce((sum, row) => sum + row.audioSeconds, 0);
-    const totalProcessingMs = rows.reduce((sum, row) => sum + row.processingMs, 0);
-    const confidenceSum = rows.reduce((sum, row) => sum + row.confidenceSum, 0);
-    const confidenceCount = rows.reduce((sum, row) => sum + row.confidenceCount, 0);
-    const busiest = [...rows].sort((a, b) => b.words - a.words || b.dictations - a.dictations)[0];
+    const normalizedRows = rows.map(normalizeDailyRow);
+    const totalDictations = normalizedRows.reduce((sum, row) => safeAdd(sum, row.dictations), 0);
+    const totalWords = normalizedRows.reduce((sum, row) => safeAdd(sum, row.words), 0);
+    const totalAudioSeconds = normalizedRows.reduce((sum, row) => safeAdd(sum, row.audioSeconds), 0);
+    const totalProcessingMs = normalizedRows.reduce((sum, row) => safeAdd(sum, row.processingMs), 0);
+    const confidenceSum = normalizedRows.reduce((sum, row) => safeAdd(sum, row.confidenceSum), 0);
+    const confidenceCount = normalizedRows.reduce((sum, row) => safeAdd(sum, row.confidenceCount), 0);
+    const busiest = [...normalizedRows].sort((a, b) => b.words - a.words || b.dictations - a.dictations)[0];
 
     return {
       totalDictations,
       totalWords,
       totalAudioSeconds,
       totalProcessingMs,
-      avgConfidence: confidenceCount > 0 ? confidenceSum / confidenceCount : 0,
+      avgConfidence: safeConfidence(confidenceSum, confidenceCount),
       // Weighted by recorded audio duration so a one-word clip cannot skew the speaking pace.
       avgWpm: calcWordsPerMinute(totalWords, totalAudioSeconds),
       avgProcessingRatio: calcProcessingRatio(totalAudioSeconds, totalProcessingMs),
@@ -885,6 +887,36 @@ interface DailyRollupRow {
   confidenceCount: number;
 }
 
+function normalizeDailyRow(row: DailyRollupRow): DailyRollupRow {
+  return {
+    day: typeof row.day === 'string' ? row.day : '',
+    dictations: safeCount(row.dictations),
+    words: safeCount(row.words),
+    audioSeconds: safeNonNegative(row.audioSeconds),
+    processingMs: safeNonNegative(row.processingMs),
+    confidenceSum: safeNonNegative(row.confidenceSum),
+    confidenceCount: safeCount(row.confidenceCount),
+  };
+}
+
+function safeCount(value: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function safeNonNegative(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function safeConfidence(sum: number, count: number): number {
+  if (!Number.isFinite(sum) || !Number.isFinite(count) || count <= 0) return 0;
+  return Math.min(1, Math.max(0, sum / count));
+}
+
+function safeAdd(first: number, second: number): number {
+  const sum = first + second;
+  return Number.isFinite(sum) ? sum : Number.MAX_VALUE;
+}
+
 function emptyDailyRow(day: string): DailyRollupRow {
   return {
     day,
@@ -929,15 +961,17 @@ function getNextLocalDayKey(dayKey: string): string {
 }
 
 function toEntryStat(entry: InsightSourceEntry): InsightsEntryStat {
-  const wordCount = entry.wordCount ?? countWords(entry.text);
+  const wordCount = safeCount(entry.wordCount ?? countWords(entry.text));
+  const audioDuration = safeNonNegative(entry.audioDuration);
+  const transcriptionTime = safeNonNegative(entry.transcriptionTime);
   return {
     id: entry.id,
     timestamp: entry.timestamp,
     text: entry.text,
     wordCount,
-    audioDuration: entry.audioDuration || 0,
-    transcriptionTime: entry.transcriptionTime || 0,
-    processingRatio: calcProcessingRatio(entry.audioDuration || 0, entry.transcriptionTime || 0),
+    audioDuration,
+    transcriptionTime,
+    processingRatio: calcProcessingRatio(audioDuration, transcriptionTime),
   };
 }
 

--- a/app/src/renderer/app/insights-chart.ts
+++ b/app/src/renderer/app/insights-chart.ts
@@ -1,0 +1,272 @@
+import type { InsightsTrendPoint } from '../../shared/types.js';
+
+/**
+ * The primary Insights chart is daily dictation time: persisted audio seconds
+ * per local calendar day over the selected period. Zero-valued fixed-range
+ * days are retained, while gaps in All time remain visible as empty space.
+ */
+export const DICTATION_TIME_CHART_WIDTH = 240;
+export const DICTATION_TIME_CHART_HEIGHT = 112;
+// Past this many seconds, scientific notation keeps labels stable in narrow layouts.
+export const EXTREME_DURATION_SECONDS = 1e12;
+
+const PLOT_LEFT = 34;
+const PLOT_RIGHT = 8;
+const PLOT_TOP = 10;
+const PLOT_BOTTOM = 82;
+const MAX_BAR_WIDTH = 18;
+
+export interface DictationTimeChartTick {
+  valueSeconds: number;
+  y: number;
+  label: string;
+}
+
+export interface DictationTimeChartBar {
+  date: string;
+  label: string;
+  valueSeconds: number;
+  valueLabel: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  relativeWidth: number;
+  gapBeforeDays: number;
+}
+
+export interface DictationTimeChart {
+  metricLabel: 'Daily dictation time';
+  unitLabel: 'seconds per local calendar day';
+  width: number;
+  height: number;
+  plotLeft: number;
+  plotRight: number;
+  zeroY: number;
+  scaleMaxSeconds: number;
+  scaleLabel: string;
+  totalSeconds: number;
+  gapDays: number;
+  xAxisStartLabel: string;
+  xAxisEndLabel: string | null;
+  xAxisDescription: string;
+  ticks: DictationTimeChartTick[];
+  bars: DictationTimeChartBar[];
+}
+
+interface NormalizedPoint {
+  date: string;
+  label: string;
+  valueSeconds: number;
+}
+
+export function buildDictationTimeChart(
+  points: InsightsTrendPoint[],
+  width = DICTATION_TIME_CHART_WIDTH,
+  height = DICTATION_TIME_CHART_HEIGHT,
+): DictationTimeChart {
+  const safeWidth = finitePositive(width, DICTATION_TIME_CHART_WIDTH);
+  const safeHeight = finitePositive(height, DICTATION_TIME_CHART_HEIGHT);
+  const normalized = normalizePoints(points);
+  const plotLeft = clamp(PLOT_LEFT, 0, safeWidth);
+  const plotRight = Math.max(plotLeft, safeWidth - Math.min(PLOT_RIGHT, safeWidth - plotLeft));
+  const plotWidth = plotRight - plotLeft;
+  const plotTop = clamp(PLOT_TOP, 0, safeHeight);
+  const zeroY = clamp(PLOT_BOTTOM, plotTop, safeHeight);
+  const plotHeight = Math.max(0, zeroY - plotTop);
+  const maximum = normalized.reduce((peak, point) => Math.max(peak, point.valueSeconds), 0);
+  const scaleMaxSeconds = chooseScaleMax(maximum);
+  const totalSeconds = normalized.reduce((sum, point) => safeAdd(sum, point.valueSeconds), 0);
+  const firstDay = normalized[0] ? dayOrdinal(normalized[0].date) ?? 0 : 0;
+  const lastDay = normalized.at(-1) ? dayOrdinal(normalized.at(-1)!.date) ?? firstDay : firstDay;
+  const daySpan = Math.max(1, lastDay - firstDay + 1);
+  const barWidth = normalized.length > 0 && plotWidth > 0
+    ? Math.min(MAX_BAR_WIDTH, (plotWidth / daySpan) * 0.7)
+    : 0;
+
+  let gapDays = 0;
+  let previousDay: number | null = null;
+  const bars = normalized.map((point) => {
+    // normalizePoints has already discarded invalid keys; the fallback keeps the
+    // geometry total if this helper is changed independently in the future.
+    const currentDay = dayOrdinal(point.date) ?? firstDay;
+    const gapBeforeDays = previousDay === null ? 0 : Math.max(0, currentDay - previousDay - 1);
+    gapDays += gapBeforeDays;
+    previousDay = currentDay;
+
+    const center = normalized.length === 1
+      ? plotLeft + plotWidth / 2
+      : plotLeft + ((currentDay - firstDay) / Math.max(1, daySpan - 1)) * plotWidth;
+    const x = clamp(center - barWidth / 2, plotLeft, Math.max(plotLeft, plotRight - barWidth));
+    const heightValue = clamp((point.valueSeconds / scaleMaxSeconds) * plotHeight, 0, plotHeight);
+    const y = clamp(zeroY - heightValue, plotTop, zeroY);
+
+    return {
+      date: point.date,
+      label: point.label,
+      valueSeconds: point.valueSeconds,
+      valueLabel: formatChartDuration(point.valueSeconds),
+      x,
+      y,
+      width: barWidth,
+      height: heightValue,
+      relativeWidth: clamp((point.valueSeconds / scaleMaxSeconds) * 100, 0, 100),
+      gapBeforeDays,
+    };
+  });
+
+  const ticks = [0, scaleMaxSeconds / 2, scaleMaxSeconds].map((valueSeconds) => ({
+    valueSeconds,
+    y: clamp(zeroY - (valueSeconds / scaleMaxSeconds) * plotHeight, plotTop, zeroY),
+    label: formatChartDuration(valueSeconds),
+  }));
+  const xAxis = buildXAxisLabels(normalized);
+
+  return {
+    metricLabel: 'Daily dictation time',
+    unitLabel: 'seconds per local calendar day',
+    width: safeWidth,
+    height: safeHeight,
+    plotLeft,
+    plotRight,
+    zeroY,
+    scaleMaxSeconds,
+    scaleLabel: formatChartDuration(scaleMaxSeconds),
+    totalSeconds,
+    gapDays,
+    ...xAxis,
+    ticks,
+    bars,
+  };
+}
+
+export function formatChartDuration(seconds: number): string {
+  const value = finiteNonNegative(seconds);
+  if (value >= EXTREME_DURATION_SECONDS) return formatExtremeDuration(value);
+  if (value === 0) return '0s';
+  if (value < 60) return `${formatCompact(value)}s`;
+  if (value < 3600) return `${formatCompact(value / 60)}m`;
+  return `${formatCompact(value / 3600)}h`;
+}
+
+export function formatInsightsDuration(seconds: number): string {
+  const value = finiteNonNegative(seconds);
+  if (value >= EXTREME_DURATION_SECONDS) return formatExtremeDuration(value);
+  if (value < 60) return `${Math.round(value)}s`;
+  const minutes = Math.floor(value / 60);
+  const remainingSeconds = Math.round(value % 60);
+  if (minutes < 60) return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+function normalizePoints(points: InsightsTrendPoint[]): NormalizedPoint[] {
+  const byDate = new Map<string, NormalizedPoint>();
+  for (const point of points) {
+    if (dayOrdinal(point.date) === null) continue;
+    const current = byDate.get(point.date);
+    const valueSeconds = finiteNonNegative(point.audioSeconds);
+    if (current) {
+      current.valueSeconds = safeAdd(current.valueSeconds, valueSeconds);
+    } else {
+      byDate.set(point.date, {
+        date: point.date,
+        label: point.label || point.date,
+        valueSeconds,
+      });
+    }
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+function chooseScaleMax(value: number): number {
+  const maximum = finiteNonNegative(value);
+  if (maximum === 0) return 1;
+
+  const exponent = Math.floor(Math.log10(maximum));
+  const magnitude = 10 ** exponent;
+  if (!Number.isFinite(magnitude) || magnitude <= 0) return maximum;
+
+  const normalized = maximum / magnitude;
+  const step = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  const scale = step * magnitude;
+  return Number.isFinite(scale) && scale >= maximum ? scale : maximum;
+}
+
+function buildXAxisLabels(points: NormalizedPoint[]): Pick<DictationTimeChart, 'xAxisStartLabel' | 'xAxisEndLabel' | 'xAxisDescription'> {
+  if (points.length === 0) {
+    return {
+      xAxisStartLabel: 'No recorded days',
+      xAxisEndLabel: null,
+      xAxisDescription: 'no recorded local days',
+    };
+  }
+
+  const start = formatDayLabel(points[0]!.date);
+  if (points.length === 1) {
+    return {
+      xAxisStartLabel: start,
+      xAxisEndLabel: null,
+      xAxisDescription: `one local day: ${start}`,
+    };
+  }
+
+  const end = formatDayLabel(points.at(-1)!.date);
+  return {
+    xAxisStartLabel: start,
+    xAxisEndLabel: end,
+    xAxisDescription: `from ${start} through ${end}`,
+  };
+}
+
+function dayOrdinal(dayKey: string): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dayKey);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const timestamp = Date.UTC(year, month - 1, day);
+  if (!Number.isFinite(timestamp)) return null;
+  const date = new Date(timestamp);
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) return null;
+  return timestamp / 86400000;
+}
+
+function formatDayLabel(dayKey: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dayKey);
+  if (!match) return dayKey;
+  return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3])).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function finitePositive(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function finiteNonNegative(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function safeAdd(first: number, second: number): number {
+  const sum = first + second;
+  return Number.isFinite(sum) ? sum : Number.MAX_VALUE;
+}
+
+function formatCompact(value: number): string {
+  if (!Number.isFinite(value)) return '0';
+  if (value >= EXTREME_DURATION_SECONDS) return value.toExponential(2);
+  if (value < 10) return value.toFixed(1).replace(/\.0$/, '');
+  return Math.round(value).toLocaleString('en-US');
+}
+
+function formatExtremeDuration(value: number): string {
+  return `${value.toExponential(2)}s`;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  if (!Number.isFinite(value)) return minimum;
+  return Math.min(maximum, Math.max(minimum, value));
+}

--- a/app/src/renderer/app/views/InsightsView.svelte
+++ b/app/src/renderer/app/views/InsightsView.svelte
@@ -10,6 +10,8 @@
   import { createLatestRequestGuard } from '../latest-request';
   import PrimaryPage from '../components/PrimaryPage.svelte';
   import EveDropdown from '../components/EveDropdown.svelte';
+  import { buildDictationTimeChart, formatInsightsDuration } from '../insights-chart';
+  import type { DictationTimeChart } from '../insights-chart';
 
   const ranges: Array<{ id: InsightsRange; label: string }> = [
     { id: 'today', label: 'Today' },
@@ -24,6 +26,8 @@
   let error = $state<string | null>(null);
   let scrollContainer: HTMLDivElement | undefined = $state(undefined);
   const insightRequests = createLatestRequestGuard();
+  let selectedRangeLabel = $derived(ranges.find((option) => option.id === range)?.label ?? range);
+  let dailyChart = $derived(buildDictationTimeChart(insights?.trends ?? []));
 
   async function loadInsights() {
     const requestId = insightRequests.begin();
@@ -52,27 +56,22 @@
   }
 
   function formatInteger(value: number): string {
-    return Math.round(value).toLocaleString();
+    return Math.max(0, Math.round(finiteNonNegative(value))).toLocaleString();
   }
 
   function formatDuration(seconds: number): string {
-    if (seconds < 60) return `${Math.round(seconds)}s`;
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = Math.round(seconds % 60);
-    if (minutes < 60) return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
-    const hours = Math.floor(minutes / 60);
-    const remainingMinutes = minutes % 60;
-    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+    return formatInsightsDuration(seconds);
   }
 
   function formatPercent(value: number): string {
-    if (value <= 0) return '0%';
-    return `${Math.round(value * 100)}%`;
+    const bounded = Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0;
+    return `${Math.round(bounded * 100)}%`;
   }
 
   function formatRatio(value: number): string {
-    if (value <= 0) return '0x';
-    return `${value.toFixed(value >= 10 ? 0 : 1)}x`;
+    const safeValue = finiteNonNegative(value);
+    if (safeValue <= 0) return '0x';
+    return `${safeValue.toFixed(safeValue >= 10 ? 0 : 1)}x`;
   }
 
   function formatEntryTime(timestamp: number): string {
@@ -85,6 +84,10 @@
   function truncateText(text: string): string {
     const cleaned = text.replace(/\s+/g, ' ').trim();
     return cleaned.length > 88 ? `${cleaned.slice(0, 85)}...` : cleaned;
+  }
+
+  function finiteNonNegative(value: number): number {
+    return Number.isFinite(value) && value > 0 ? value : 0;
   }
 
   onMount(() => {
@@ -150,13 +153,15 @@
       {/if}
 
       <div class="grid grid-cols-1 gap-2.5">
-        <section class="flex min-h-[106px] items-center justify-between rounded-[9px] border border-white/10 bg-white/[0.025] px-3 py-3" aria-labelledby="dictation-time-heading">
-          <div>
-            <h2 id="dictation-time-heading" class="text-xs text-zinc-400">Dictation time</h2>
-            <p class="mt-1.5 text-[22px] font-medium leading-none text-zinc-100">{formatDuration(insights.summary.totalAudioSeconds)}</p>
-            <p class="mt-2 text-[11px] text-zinc-500">Total dictation time</p>
+        <section data-insights-dictation-time-chart class="rounded-[9px] border border-white/10 bg-white/[0.025] px-3 py-3" aria-labelledby="dictation-time-heading">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <h2 id="dictation-time-heading" class="text-xs text-zinc-300">Daily dictation time</h2>
+              <p class="mt-1 text-[11px] text-zinc-500">{dailyChart.unitLabel} · {selectedRangeLabel}</p>
+            </div>
+            <p class="shrink-0 text-sm font-medium tabular-nums text-zinc-100">{formatDuration(insights.summary.totalAudioSeconds)} total</p>
           </div>
-          {@render MiniBars(insights.trends, 'audioSeconds')}
+          {@render DailyDictationChart(dailyChart, selectedRangeLabel)}
         </section>
         <section class="flex min-h-[106px] items-center justify-between rounded-[9px] border border-white/10 bg-white/[0.025] px-3 py-3" aria-labelledby="dictations-heading">
           <div>
@@ -166,7 +171,7 @@
           </div>
           <div class="grid w-40 grid-cols-8 gap-1.5" role="img" aria-label="{formatInteger(insights.summary.totalDictations)} total dictations">
             {#each Array(48) as _, index}
-              <span class="h-2 w-2 rounded-full {index < Math.min(insights.summary.totalDictations, 48) ? 'bg-zinc-300/75' : 'bg-zinc-700/45'}"></span>
+              <span class="h-2 w-2 rounded-full {index < Math.min(Math.floor(finiteNonNegative(insights.summary.totalDictations)), 48) ? 'bg-zinc-300/75' : 'bg-zinc-700/45'}"></span>
             {/each}
           </div>
         </section>
@@ -182,18 +187,20 @@
         </section>
 
         <section class="overflow-hidden rounded-[9px] border border-white/10 bg-white/[0.025]" aria-labelledby="day-table-heading">
-          <h2 id="day-table-heading" class="border-b border-white/[0.08] px-3 py-2.5 text-xs text-zinc-300">Dictation time by day</h2>
+          <h2 id="day-table-heading" class="border-b border-white/[0.08] px-3 py-2.5 text-xs text-zinc-300">Daily totals</h2>
           <table class="w-full text-left text-[11px]">
             <thead class="text-zinc-500">
               <tr><th class="px-3 py-2 font-normal">Day</th><th class="px-3 py-2 font-normal">Time</th><th class="px-3 py-2 font-normal"><span class="sr-only">Relative duration</span></th></tr>
             </thead>
             <tbody class="divide-y divide-white/[0.07] text-zinc-300">
-              {#each insights.trends.slice(-7) as point}
+              {#each dailyChart.bars.slice(-7) as bar}
                 <tr>
-                  <th scope="row" class="px-3 py-2 font-normal">{point.label}</th>
-                  <td class="px-3 py-2 tabular-nums">{formatDuration(point.audioSeconds)}</td>
+                  <th scope="row" class="px-3 py-2 font-normal">{bar.label}</th>
+                  <td class="px-3 py-2 tabular-nums">{bar.valueLabel}</td>
                   <td class="w-1/2 px-3 py-2">
-                    <span class="block h-1 rounded-full bg-zinc-300/70" style:width={`${Math.max(4, (point.audioSeconds / Math.max(...insights.trends.map((trend) => trend.audioSeconds), 1)) * 100)}%`}></span>
+                    <span class="block h-1 rounded-full bg-zinc-800" aria-hidden="true">
+                      <span class="block h-1 rounded-full bg-zinc-300/70" style:width={`${bar.relativeWidth}%`}></span>
+                    </span>
                   </td>
                 </tr>
               {/each}
@@ -249,34 +256,53 @@
   </div>
 </PrimaryPage>
 
-{#snippet MiniBars(points: InsightsTrendPoint[], metric: 'dictations' | 'words' | 'audioSeconds' | 'processingMs')}
-  {@const peak = Math.max(...points.map((point) => point[metric]), 1)}
-  <svg
-    viewBox="0 0 160 52"
-    class="h-[52px] w-40 shrink-0"
-    role="img"
-    aria-label="Recent {metric === 'audioSeconds' ? 'dictation time' : metric} trend"
-  >
-    <line x1="0" y1="49" x2="160" y2="49" stroke="rgb(113 113 122 / 0.35)" stroke-width="1" />
-    {#each points.slice(-7) as point, index}
-      {@const height = Math.max(3, (point[metric] / peak) * 42)}
-      <rect
-        x={index * 22 + 3}
-        y={49 - height}
-        width="12"
-        height={height}
-        rx="2"
-        class="fill-zinc-300/80"
-      >
-        <title>{point.label}: {point[metric]}</title>
-      </rect>
-    {/each}
-  </svg>
+{#snippet DailyDictationChart(chart: DictationTimeChart, periodLabel: string)}
+  <div class="mt-3" data-insights-chart>
+    <svg
+      viewBox={`0 0 ${chart.width} ${chart.height}`}
+      class="h-28 w-full max-w-full"
+      role="img"
+      aria-label={`${chart.metricLabel}; ${chart.unitLabel}; period ${periodLabel}; ${chart.xAxisDescription}; zero baseline; maximum scale ${chart.scaleLabel}`}
+    >
+      {#each chart.ticks as tick}
+        <line x1={chart.plotLeft} x2={chart.plotRight} y1={tick.y} y2={tick.y} stroke="rgb(113 113 122 / 0.22)" stroke-width="1" />
+        <text x="1" y={tick.y + 3} fill="rgb(161 161 170)" font-size="8">{tick.label}</text>
+      {/each}
+      <line x1={chart.plotLeft} x2={chart.plotRight} y1={chart.zeroY} y2={chart.zeroY} stroke="rgb(212 212 216 / 0.65)" stroke-width="1" />
+      {#each chart.bars as bar}
+        <rect x={bar.x} y={bar.y} width={bar.width} height={bar.height} rx="1.5" class="fill-zinc-300/80">
+          <title>{bar.label}: {bar.valueLabel}</title>
+        </rect>
+      {/each}
+    </svg>
+    <div class="flex min-h-4 justify-between gap-3 pl-8 text-[10px] text-zinc-600" data-insights-chart-x-axis>
+      {#if chart.xAxisEndLabel}
+        <span>{chart.xAxisStartLabel}</span>
+        <span>{chart.xAxisEndLabel}</span>
+      {:else if chart.bars.length === 1}
+        <span>Only recorded day: {chart.xAxisStartLabel}</span>
+      {:else}
+        <span>{chart.xAxisStartLabel}</span>
+      {/if}
+    </div>
+    <p class="mt-2 text-[10px] text-zinc-600">
+      {#if chart.gapDays > 0}
+        {formatInteger(chart.gapDays)} empty calendar {chart.gapDays === 1 ? 'day is' : 'days are'} shown as gaps; fixed-range empty days are zero.
+      {:else}
+        Empty calendar days are shown at zero.
+      {/if}
+    </p>
+  </div>
 {/snippet}
 
 {#snippet MiniLine(points: InsightsTrendPoint[])}
   {@const recent = points.slice(-7)}
-  {@const averages = recent.map((point) => point.dictations > 0 ? point.audioSeconds / point.dictations : 0)}
+  {@const averages = recent.map((point) => {
+    const dictations = Math.floor(finiteNonNegative(point.dictations));
+    const audioSeconds = finiteNonNegative(point.audioSeconds);
+    const average = dictations > 0 ? audioSeconds / dictations : 0;
+    return Number.isFinite(average) && average > 0 ? average : 0;
+  })}
   {@const peak = Math.max(...averages, 1)}
   {@const coordinates = averages.map((average, index) => `${index * 25 + 5},${48 - (average / peak) * 38}`).join(' ')}
   <svg viewBox="0 0 160 52" class="h-[52px] w-40 shrink-0" role="img" aria-label="Average dictation length trend">

--- a/app/src/shared/insights.ts
+++ b/app/src/shared/insights.ts
@@ -152,13 +152,15 @@ export function countWords(text: string): number {
 }
 
 export function calcWordsPerMinute(wordCount: number, audioDurationSec: number): number {
-  if (audioDurationSec <= 0) return 0;
-  return wordCount / (audioDurationSec / 60);
+  if (!Number.isFinite(wordCount) || wordCount <= 0 || !Number.isFinite(audioDurationSec) || audioDurationSec <= 0) return 0;
+  const result = wordCount / (audioDurationSec / 60);
+  return Number.isFinite(result) && result > 0 ? result : 0;
 }
 
 export function calcProcessingRatio(audioDurationSec: number, processingTimeMs: number): number {
-  if (processingTimeMs <= 0) return 0;
-  return audioDurationSec / (processingTimeMs / 1000);
+  if (!Number.isFinite(audioDurationSec) || audioDurationSec <= 0 || !Number.isFinite(processingTimeMs) || processingTimeMs <= 0) return 0;
+  const result = audioDurationSec / (processingTimeMs / 1000);
+  return Number.isFinite(result) && result > 0 ? result : 0;
 }
 
 export function tokenizeInsightWords(text: string): string[] {
@@ -185,7 +187,8 @@ export function buildPhraseStats(entries: Pick<InsightSourceEntry, 'text'>[], li
 
 export function sortWordStats(counts: Map<string, number>, limit: number): InsightsWordStat[] {
   return [...counts.entries()]
-    .map(([text, count]) => ({ text, count }))
+    .map(([text, count]) => ({ text, count: finiteNonNegative(count) }))
+    .filter(({ count }) => count > 0)
     .sort((a, b) => b.count - a.count || a.text.localeCompare(b.text))
     .slice(0, limit);
 }
@@ -243,6 +246,7 @@ export function buildTrendPoints(
   const rangeStart = getRangeStart(range, now);
 
   for (const entry of entries) {
+    if (!Number.isFinite(entry.timestamp)) continue;
     if (rangeStart !== null && entry.timestamp < rangeStart) continue;
     const key = getLocalDayKey(entry.timestamp);
     const bucket = buckets.get(key) ?? [];
@@ -263,12 +267,12 @@ export function buildTrendPoints(
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([date, bucket]) => {
       const dictations = bucket.length;
-      const words = bucket.reduce((sum, item) => sum + (item.wordCount ?? countWords(item.text)), 0);
-      const audioSeconds = bucket.reduce((sum, item) => sum + (item.audioDuration || 0), 0);
-      const processingMs = bucket.reduce((sum, item) => sum + (item.transcriptionTime || 0), 0);
-      const confidenceEntries = bucket.filter((item) => Number.isFinite(item.confidence));
+      const words = bucket.reduce((sum, item) => sum + finiteNonNegative(item.wordCount ?? countWords(item.text)), 0);
+      const audioSeconds = bucket.reduce((sum, item) => sum + finiteNonNegative(item.audioDuration), 0);
+      const processingMs = bucket.reduce((sum, item) => sum + finiteNonNegative(item.transcriptionTime), 0);
+      const confidenceEntries = bucket.filter((item) => Number.isFinite(item.confidence) && item.confidence >= 0);
       const avgConfidence = confidenceEntries.length
-        ? confidenceEntries.reduce((sum, item) => sum + item.confidence, 0) / confidenceEntries.length
+        ? Math.min(1, confidenceEntries.reduce((sum, item) => sum + finiteNonNegative(item.confidence), 0) / confidenceEntries.length)
         : 0;
 
       return {
@@ -283,4 +287,8 @@ export function buildTrendPoints(
         avgProcessingRatio: calcProcessingRatio(audioSeconds, processingMs),
       };
     });
+}
+
+function finiteNonNegative(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
 }

--- a/app/src/shared/insights.ts
+++ b/app/src/shared/insights.ts
@@ -267,12 +267,12 @@ export function buildTrendPoints(
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([date, bucket]) => {
       const dictations = bucket.length;
-      const words = bucket.reduce((sum, item) => sum + finiteNonNegative(item.wordCount ?? countWords(item.text)), 0);
-      const audioSeconds = bucket.reduce((sum, item) => sum + finiteNonNegative(item.audioDuration), 0);
-      const processingMs = bucket.reduce((sum, item) => sum + finiteNonNegative(item.transcriptionTime), 0);
+      const words = bucket.reduce((sum, item) => saturatingAdd(sum, finiteNonNegative(item.wordCount ?? countWords(item.text))), 0);
+      const audioSeconds = bucket.reduce((sum, item) => saturatingAdd(sum, finiteNonNegative(item.audioDuration)), 0);
+      const processingMs = bucket.reduce((sum, item) => saturatingAdd(sum, finiteNonNegative(item.transcriptionTime)), 0);
       const confidenceEntries = bucket.filter((item) => Number.isFinite(item.confidence) && item.confidence >= 0);
       const avgConfidence = confidenceEntries.length
-        ? Math.min(1, confidenceEntries.reduce((sum, item) => sum + finiteNonNegative(item.confidence), 0) / confidenceEntries.length)
+        ? Math.min(1, saturatingAddMany(confidenceEntries.map((item) => finiteNonNegative(item.confidence))) / confidenceEntries.length)
         : 0;
 
       return {
@@ -291,4 +291,13 @@ export function buildTrendPoints(
 
 function finiteNonNegative(value: number): number {
   return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function saturatingAdd(first: number, second: number): number {
+  const sum = first + second;
+  return Number.isFinite(sum) ? sum : Number.MAX_VALUE;
+}
+
+function saturatingAddMany(values: number[]): number {
+  return values.reduce((sum, value) => saturatingAdd(sum, value), 0);
 }

--- a/app/tests/history-insights.node-check.mjs
+++ b/app/tests/history-insights.node-check.mjs
@@ -91,6 +91,55 @@ try {
   ]);
   service.close();
 
+  const deterministicDbPath = join(workDir, 'deterministic-insights.db');
+  const deterministicService = new HistoryService(deterministicDbPath);
+  deterministicService.initialize();
+  deterministicService.save(transcription(
+    'det-older',
+    new Date(2026, 5, 29, 10).getTime(),
+    'Older deterministic record',
+    40,
+    4000,
+  ));
+  deterministicService.save(transcription(
+    'det-current',
+    now,
+    'Current deterministic record',
+    20,
+    2000,
+  ));
+  const deterministic = deterministicService.getInsights('7d', now);
+  assert.deepEqual(deterministic.trends.map(({ date }) => date), [
+    '2026-06-25',
+    '2026-06-26',
+    '2026-06-27',
+    '2026-06-28',
+    '2026-06-29',
+    '2026-06-30',
+    '2026-07-01',
+  ]);
+  assert.equal(deterministic.trends.find(({ date }) => date === '2026-06-29')?.audioSeconds, 40);
+  assert.equal(deterministic.trends.find(({ date }) => date === '2026-06-30')?.audioSeconds, 0);
+  assert.equal(deterministic.trends.find(({ date }) => date === '2026-07-01')?.audioSeconds, 20);
+  assert.equal(deterministic.summary.totalAudioSeconds, 60);
+
+  deterministicService.delete('det-older');
+  const afterDeterministicDelete = deterministicService.getInsights('7d', now);
+  assert.equal(afterDeterministicDelete.trends.find(({ date }) => date === '2026-06-29')?.audioSeconds, 0);
+  assert.equal(afterDeterministicDelete.summary.totalAudioSeconds, 20);
+
+  deterministicService.save(transcription(
+    'det-middle',
+    new Date(2026, 5, 30, 10).getTime(),
+    'Middle deterministic record',
+    10,
+    1000,
+  ));
+  const afterDeterministicAdd = deterministicService.getInsights('7d', now);
+  assert.equal(afterDeterministicAdd.trends.find(({ date }) => date === '2026-06-30')?.audioSeconds, 10);
+  assert.equal(afterDeterministicAdd.summary.totalAudioSeconds, 30);
+  deterministicService.close();
+
   const bulkDbPath = join(workDir, 'bulk-history.db');
   const bulkService = new HistoryService(bulkDbPath);
   bulkService.initialize();

--- a/app/tests/history-insights.node-check.mjs
+++ b/app/tests/history-insights.node-check.mjs
@@ -93,52 +93,55 @@ try {
 
   const deterministicDbPath = join(workDir, 'deterministic-insights.db');
   const deterministicService = new HistoryService(deterministicDbPath);
-  deterministicService.initialize();
-  deterministicService.save(transcription(
-    'det-older',
-    new Date(2026, 5, 29, 10).getTime(),
-    'Older deterministic record',
-    40,
-    4000,
-  ));
-  deterministicService.save(transcription(
-    'det-current',
-    now,
-    'Current deterministic record',
-    20,
-    2000,
-  ));
-  const deterministic = deterministicService.getInsights('7d', now);
-  assert.deepEqual(deterministic.trends.map(({ date }) => date), [
-    '2026-06-25',
-    '2026-06-26',
-    '2026-06-27',
-    '2026-06-28',
-    '2026-06-29',
-    '2026-06-30',
-    '2026-07-01',
-  ]);
-  assert.equal(deterministic.trends.find(({ date }) => date === '2026-06-29')?.audioSeconds, 40);
-  assert.equal(deterministic.trends.find(({ date }) => date === '2026-06-30')?.audioSeconds, 0);
-  assert.equal(deterministic.trends.find(({ date }) => date === '2026-07-01')?.audioSeconds, 20);
-  assert.equal(deterministic.summary.totalAudioSeconds, 60);
+  try {
+    deterministicService.initialize();
+    deterministicService.save(transcription(
+      'det-older',
+      new Date(2026, 5, 29, 10).getTime(),
+      'Older deterministic record',
+      40,
+      4000,
+    ));
+    deterministicService.save(transcription(
+      'det-current',
+      now,
+      'Current deterministic record',
+      20,
+      2000,
+    ));
+    const deterministic = deterministicService.getInsights('7d', now);
+    assert.deepEqual(deterministic.trends.map(({ date }) => date), [
+      '2026-06-25',
+      '2026-06-26',
+      '2026-06-27',
+      '2026-06-28',
+      '2026-06-29',
+      '2026-06-30',
+      '2026-07-01',
+    ]);
+    assert.equal(deterministic.trends.find(({ date }) => date === '2026-06-29')?.audioSeconds, 40);
+    assert.equal(deterministic.trends.find(({ date }) => date === '2026-06-30')?.audioSeconds, 0);
+    assert.equal(deterministic.trends.find(({ date }) => date === '2026-07-01')?.audioSeconds, 20);
+    assert.equal(deterministic.summary.totalAudioSeconds, 60);
 
-  deterministicService.delete('det-older');
-  const afterDeterministicDelete = deterministicService.getInsights('7d', now);
-  assert.equal(afterDeterministicDelete.trends.find(({ date }) => date === '2026-06-29')?.audioSeconds, 0);
-  assert.equal(afterDeterministicDelete.summary.totalAudioSeconds, 20);
+    deterministicService.delete('det-older');
+    const afterDeterministicDelete = deterministicService.getInsights('7d', now);
+    assert.equal(afterDeterministicDelete.trends.find(({ date }) => date === '2026-06-29')?.audioSeconds, 0);
+    assert.equal(afterDeterministicDelete.summary.totalAudioSeconds, 20);
 
-  deterministicService.save(transcription(
-    'det-middle',
-    new Date(2026, 5, 30, 10).getTime(),
-    'Middle deterministic record',
-    10,
-    1000,
-  ));
-  const afterDeterministicAdd = deterministicService.getInsights('7d', now);
-  assert.equal(afterDeterministicAdd.trends.find(({ date }) => date === '2026-06-30')?.audioSeconds, 10);
-  assert.equal(afterDeterministicAdd.summary.totalAudioSeconds, 30);
-  deterministicService.close();
+    deterministicService.save(transcription(
+      'det-middle',
+      new Date(2026, 5, 30, 10).getTime(),
+      'Middle deterministic record',
+      10,
+      1000,
+    ));
+    const afterDeterministicAdd = deterministicService.getInsights('7d', now);
+    assert.equal(afterDeterministicAdd.trends.find(({ date }) => date === '2026-06-30')?.audioSeconds, 10);
+    assert.equal(afterDeterministicAdd.summary.totalAudioSeconds, 30);
+  } finally {
+    deterministicService.close();
+  }
 
   const bulkDbPath = join(workDir, 'bulk-history.db');
   const bulkService = new HistoryService(bulkDbPath);

--- a/app/tests/insights-chart.test.ts
+++ b/app/tests/insights-chart.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildDictationTimeChart,
+  formatChartDuration,
+  formatInsightsDuration,
+} from '../src/renderer/app/insights-chart.js';
+import type { InsightsTrendPoint } from '../src/shared/types.js';
+
+function point(date: string, audioSeconds: number, dictations = 1): InsightsTrendPoint {
+  return {
+    date,
+    label: date,
+    dictations,
+    words: 0,
+    audioSeconds,
+    processingMs: 0,
+    avgWpm: 0,
+    avgConfidence: 0,
+    avgProcessingRatio: 0,
+  };
+}
+
+function expectFiniteGeometry(chart: ReturnType<typeof buildDictationTimeChart>): void {
+  expect(Number.isFinite(chart.scaleMaxSeconds)).toBe(true);
+  expect(Number.isFinite(chart.totalSeconds)).toBe(true);
+  expect(Number.isFinite(chart.zeroY)).toBe(true);
+  for (const tick of chart.ticks) {
+    expect(Number.isFinite(tick.valueSeconds)).toBe(true);
+    expect(Number.isFinite(tick.y)).toBe(true);
+    expect(tick.y).toBeGreaterThanOrEqual(0);
+    expect(tick.y).toBeLessThanOrEqual(chart.height);
+  }
+  for (const bar of chart.bars) {
+    for (const value of [bar.x, bar.y, bar.width, bar.height, bar.relativeWidth, bar.valueSeconds]) {
+      expect(Number.isFinite(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(0);
+    }
+    expect(bar.x).toBeLessThanOrEqual(chart.width);
+    expect(bar.y).toBeLessThanOrEqual(chart.height);
+    expect(bar.x + bar.width).toBeLessThanOrEqual(chart.width);
+    expect(bar.y + bar.height).toBeLessThanOrEqual(chart.height);
+  }
+}
+
+describe('deterministic Insights dictation-time chart', () => {
+  test('uses an honest zero baseline for empty and all-zero data', () => {
+    const empty = buildDictationTimeChart([]);
+    expect(empty.bars).toEqual([]);
+    expect(empty.scaleMaxSeconds).toBe(1);
+    expect(empty.xAxisStartLabel).toBe('No recorded days');
+    expect(empty.xAxisEndLabel).toBeNull();
+    expect(empty.ticks.map((tick) => tick.label)).toEqual(['0s', '0.5s', '1s']);
+
+    const zero = buildDictationTimeChart([
+      point('2026-07-01', 0),
+      point('2026-07-02', 0),
+    ]);
+    expect(zero.bars.map((bar) => bar.height)).toEqual([0, 0]);
+    expect(zero.bars.map((bar) => bar.relativeWidth)).toEqual([0, 0]);
+    expectFiniteGeometry(zero);
+  });
+
+  test('sorts buckets chronologically and leaves sparse days as visible gaps', () => {
+    const chart = buildDictationTimeChart([
+      point('2026-07-03', 120),
+      point('2026-07-01', 0),
+    ]);
+
+    expect(chart.bars.map((bar) => bar.date)).toEqual(['2026-07-01', '2026-07-03']);
+    expect(chart.bars.map((bar) => bar.gapBeforeDays)).toEqual([0, 1]);
+    expect(chart.gapDays).toBe(1);
+    expect(chart.bars[0]?.x).toBeLessThan(chart.bars[1]?.x ?? 0);
+    expect(chart.bars[0]?.height).toBe(0);
+    expect(chart.bars[1]?.height).toBeGreaterThan(0);
+    expectFiniteGeometry(chart);
+  });
+
+  test('keeps one and identical values deterministic', () => {
+    const one = buildDictationTimeChart([point('2026-07-01', 60)]);
+    expect(one.xAxisStartLabel).toBe('Jul 1');
+    expect(one.xAxisEndLabel).toBeNull();
+    expect(one.xAxisDescription).toBe('one local day: Jul 1');
+
+    const chart = buildDictationTimeChart([
+      point('2026-07-02', 60),
+      point('2026-07-01', 60),
+      point('2026-07-01', 0),
+    ]);
+
+    expect(chart.bars.map((bar) => bar.valueSeconds)).toEqual([60, 60]);
+    expect(chart.bars[0]?.height).toBe(chart.bars[1]?.height);
+    expect(chart.totalSeconds).toBe(120);
+    expect(formatChartDuration(60)).toBe('1m');
+  });
+
+  test('discards calendar-invalid dates without changing valid geometry', () => {
+    const valid = [point('2026-07-01', 30), point('2026-07-03', 90)];
+    const baseline = buildDictationTimeChart(valid);
+    const chart = buildDictationTimeChart([
+      ...valid,
+      point('2026-02-31', 10),
+      point('2026-13-01', 20),
+      point('2026-00-15', 30),
+    ]);
+
+    expect(chart.bars).toEqual(baseline.bars);
+    expect(chart.gapDays).toBe(baseline.gapDays);
+    expect(chart.scaleMaxSeconds).toBe(baseline.scaleMaxSeconds);
+  });
+
+  test('sanitizes malformed and very large values with bounded labels and geometry', () => {
+    const chart = buildDictationTimeChart([
+      point('2026-07-01', Number.NaN),
+      point('2026-07-02', Number.POSITIVE_INFINITY),
+      point('2026-07-03', -10),
+      point('2026-07-04', Number.MAX_VALUE),
+    ]);
+
+    expect(chart.bars.slice(0, 3).map((bar) => bar.valueSeconds)).toEqual([0, 0, 0]);
+    expect(chart.bars[3]?.valueSeconds).toBe(Number.MAX_VALUE);
+    expectFiniteGeometry(chart);
+    expect(formatChartDuration(Number.NaN)).toBe('0s');
+    expect(formatChartDuration(Number.POSITIVE_INFINITY)).toBe('0s');
+    for (const label of [formatChartDuration(Number.MAX_VALUE), formatInsightsDuration(Number.MAX_VALUE)]) {
+      expect(label).toBe('1.80e+308s');
+      expect(label.length).toBeLessThanOrEqual(12);
+    }
+  });
+
+  test('contains bars and ticks inside a collapsed custom viewBox', () => {
+    const chart = buildDictationTimeChart([
+      point('2026-07-01', 1),
+      point('2026-07-02', 2),
+    ], 1, 1);
+
+    expect(chart.width).toBe(1);
+    expect(chart.height).toBe(1);
+    expectFiniteGeometry(chart);
+  });
+});

--- a/app/tests/insights.test.ts
+++ b/app/tests/insights.test.ts
@@ -51,8 +51,12 @@ describe('insights helpers', () => {
   test('calculates weighted speaking and processing performance metrics', () => {
     expect(calcWordsPerMinute(120, 60)).toBe(120);
     expect(calcWordsPerMinute(10, 0)).toBe(0);
+    expect(calcWordsPerMinute(-10, 60)).toBe(0);
+    expect(calcWordsPerMinute(Number.POSITIVE_INFINITY, 60)).toBe(0);
     expect(calcProcessingRatio(30, 15000)).toBe(2);
     expect(calcProcessingRatio(30, 0)).toBe(0);
+    expect(calcProcessingRatio(-30, 15000)).toBe(0);
+    expect(calcProcessingRatio(30, Number.NaN)).toBe(0);
   });
 
   test('tokenizes common words with stop-word filtering', () => {
@@ -124,6 +128,35 @@ describe('insights helpers', () => {
     } finally {
       if (originalTimezone === undefined) delete process.env.TZ;
       else process.env.TZ = originalTimezone;
+    }
+  });
+
+  test('keeps sparse fixed-range buckets explicit and finite', () => {
+    const now = new Date(2026, 6, 1, 12).getTime();
+    const trends = buildTrendPoints([
+      entry('one', now, 'one record', 30, 1000),
+      entry('malformed', new Date(2026, 5, 29, 12).getTime(), 'bad record', Number.NaN, Number.POSITIVE_INFINITY),
+    ], '7d', now);
+
+    expect(trends).toHaveLength(7);
+    expect(trends.map((trend) => trend.date)).toEqual([
+      '2026-06-25',
+      '2026-06-26',
+      '2026-06-27',
+      '2026-06-28',
+      '2026-06-29',
+      '2026-06-30',
+      '2026-07-01',
+    ]);
+    expect(trends.find((trend) => trend.date === '2026-06-28')?.audioSeconds).toBe(0);
+    expect(trends.find((trend) => trend.date === '2026-06-29')?.audioSeconds).toBe(0);
+    expect(trends.find((trend) => trend.date === '2026-07-01')?.audioSeconds).toBe(30);
+    for (const trend of trends) {
+      expect(Number.isFinite(trend.audioSeconds)).toBe(true);
+      expect(Number.isFinite(trend.processingMs)).toBe(true);
+      expect(Number.isFinite(trend.avgWpm)).toBe(true);
+      expect(trend.audioSeconds).toBeGreaterThanOrEqual(0);
+      expect(trend.processingMs).toBeGreaterThanOrEqual(0);
     }
   });
 

--- a/app/tests/insights.test.ts
+++ b/app/tests/insights.test.ts
@@ -160,4 +160,18 @@ describe('insights helpers', () => {
     }
   });
 
+  test('saturates extreme bucket sums without producing Infinity', () => {
+    const now = new Date(2026, 6, 1, 12).getTime();
+    const first = { ...entry('max-one', now, 'one', Number.MAX_VALUE, Number.MAX_VALUE), wordCount: Number.MAX_VALUE };
+    const second = { ...entry('max-two', now, 'two', Number.MAX_VALUE, Number.MAX_VALUE), wordCount: Number.MAX_VALUE };
+    const [trend] = buildTrendPoints([first, second], 'today', now);
+
+    expect(trend?.words).toBe(Number.MAX_VALUE);
+    expect(trend?.audioSeconds).toBe(Number.MAX_VALUE);
+    expect(trend?.processingMs).toBe(Number.MAX_VALUE);
+    expect(Number.isFinite(trend?.words)).toBe(true);
+    expect(Number.isFinite(trend?.audioSeconds)).toBe(true);
+    expect(Number.isFinite(trend?.processingMs)).toBe(true);
+  });
+
 });

--- a/app/tests/renderer-visual-guards.test.ts
+++ b/app/tests/renderer-visual-guards.test.ts
@@ -52,15 +52,19 @@ describe('renderer visual regression guards', () => {
   });
 
   test('keeps the approved Insights visual hierarchy backed by real trend data', () => {
-    expect(insightsView).toContain('Dictation time');
+    expect(insightsView).toContain('Daily dictation time');
     expect(insightsView).toContain('Dictations');
     expect(insightsView).toContain('Average dictation length');
-    expect(insightsView).toContain('Dictation time by day');
-    expect(insightsView).toContain("MiniBars(insights.trends, 'audioSeconds')");
+    expect(insightsView).toContain('Daily totals');
+    expect(insightsView).toContain('dailyChart.unitLabel');
+    expect(insightsView).toContain('@render DailyDictationChart(dailyChart, selectedRangeLabel)');
+    expect(insightsView).toContain('data-insights-chart-x-axis');
+    expect(insightsView).toContain('chart.xAxisStartLabel');
+    expect(insightsView).toContain('chart.xAxisEndLabel');
+    expect(insightsView).toContain('period ${periodLabel}; ${chart.xAxisDescription}; zero baseline; maximum scale');
     expect(insightsView).toContain('MiniLine(insights.trends)');
-    expect(insightsView).toContain('point.audioSeconds / point.dictations');
     expect(insightsView).toContain('formatDuration(averages[index])');
-    expect(insightsView).toContain('insights.trends.slice(-7)');
+    expect(insightsView).toContain('dailyChart.bars.slice(-7)');
     expect(insightsView).toContain('<EveDropdown');
     expect(eveDropdown).toContain('role="combobox"');
     expect(eveDropdown).toContain('aria-haspopup="listbox"');


### PR DESCRIPTION
## Summary
- Add deterministic daily dictation-time aggregation from persisted Insights rollups.
- Render chronological, honest zero-baseline charts with fixed-range zero buckets and visible All-time gaps.
- Bound extreme duration labels, reject invalid calendar keys, and keep chart geometry contained and accessible.
- Add deterministic service, aggregation, renderer-contract, geometry, and add/delete recomputation coverage.

## Validation
- Focused Insights/chart suite: 21 passed, 375 expectations.
- Real SQLite History/Insights aggregate check: passed.
- Full non-rendered app matrix: 203 passed, 0 failed, 1,720 expectations across 38 files.
- Main/preload/renderer production builds: passed.
- Frozen dependency setup: exit 0; native rebuild completed.
- `package.json` and `bun.lock` unchanged; generated `dist` and `node_modules` remain ignored.
- Local settings rendered fixtures were excluded from this non-rendered run because the known interactive display-surface capture limitation is outside this diff; hosted CI should exercise them.
- Repository strict typecheck still reports the pre-existing `src/renderer/app/components/eve-dropdown.ts:59` possibly-undefined diagnostic; no changed file is implicated.

Refs #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an accessible daily dictation-time chart with bars, scale ticks, labels, totals, and gaps for days without activity.
  - Added clearer duration formatting for chart and Insights views.
  - Insights now displays normalized daily totals and trend data.

- **Bug Fixes**
  - Improved handling of invalid, negative, missing, or extreme metric values.
  - Prevented malformed dates and numeric inputs from producing inaccurate statistics or visualizations.

- **Tests**
  - Added coverage for chart rendering, sparse dates, formatting, trends, totals, and invalid data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->