### PR TITLE
fix: harden runtime recovery edge cases

### DIFF
--- a/app/src/renderer/app/server-settings-recovery.ts
+++ b/app/src/renderer/app/server-settings-recovery.ts
@@ -2,6 +2,21 @@ import type { ServerStatePayload } from '../../shared/types';
 
 type SettingsRecoveryState = Pick<ServerStatePayload, 'status' | 'port' | 'wsUrl' | 'version' | 'engineStatus' | 'modelDownload'>;
 
+export interface EnginePreparationLifecycle {
+  pending: Record<string, unknown>;
+  requested: boolean;
+  active: boolean;
+  observed: boolean;
+  applying: boolean;
+}
+
+export interface ManagedServerPreparationRecovery extends EnginePreparationLifecycle {
+  message: string;
+}
+
+const MANAGED_SERVER_PREPARATION_INTERRUPTED =
+  'The managed speech server stopped while model settings were being prepared. Restart it, then select and apply the model again.';
+
 /**
  * Identify a meaningful server transition without using uptime or byte-level
  * progress, so a failed settings request is retried once per readiness state.
@@ -39,4 +54,32 @@ export function shouldClearServerSettings(
   externalMode: boolean,
 ): boolean {
   return !externalMode && state !== null && state !== undefined && state.status !== 'running';
+}
+
+/**
+ * Clear every renderer-only preparation flag when the managed server leaves
+ * running state. Keeping a staged model after that transition would leave the
+ * Settings surface stuck on Preparing with no server-side transaction alive.
+ */
+export function recoverInterruptedManagedPreparation(
+  state: SettingsRecoveryState | null | undefined,
+  externalMode: boolean,
+  lifecycle: EnginePreparationLifecycle,
+): ManagedServerPreparationRecovery | null {
+  if (!shouldClearServerSettings(state, externalMode)) return null;
+
+  const interrupted = lifecycle.requested
+    || lifecycle.active
+    || lifecycle.observed
+    || lifecycle.applying
+    || Object.keys(lifecycle.pending).length > 0;
+
+  return {
+    pending: {},
+    requested: false,
+    active: false,
+    observed: false,
+    applying: false,
+    message: interrupted ? MANAGED_SERVER_PREPARATION_INTERRUPTED : '',
+  };
 }

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -12,7 +12,12 @@
   import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
   import { SPEECH_MODEL_PRESETS, hasPendingCompatibilityChanges, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../speech-model-presets';
   import { getServerManagementMode, serverStatusState } from '../server-status';
-  import { serverSettingsStateKey, shouldClearServerSettings, shouldRetryServerSettings } from '../server-settings-recovery';
+  import {
+    recoverInterruptedManagedPreparation,
+    serverSettingsStateKey,
+    shouldClearServerSettings,
+    shouldRetryServerSettings,
+  } from '../server-settings-recovery';
   import { disabledOptionReasons, optionsForDraftWhisperDevice } from '../server-setting-options';
   import { enginePreparationPhase, shouldDisableEngineRevert, shouldRefreshCommittedSettings } from '../engine-settings-transaction';
   import { toast } from '$lib/toast.svelte';
@@ -355,11 +360,26 @@
   $effect(() => {
     const state = sharedServerState;
     if (shouldClearServerSettings(state, externalMode)) {
+      const recovery = recoverInterruptedManagedPreparation(state, externalMode, {
+        pending: pendingEngine,
+        requested: enginePreparationRequested,
+        active: enginePreparationActive,
+        observed: enginePreparationObserved,
+        applying: engineApplying,
+      });
       serverSettings = null;
       engineStatus = null;
       availableEngines = [];
       serverConnected = false;
       lastServerSettingsAttemptKey = null;
+      if (recovery) {
+        pendingEngine = recovery.pending;
+        enginePreparationRequested = recovery.requested;
+        enginePreparationActive = recovery.active;
+        enginePreparationObserved = recovery.observed;
+        engineApplying = recovery.applying;
+        if (recovery.message) engineApplyError = recovery.message;
+      }
       return;
     }
 
@@ -839,6 +859,9 @@
       {#if !serverConnected || !serverSettings}
         <div data-speech-model-panel class="min-w-0 w-full rounded-xl border border-white/10 bg-white/[0.025] p-4 sm:p-5">
           <p class="text-xs leading-5 text-zinc-500">Speech model choices are available when the server reports its settings.</p>
+          {#if engineApplyError}
+            <p data-engine-preparation-interrupted role="alert" class="mt-2 text-xs leading-5 text-red-300">{engineApplyError}</p>
+          {/if}
         </div>
       {:else}
         <SpeechModelChooser

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -358,6 +358,10 @@ export interface EngineStatus {
     status: 'loading' | 'ready' | 'error';
     message?: string;
   };
+  recovery?: {
+    action: 'restart_server';
+    message: string;
+  };
 }
 
 export interface ServerSettingsResponse {

--- a/app/tests/engine-settings-transaction.test.ts
+++ b/app/tests/engine-settings-transaction.test.ts
@@ -49,5 +49,7 @@ describe('Engine settings transaction UI', () => {
     expect(settingsView).toContain('function revertEngineSettings()');
     expect(settingsView).toContain('pendingEngine = {};');
     expect(settingsView).toContain('disabled={engineApplying || engineRevertDisabled}');
+    expect(settingsView).toContain('recoverInterruptedManagedPreparation');
+    expect(settingsView).toContain('data-engine-preparation-interrupted');
   });
 });

--- a/app/tests/server-settings-recovery.test.ts
+++ b/app/tests/server-settings-recovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  recoverInterruptedManagedPreparation,
   serverSettingsStateKey,
   shouldClearServerSettings,
   shouldRetryServerSettings,
@@ -39,5 +40,26 @@ describe('Settings server-state recovery', () => {
   test('retries when the live endpoint changes even if its port is reused', () => {
     const samePortDifferentEndpoint = { ...ready, wsUrl: 'ws://127.0.0.1:51490/transcribe' };
     expect(serverSettingsStateKey(samePortDifferentEndpoint)).not.toBe(serverSettingsStateKey(ready));
+  });
+
+  test('clears an interrupted managed preparation and preserves external-server state', () => {
+    const lifecycle = {
+      pending: { engine: 'nemotron', nemotron_model: 'nvidia/canary-qwen-2.5b' },
+      requested: true,
+      active: true,
+      observed: true,
+      applying: true,
+    };
+
+    expect(recoverInterruptedManagedPreparation(starting, false, lifecycle)).toEqual({
+      pending: {},
+      requested: false,
+      active: false,
+      observed: false,
+      applying: false,
+      message: 'The managed speech server stopped while model settings were being prepared. Restart it, then select and apply the model again.',
+    });
+    expect(recoverInterruptedManagedPreparation(starting, true, lifecycle)).toBeNull();
+    expect(recoverInterruptedManagedPreparation(ready, false, lifecycle)).toBeNull();
   });
 });

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -120,6 +120,8 @@ def create_app() -> FastAPI:
             payload["pending"] = status.pending
         if status.message:
             payload["message"] = status.message
+        if getattr(status, "recovery", None):
+            payload["recovery"] = status.recovery
         return payload
 
     @app.get("/health")

--- a/server/src/transcription/errors.py
+++ b/server/src/transcription/errors.py
@@ -39,6 +39,16 @@ class NemotronCudaPreflightError(RuntimeError):
     """The real Nemotron CUDA/cuDNN operation could not initialize safely."""
 
 
+ENGINE_RECOVERY_REQUIRED_MESSAGE = (
+    "Eve could not restore the previous speech engine. "
+    "Restart the managed server, then retry or revert the selected model."
+)
+
+
+class EngineRecoveryRequiredError(RuntimeError):
+    """A failed unload-first swap left no usable engine until the server restarts."""
+
+
 _AUTH_ERROR_MARKERS = (
     "oauth token signature",
     "invalid token",
@@ -91,6 +101,8 @@ def _exception_text(exc: BaseException) -> str:
 def safe_engine_preparation_message(exc: BaseException) -> str:
     """Return a stable user-facing engine error while logs retain the raw exception."""
     text = _exception_text(exc)
+    if isinstance(exc, EngineRecoveryRequiredError):
+        return ENGINE_RECOVERY_REQUIRED_MESSAGE
     if isinstance(exc, NemotronCudaPreflightError):
         return (
             "Nemotron could not initialize the packaged CUDA runtime. "

--- a/server/src/transcription/factory.py
+++ b/server/src/transcription/factory.py
@@ -12,7 +12,11 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from transcription.base import EngineInfo, EngineSession, TranscriptionEngine
-from transcription.errors import safe_engine_preparation_message
+from transcription.errors import (
+    ENGINE_RECOVERY_REQUIRED_MESSAGE,
+    EngineRecoveryRequiredError,
+    safe_engine_preparation_message,
+)
 from transcription.vram import (
     detect_gpu_capabilities,
     estimate_max_duration_s,
@@ -136,6 +140,7 @@ class EngineStatus:
     info: EngineInfo | None = None
     pending: dict | None = None
     message: str | None = None
+    recovery: dict | None = None
 
 
 class EngineManager:
@@ -149,6 +154,7 @@ class EngineManager:
         self._pending_engine_id: str | None = None
         self._pending_message: str | None = None
         self._swap_error: str | None = None
+        self._recovery_required = False
         self._gpu_name: str | None = None
         self._gpu_vram_gb: float | None = None
         self._estimated_max_duration_s: int | None = None
@@ -271,6 +277,8 @@ class EngineManager:
     @property
     def engine(self) -> TranscriptionEngine:
         if self._engine is None:
+            if self._recovery_required:
+                raise RuntimeError(ENGINE_RECOVERY_REQUIRED_MESSAGE)
             raise RuntimeError("Engine not loaded. Call load_initial_engine() first.")
         return self._engine
 
@@ -307,6 +315,11 @@ class EngineManager:
             }
         if self._swap_error:
             status.message = self._swap_error
+        if self._recovery_required:
+            status.recovery = {
+                "action": "restart_server",
+                "message": ENGINE_RECOVERY_REQUIRED_MESSAGE,
+            }
         return status
 
     def create_session(self, session_id: str) -> EngineSession:
@@ -390,9 +403,9 @@ class EngineManager:
                 await loop.run_in_executor(None, old_engine.shutdown)
                 _force_free_vram()
 
-            async def restore_previous_engine() -> None:
+            async def restore_previous_engine() -> Exception | None:
                 if not should_unload_old or self._shutting_down:
-                    return
+                    return None
                 logger.warning(
                     "Engine activation failed; attempting to restore previous engine"
                 )
@@ -410,13 +423,20 @@ class EngineManager:
                         await loop.run_in_executor(None, restored.shutdown)
                     else:
                         logger.info("Previous engine restored successfully")
+                    return None
                 except Exception as restore_error:
                     logger.error("Failed to restore previous engine: %s", restore_error)
+                    return restore_error
 
             try:
                 new_engine = await loop.run_in_executor(None, lambda: _create_engine(new_settings))
             except Exception as create_error:
-                await restore_previous_engine()
+                restore_error = await restore_previous_engine()
+                if restore_error is not None:
+                    self._recovery_required = True
+                    raise EngineRecoveryRequiredError(
+                        "Candidate engine creation and previous-engine recovery both failed"
+                    ) from create_error
                 raise create_error
 
             try:
@@ -436,12 +456,17 @@ class EngineManager:
                             old_engine is not None
                             and old_engine in self._active_sessions.values()
                         )
-            except Exception:
+            except Exception as activation_error:
                 try:
                     await loop.run_in_executor(None, new_engine.shutdown)
                 except Exception as shutdown_error:
                     logger.error("Failed to discard unactivated engine: %s", shutdown_error)
-                await restore_previous_engine()
+                restore_error = await restore_previous_engine()
+                if restore_error is not None:
+                    self._recovery_required = True
+                    raise EngineRecoveryRequiredError(
+                        "Candidate engine activation and previous-engine recovery both failed"
+                    ) from activation_error
                 raise
 
             if discard_new_engine:
@@ -462,6 +487,7 @@ class EngineManager:
             self._pending_engine_id = None
             self._pending_message = None
             self._swap_error = None
+            self._recovery_required = False
             logger.info("Engine swap complete: now using %s", new_settings.engine)
 
         except Exception as e:

--- a/server/src/transcription/factory.py
+++ b/server/src/transcription/factory.py
@@ -459,6 +459,7 @@ class EngineManager:
             except Exception as activation_error:
                 try:
                     await loop.run_in_executor(None, new_engine.shutdown)
+                    _force_free_vram()
                 except Exception as shutdown_error:
                     logger.error("Failed to discard unactivated engine: %s", shutdown_error)
                 restore_error = await restore_previous_engine()

--- a/server/tests/test_review_fixes.py
+++ b/server/tests/test_review_fixes.py
@@ -191,26 +191,95 @@ async def test_swap_engine_restores_old_engine_when_activation_callback_fails(
 
 
 @pytest.mark.asyncio
-async def test_swap_engine_restore_also_fails(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When both new engine and restore fail, _engine is None and original error propagates."""
+async def test_swap_engine_restore_failure_reports_recovery_and_can_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed unload-first restore must surface recovery instead of a silent empty manager."""
     settings = Settings(engine="whisper", unload_before_swap=True)
     monkeypatch.setattr(factory_module, "_get_available_engine_ids", lambda: ["whisper", "nemotron"])
     _stub_gpu(monkeypatch)
 
-    def _always_fail(s: Settings) -> _DummyEngine:
-        raise RuntimeError(f"Cannot create {s.engine}")
+    create_calls: list[str] = []
 
-    monkeypatch.setattr(factory_module, "_create_engine", _always_fail)
+    def _fail_then_recover(s: Settings) -> _DummyEngine:
+        create_calls.append(s.engine)
+        if len(create_calls) <= 2:
+            raise RuntimeError(f"Cannot create {s.engine}")
+        return _DummyEngine(s.engine)
+
+    monkeypatch.setattr(factory_module, "_create_engine", _fail_then_recover)
 
     manager = factory_module.EngineManager(settings)
     manager._engine = _DummyEngine("whisper")
 
     new_settings = Settings(engine="nemotron", unload_before_swap=True)
-    with pytest.raises(RuntimeError, match="Cannot create nemotron"):
+    with pytest.raises(
+        factory_module.EngineRecoveryRequiredError,
+        match="Candidate engine creation and previous-engine recovery both failed",
+    ):
         await manager.swap_engine(new_settings)
 
-    # Engine should be None since both attempts failed
-    assert manager._engine is None
+    status = manager.get_status()
+    assert status.current == "whisper"
+    assert status.status == "error"
+    assert status.info is None
+    assert status.message == (
+        "Eve could not restore the previous speech engine. "
+        "Restart the managed server, then retry or revert the selected model."
+    )
+    assert status.recovery == {
+        "action": "restart_server",
+        "message": status.message,
+    }
+    assert manager._settings is settings
+    with pytest.raises(RuntimeError, match="Restart the managed server"):
+        _ = manager.engine
+
+    # A fresh managed-server start invokes the same committed-settings path.
+    await manager.swap_engine(settings)
+    recovered = manager.get_status()
+    assert recovered.status == "ready"
+    assert recovered.current == "whisper"
+    assert recovered.recovery is None
+    assert create_calls == ["nemotron", "whisper", "whisper"]
+
+
+@pytest.mark.asyncio
+async def test_swap_engine_restore_failure_after_persistence_callback_is_recoverable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(engine="whisper", whisper_model="small", unload_before_swap=True)
+    monkeypatch.setattr(factory_module, "_get_available_engine_ids", lambda: ["whisper"])
+    _stub_gpu(monkeypatch)
+
+    def _fail_restoring_committed_engine(s: Settings) -> _DummyEngine:
+        if s.whisper_model == "small":
+            raise RuntimeError("Cannot restore whisper")
+        return _DummyEngine(s.engine)
+
+    monkeypatch.setattr(factory_module, "_create_engine", _fail_restoring_committed_engine)
+
+    manager = factory_module.EngineManager(settings)
+    manager._engine = _DummyEngine("whisper")
+
+    with pytest.raises(
+        factory_module.EngineRecoveryRequiredError,
+        match="Candidate engine activation and previous-engine recovery both failed",
+    ):
+        await manager.swap_engine(
+            Settings(
+                engine="whisper",
+                whisper_model="medium",
+                unload_before_swap=True,
+            ),
+            before_activate=lambda: (_ for _ in ()).throw(OSError("disk unavailable")),
+        )
+
+    status = manager.get_status()
+    assert status.status == "error"
+    assert status.recovery is not None
+    assert status.recovery["action"] == "restart_server"
+    assert manager._settings is settings
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_review_fixes.py
+++ b/server/tests/test_review_fixes.py
@@ -167,8 +167,15 @@ async def test_swap_engine_restores_old_engine_when_activation_callback_fails(
         return engine
 
     shutdown_calls: list[str] = []
+    cleanup_events: list[str] = []
     monkeypatch.setattr(factory_module, "_create_engine", _fake_create)
-    monkeypatch.setattr(_DummyEngine, "shutdown", lambda self: shutdown_calls.append(self._engine_id))
+
+    def _record_shutdown(self: _DummyEngine) -> None:
+        shutdown_calls.append(self._engine_id)
+        cleanup_events.append(f"shutdown:{self._engine_id}")
+
+    monkeypatch.setattr(_DummyEngine, "shutdown", _record_shutdown)
+    monkeypatch.setattr(factory_module, "_force_free_vram", lambda: cleanup_events.append("free"))
 
     manager = factory_module.EngineManager(settings)
     manager._engine = _DummyEngine("whisper")
@@ -188,6 +195,7 @@ async def test_swap_engine_restores_old_engine_when_activation_callback_fails(
     assert manager._settings is settings
     assert len(created) == 2
     assert shutdown_calls == ["whisper", "whisper"]
+    assert cleanup_events == ["shutdown:whisper", "free", "shutdown:whisper", "free"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Expose an explicit recovery-required engine status when unload-before-swap candidate construction or activation fails and previous-engine restoration also fails. Persisted settings remain unchanged, and the existing managed-server restart path is the deterministic recovery action.
- Clear all renderer engine-preparation lifecycle state when a managed server leaves running state, preserve external-server semantics, and announce a recoverable restart/reselect/apply message.

## Validation

- Focused server recovery/failure-injection tests: 34 passed.
- Direct Settings lifecycle tests: 8 passed, 32 expectations.
- Full server suite: 212 passed.
- Non-rendered app suite: 198 passed, 0 failed, 1540 expectations.
- History aggregate check passed.
- Main/preload/Vite production builds passed.
- git diff --check passed.

## Scope

P0 runtime recovery only. LAYOUT-03 is intentionally excluded for its own scoped phase.

Refs #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recovery status information when engine changes require a server restart.
  - Engine access is temporarily blocked until the server is restarted, preventing use of an incomplete engine configuration.
  - Added clear recovery messaging and restart guidance in status and settings views.

- **Bug Fixes**
  - Interrupted managed engine preparation is now detected and reset safely.
  - Settings views display an alert when applying a speech model fails.
  - Recovery state clears automatically after a successful engine change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->