### PR TITLE
Add content-aware server log states

### DIFF
--- a/app/src/renderer/app/fixtures/SettingsServerFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsServerFixture.svelte
@@ -4,7 +4,15 @@
   import ServerView from '../views/ServerView.svelte';
   import Toggle from '../components/Toggle.svelte';
 
-  type FixtureState = 'managed-ready' | 'managed-error' | 'external-ready' | 'managed-long';
+  type FixtureState =
+    | 'managed-ready'
+    | 'managed-error'
+    | 'external-ready'
+    | 'managed-long'
+    | 'managed-short'
+    | 'managed-empty'
+    | 'managed-log-error'
+    | 'managed-log-loading';
 
   const params = new URLSearchParams(globalThis.location.search);
   const fixtureState = (params.get('state') ?? 'managed-ready') as FixtureState;

--- a/app/src/renderer/app/fixtures/settings-server-fixture.ts
+++ b/app/src/renderer/app/fixtures/settings-server-fixture.ts
@@ -5,13 +5,24 @@ import { serverStatusState } from '../server-status';
 import SettingsServerFixture from './SettingsServerFixture.svelte';
 import '../app.css';
 
-type FixtureState = 'managed-ready' | 'managed-error' | 'external-ready' | 'managed-long';
+type FixtureState =
+  | 'managed-ready'
+  | 'managed-error'
+  | 'external-ready'
+  | 'managed-long'
+  | 'managed-short'
+  | 'managed-empty'
+  | 'managed-log-error'
+  | 'managed-log-loading';
 
 const params = new URLSearchParams(globalThis.location.search);
 const fixtureState = (params.get('state') ?? 'managed-ready') as FixtureState;
 const externalMode = fixtureState === 'external-ready';
 const longStrings = fixtureState === 'managed-long';
 const hasError = fixtureState === 'managed-error';
+const logError = fixtureState === 'managed-log-error';
+const logLoading = fixtureState === 'managed-log-loading';
+const logCount = fixtureState === 'managed-short' ? 3 : fixtureState === 'managed-empty' || logError || logLoading ? 0 : 42;
 
 const longWarning = 'The fixture warning deliberately contains a long diagnostic explanation with a host, a compatibility hint, and a recovery action so responsive wrapping can be measured without accessing personal data.';
 const engineStatus = {
@@ -56,7 +67,7 @@ const serverState: ServerStatePayload = {
   },
 };
 
-const logs: ServerLogEntry[] = Array.from({ length: 42 }, (_, index) => ({
+const logs: ServerLogEntry[] = Array.from({ length: logCount }, (_, index) => ({
   timestamp: Date.UTC(2026, 7, 3, 12, 0, index),
   level: index % 11 === 0 ? 'stderr' : 'stdout',
   message: longStrings
@@ -82,7 +93,11 @@ serverStatusState.set({
 });
 
 const fixtureMain = {
-  getServerLogs: async () => logs,
+  getServerLogs: async () => {
+    if (logLoading) return new Promise<ServerLogEntry[]>(() => {});
+    if (logError) throw new Error('fixture log retrieval failed');
+    return logs;
+  },
   getSettings: async () => fixtureSettings,
   onServerLog: (_callback: (entry: ServerLogEntry) => void) => () => {},
   copyDiagnostics: async () => {},

--- a/app/src/renderer/app/server-log.ts
+++ b/app/src/renderer/app/server-log.ts
@@ -1,0 +1,26 @@
+export const MAX_SERVER_LOG_ENTRIES = 500;
+export const SHORT_SERVER_LOG_ENTRY_LIMIT = 12;
+export const SERVER_LOG_LOAD_ERROR = 'Server logs are unavailable right now.';
+
+export type ServerLogLoadState = 'loading' | 'ready' | 'error';
+export type ServerLogBodySize = 'empty' | 'short' | 'long';
+
+function normalizeLogCount(count: number): number {
+  if (!Number.isFinite(count)) return 0;
+  return Math.max(0, Math.floor(count));
+}
+
+export function getServerLogBodySize(state: ServerLogLoadState, count: number): ServerLogBodySize {
+  const normalizedCount = normalizeLogCount(count);
+  if (state !== 'ready' || normalizedCount === 0) return 'empty';
+  return normalizedCount <= SHORT_SERVER_LOG_ENTRY_LIMIT ? 'short' : 'long';
+}
+
+export function getServerLogCountLabel(state: ServerLogLoadState, count: number): string {
+  if (state === 'loading') return 'Loading';
+  if (state === 'error') return 'Unavailable';
+
+  const normalizedCount = normalizeLogCount(count);
+  if (normalizedCount === 0) return 'No logs';
+  return `${normalizedCount} ${normalizedCount === 1 ? 'log' : 'logs'}`;
+}

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -505,25 +505,25 @@
       </button>
       <p id={privacyWarningId} data-server-logs-privacy class="mt-3 text-xs leading-5 text-amber-300/80 [overflow-wrap:anywhere]">Raw logs may contain local paths. Review them before sharing.</p>
 
-      {#if logsLoadState === 'loading'}
-        <p data-server-logs-state="loading" data-server-logs-loading role="status" aria-live="polite" class="mt-3 rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-3 text-xs text-zinc-400">Loading recent server logs…</p>
-      {:else if logsLoadState === 'error'}
-        <div data-server-logs-state="error" data-server-logs-error role="alert" class="mt-3 flex min-w-0 flex-wrap items-center justify-between gap-3 rounded-lg border border-red-900/60 bg-red-950/30 px-3 py-3">
-          <p class="min-w-0 text-xs leading-5 text-red-300 [overflow-wrap:anywhere]">{SERVER_LOG_LOAD_ERROR}</p>
-          <button
-            type="button"
-            onclick={retryLogs}
-            disabled={logsLoadState === 'loading'}
-            class="inline-flex min-h-9 shrink-0 items-center justify-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Retry
-          </button>
-        </div>
-      {:else if logs.length === 0}
-        <p data-server-logs-state="empty" data-server-logs-empty class="mt-3 rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-3 text-xs text-zinc-500">No server logs are available yet.</p>
-      {/if}
-
       <div id={logOutputId} hidden={!showLogs} class="mt-3 min-w-0">
+        {#if logsLoadState === 'loading'}
+          <p data-server-logs-state="loading" data-server-logs-loading role="status" aria-live="polite" class="mt-3 rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-3 text-xs text-zinc-400">Loading recent server logs…</p>
+        {:else if logsLoadState === 'error'}
+          <div data-server-logs-state="error" data-server-logs-error role="alert" class="mt-3 flex min-w-0 flex-wrap items-center justify-between gap-3 rounded-lg border border-red-900/60 bg-red-950/30 px-3 py-3">
+            <p class="min-w-0 text-xs leading-5 text-red-300 [overflow-wrap:anywhere]">{SERVER_LOG_LOAD_ERROR}</p>
+            <button
+              type="button"
+              onclick={retryLogs}
+              disabled={logsLoadState === 'loading'}
+              class="inline-flex min-h-9 shrink-0 items-center justify-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Retry
+            </button>
+          </div>
+        {:else if logs.length === 0}
+          <p data-server-logs-state="empty" data-server-logs-empty class="mt-3 rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-3 text-xs text-zinc-500">No server logs are available yet.</p>
+        {/if}
+
         <div class="flex min-w-0 flex-wrap items-center justify-end gap-2">
           <button
             type="button"

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -6,6 +6,13 @@
   import type { ServerStatePayload, ServerLogEntry } from '$shared/types';
   import { shouldShowModelProgress } from '$shared/model-progress';
   import { getServerManagementMode, serverStatusState } from '../server-status';
+  import {
+    getServerLogBodySize,
+    getServerLogCountLabel,
+    MAX_SERVER_LOG_ENTRIES,
+    SERVER_LOG_LOAD_ERROR,
+    type ServerLogLoadState,
+  } from '../server-log';
 
   interface Props {
     embedded?: boolean;
@@ -27,18 +34,21 @@
 
   let serverState = $derived($serverStatusState.state ?? unavailableState);
   let logs = $state<ServerLogEntry[]>([]);
+  let logsLoadState = $state<ServerLogLoadState>('loading');
   let showLogs = $state(false);
   let autoStart = $state(true);
   let configuredExternalServer = $state(false);
   let isLoading = $state(false);
   let logsContainer: HTMLDivElement | null = $state(null);
   let logsCopied = $state(false);
+  let logsCopiedTimer: ReturnType<typeof setTimeout> | null = null;
   let diagnosticsCopyState = $state<'idle' | 'copied' | 'error'>('idle');
   let diagnosticsCopyTimer: ReturnType<typeof setTimeout> | null = null;
   let pendingLogs: ServerLogEntry[] = [];
   let logFrame: number | null = null;
   let scrollAfterLogBatch = false;
   let removeLogListener: (() => void) | null = null;
+  let reloadLogs: (() => Promise<void>) | null = null;
 
   let externalMode = $derived(
     externalModeProp ?? getServerManagementMode({ ...$serverStatusState, configuredExternalServer }) === 'external'
@@ -71,6 +81,8 @@
   let modelDownload = $derived(serverState.modelDownload);
   let showModelProgress = $derived(shouldShowModelProgress(modelDownload));
   let modelDownloadError = $derived(modelDownload?.status === 'error');
+  let logBodySize = $derived(getServerLogBodySize(logsLoadState, logs.length));
+  let logCountLabel = $derived(getServerLogCountLabel(logsLoadState, logs.length));
 
   function formatUptime(ms: number): string {
     const seconds = Math.floor(ms / 1000);
@@ -158,12 +170,18 @@
   }
 
   function copyLogs() {
+    if (logsLoadState !== 'ready' || logs.length === 0) return;
+
     const text = logs
       .map((log) => `${formatLogTime(log.timestamp)} ${log.message}`)
       .join('\n');
     window.murmurMain.copyToClipboard(text);
     logsCopied = true;
-    setTimeout(() => (logsCopied = false), 2000);
+    if (logsCopiedTimer !== null) clearTimeout(logsCopiedTimer);
+    logsCopiedTimer = setTimeout(() => {
+      logsCopied = false;
+      logsCopiedTimer = null;
+    }, 2000);
   }
 
   async function copyDiagnostics() {
@@ -184,14 +202,15 @@
   function queueLog(entry: ServerLogEntry) {
     scrollAfterLogBatch ||= showLogs && isScrolledToBottom();
     pendingLogs.push(entry);
-    if (pendingLogs.length > 500) pendingLogs = pendingLogs.slice(-500);
+    if (pendingLogs.length > MAX_SERVER_LOG_ENTRIES) pendingLogs = pendingLogs.slice(-MAX_SERVER_LOG_ENTRIES);
     if (logFrame !== null) return;
 
     logFrame = requestAnimationFrame(() => {
       logFrame = null;
       const nextLogs = pendingLogs;
       pendingLogs = [];
-      logs = [...logs, ...nextLogs].slice(-500);
+      logs = [...logs, ...nextLogs].slice(-MAX_SERVER_LOG_ENTRIES);
+      logsLoadState = 'ready';
       if (scrollAfterLogBatch) {
         scrollAfterLogBatch = false;
         requestAnimationFrame(scrollLogsToBottom);
@@ -199,20 +218,44 @@
     });
   }
 
+  async function retryLogs(): Promise<void> {
+    if (logsLoadState === 'loading') return;
+    await reloadLogs?.();
+  }
+
   onMount(() => {
     let active = true;
 
+    const loadLogs = async (): Promise<void> => {
+      const shouldScroll = showLogs && isScrolledToBottom();
+      logsLoadState = 'loading';
+
+      try {
+        const initialLogs = await window.murmurMain.getServerLogs();
+        if (!active) return;
+        logs = initialLogs.slice(-MAX_SERVER_LOG_ENTRIES);
+        logsLoadState = 'ready';
+        if (shouldScroll) requestAnimationFrame(scrollLogsToBottom);
+      } catch (error) {
+        console.error('Failed to load server logs:', error);
+        if (!active) return;
+        logs = [];
+        logsLoadState = 'error';
+      }
+    };
+
+    reloadLogs = loadLogs;
+
     async function load(): Promise<void> {
-      const initialLogs = await window.murmurMain.getServerLogs();
+      await loadLogs();
       if (!active) return;
-      logs = initialLogs;
 
       const settings = await window.murmurMain.getSettings();
       if (!active) return;
       autoStart = settings.serverAutoStart;
       configuredExternalServer = settings.useExternalServer;
 
-      if (!active) return;
+      if (!active || removeLogListener) return;
       removeLogListener = window.murmurMain.onServerLog((entry) => {
         queueLog(entry);
       });
@@ -221,14 +264,17 @@
     void load();
     return () => {
       active = false;
+      reloadLogs = null;
     };
   });
 
   onDestroy(() => {
     if (logFrame !== null) cancelAnimationFrame(logFrame);
+    if (logsCopiedTimer !== null) clearTimeout(logsCopiedTimer);
     if (diagnosticsCopyTimer !== null) clearTimeout(diagnosticsCopyTimer);
     removeLogListener?.();
     removeLogListener = null;
+    reloadLogs = null;
   });
 </script>
 
@@ -451,21 +497,42 @@
         aria-expanded={showLogs}
         aria-controls={logOutputId}
         aria-describedby={privacyWarningId}
+        aria-label={`Server logs, ${logCountLabel}`}
         class="flex min-h-12 w-full min-w-0 items-center justify-between gap-3 rounded-lg border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-left transition-colors hover:bg-zinc-800 cursor-pointer focus:outline focus:outline-2 focus:outline-offset-[-2px] focus:outline-zinc-100"
       >
         <span class="min-w-0 text-sm text-zinc-200 [overflow-wrap:anywhere]">Server logs</span>
-        <span class="shrink-0 rounded-full border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs tabular-nums text-zinc-400">{logs.length}</span>
+        <span data-server-logs-count class="shrink-0 rounded-full border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs tabular-nums text-zinc-400">{logCountLabel}</span>
       </button>
       <p id={privacyWarningId} data-server-logs-privacy class="mt-3 text-xs leading-5 text-amber-300/80 [overflow-wrap:anywhere]">Raw logs may contain local paths. Review them before sharing.</p>
+
+      {#if logsLoadState === 'loading'}
+        <p data-server-logs-state="loading" data-server-logs-loading role="status" aria-live="polite" class="mt-3 rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-3 text-xs text-zinc-400">Loading recent server logs…</p>
+      {:else if logsLoadState === 'error'}
+        <div data-server-logs-state="error" data-server-logs-error role="alert" class="mt-3 flex min-w-0 flex-wrap items-center justify-between gap-3 rounded-lg border border-red-900/60 bg-red-950/30 px-3 py-3">
+          <p class="min-w-0 text-xs leading-5 text-red-300 [overflow-wrap:anywhere]">{SERVER_LOG_LOAD_ERROR}</p>
+          <button
+            type="button"
+            onclick={retryLogs}
+            disabled={logsLoadState === 'loading'}
+            class="inline-flex min-h-9 shrink-0 items-center justify-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Retry
+          </button>
+        </div>
+      {:else if logs.length === 0}
+        <p data-server-logs-state="empty" data-server-logs-empty class="mt-3 rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-3 text-xs text-zinc-500">No server logs are available yet.</p>
+      {/if}
 
       <div id={logOutputId} hidden={!showLogs} class="mt-3 min-w-0">
         <div class="flex min-w-0 flex-wrap items-center justify-end gap-2">
           <button
             type="button"
             onclick={copyLogs}
-            disabled={logs.length === 0}
+            data-server-logs-copy
+            aria-describedby={privacyWarningId}
+            disabled={logsLoadState !== 'ready' || logs.length === 0}
             class="inline-flex min-h-9 items-center justify-center gap-1 rounded-lg border border-zinc-700 px-3 py-2 text-xs transition-colors focus:outline focus:outline-2 focus:outline-offset-[-2px] focus:outline-zinc-100
-              {logs.length === 0
+              {logsLoadState !== 'ready' || logs.length === 0
                 ? 'cursor-not-allowed text-zinc-600'
                 : logsCopied
                   ? 'cursor-default text-emerald-400'
@@ -474,27 +541,26 @@
             {#if logsCopied}Copied{:else}Copy raw logs{/if}
           </button>
         </div>
-        <!-- svelte-ignore a11y_no_noninteractive_tabindex (keyboard focus is required to scroll the bounded log region) -->
-        <div
-          data-server-log-output
-          id={`${logOutputId}-scroll`}
-          bind:this={logsContainer}
-          tabindex="0"
-          role="log"
-          aria-label="Server log output"
-          class="mt-2 max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain rounded-lg border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs focus:outline focus:outline-2 focus:outline-offset-[-2px] focus:outline-zinc-100"
-        >
-          {#if logs.length === 0}
-            <p class="py-8 text-center text-zinc-500">No logs yet</p>
-          {:else}
+        {#if logBodySize !== 'empty'}
+          <!-- svelte-ignore a11y_no_noninteractive_tabindex (keyboard focus is required to scroll the bounded log region) -->
+          <div
+            data-server-log-output
+            data-log-size={logBodySize}
+            id={`${logOutputId}-scroll`}
+            bind:this={logsContainer}
+            tabindex="0"
+            role="log"
+            aria-label="Server log output"
+            class={`mt-2 min-w-0 rounded-lg border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs focus:outline focus:outline-2 focus:outline-offset-[-2px] focus:outline-zinc-100 ${logBodySize === 'long' ? 'max-h-64 overflow-y-auto overscroll-contain' : 'min-h-16 overflow-hidden'}`}
+          >
             {#each logs as log}
               <div class="flex min-w-0 gap-2 py-0.5">
                 <span class="shrink-0 text-zinc-500">{formatLogTime(log.timestamp)}</span>
                 <span class="min-w-0 break-all {log.level === 'stderr' ? 'text-red-300' : 'text-zinc-300'}">{log.message}</span>
               </div>
             {/each}
-          {/if}
-        </div>
+          </div>
+        {/if}
       </div>
     </div>
   </section>

--- a/app/tests/fixtures/settings-server-electron.cjs
+++ b/app/tests/fixtures/settings-server-electron.cjs
@@ -100,7 +100,7 @@ async function measure(window, state, logsExpanded, zoom) {
       logsAssociation: !!logsToggle && !!logPanel && logsToggle.getAttribute('aria-controls') === logPanel.id,
       logsExpanded: logPanel ? !logPanel.hidden : false,
       logsScroller: logOutput ? { overflowY: getComputedStyle(logOutput).overflowY, overscrollBehaviorY: getComputedStyle(logOutput).overscrollBehaviorY, clientHeight: logOutput.clientHeight, scrollHeight: logOutput.scrollHeight, tabIndex: logOutput.tabIndex, role: logOutput.getAttribute('role'), ariaLabel: logOutput.getAttribute('aria-label') } : null,
-      logState: logState?.getAttribute('data-server-logs-state') ?? null,
+      logState: logState?.getAttribute('data-server-logs-state') ?? (logOutput && logPanel && !logPanel.hidden ? 'ready' : null),
       logStateRole: logState?.getAttribute('role') ?? null,
       logStateLive: logState?.getAttribute('aria-live') ?? null,
       logBodySize: logOutput?.getAttribute('data-log-size') ?? null,

--- a/app/tests/fixtures/settings-server-electron.cjs
+++ b/app/tests/fixtures/settings-server-electron.cjs
@@ -15,6 +15,10 @@ const cases = [
   ['external-ready', false, 'external-ready.png'],
   ['managed-ready', true, 'logs-expanded.png'],
   ['managed-long', false, 'long-strings.png'],
+  ['managed-short', true, null],
+  ['managed-empty', true, null],
+  ['managed-log-error', true, null],
+  ['managed-log-loading', true, null],
 ];
 
 app.setPath('userData', userData);
@@ -52,6 +56,9 @@ async function measure(window, state, logsExpanded, zoom) {
     const logPanelId = logsToggle?.getAttribute('aria-controls');
     const logPanel = logPanelId ? document.getElementById(logPanelId) : null;
     const logOutput = document.querySelector('[data-server-log-output]');
+    const logState = document.querySelector('[data-server-logs-state]');
+    const logCopy = document.querySelector('[data-server-logs-copy]');
+    const retryLogs = document.querySelector('[data-server-logs-error] button');
     const controls = [...document.querySelectorAll('[data-server-mode-surface] button, [data-server-mode-surface] input, [data-server-health-surface] button, [data-server-diagnostics-surface] button, [data-server-logs-surface] button')].filter((control) => control.offsetParent !== null);
     const focusTarget = meta.logsExpanded ? (logOutput ?? logsToggle ?? controls[0]) : (logsToggle ?? controls[0]);
     document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
@@ -93,6 +100,14 @@ async function measure(window, state, logsExpanded, zoom) {
       logsAssociation: !!logsToggle && !!logPanel && logsToggle.getAttribute('aria-controls') === logPanel.id,
       logsExpanded: logPanel ? !logPanel.hidden : false,
       logsScroller: logOutput ? { overflowY: getComputedStyle(logOutput).overflowY, overscrollBehaviorY: getComputedStyle(logOutput).overscrollBehaviorY, clientHeight: logOutput.clientHeight, scrollHeight: logOutput.scrollHeight, tabIndex: logOutput.tabIndex, role: logOutput.getAttribute('role'), ariaLabel: logOutput.getAttribute('aria-label') } : null,
+      logState: logState?.getAttribute('data-server-logs-state') ?? null,
+      logStateRole: logState?.getAttribute('role') ?? null,
+      logStateLive: logState?.getAttribute('aria-live') ?? null,
+      logBodySize: logOutput?.getAttribute('data-log-size') ?? null,
+      logEmpty: !!document.querySelector('[data-server-logs-empty]'),
+      logError: !!document.querySelector('[data-server-logs-error]'),
+      logRetryVisible: !!retryLogs && retryLogs.offsetParent !== null,
+      logCopyDisabled: logCopy?.disabled ?? null,
       privacyWarning: !!document.querySelector('[data-server-logs-privacy]'),
       scrollersOutsideLogs: scrollersOutsideLogs.length,
     };

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -227,7 +227,8 @@ describe('Home and shared server status', () => {
     expect(statusController).toContain('percent < 25');
     expect(card).toContain("aria-live={announce ? 'polite' : undefined}");
     expect(banner).not.toContain('aria-live="assertive"');
-    expect(serverView).not.toContain('aria-live="polite"');
+    expect(serverView.match(/aria-live="polite"/g)?.length).toBe(1);
+    expect(serverView).toContain('data-server-logs-loading role="status" aria-live="polite"');
     expect(appView).toContain('aria-live="polite"');
     expect(serverView).toContain('let active = true;');
     expect(serverView).toContain('if (!active) return;');

--- a/app/tests/server-log.test.ts
+++ b/app/tests/server-log.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import {
+  getServerLogBodySize,
+  getServerLogCountLabel,
+  MAX_SERVER_LOG_ENTRIES,
+  SHORT_SERVER_LOG_ENTRY_LIMIT,
+  SERVER_LOG_LOAD_ERROR,
+} from '../src/renderer/app/server-log.js';
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+const serverView = source('../src/renderer/app/views/ServerView.svelte');
+const fixture = source('../src/renderer/app/fixtures/settings-server-fixture.ts');
+
+describe('Server log state and sizing contracts', () => {
+  test('keeps loading, empty, short, and long body states deterministic', () => {
+    expect(getServerLogBodySize('loading', 0)).toBe('empty');
+    expect(getServerLogBodySize('error', 42)).toBe('empty');
+    expect(getServerLogBodySize('ready', 0)).toBe('empty');
+    expect(getServerLogBodySize('ready', 1)).toBe('short');
+    expect(getServerLogBodySize('ready', SHORT_SERVER_LOG_ENTRY_LIMIT)).toBe('short');
+    expect(getServerLogBodySize('ready', SHORT_SERVER_LOG_ENTRY_LIMIT + 1)).toBe('long');
+    expect(getServerLogBodySize('ready', MAX_SERVER_LOG_ENTRIES)).toBe('long');
+    expect(getServerLogBodySize('ready', Number.NaN)).toBe('empty');
+  });
+
+  test('uses honest accessible count labels for every retrieval state', () => {
+    expect(getServerLogCountLabel('loading', 0)).toBe('Loading');
+    expect(getServerLogCountLabel('error', 42)).toBe('Unavailable');
+    expect(getServerLogCountLabel('ready', 0)).toBe('No logs');
+    expect(getServerLogCountLabel('ready', 1)).toBe('1 log');
+    expect(getServerLogCountLabel('ready', 3)).toBe('3 logs');
+  });
+
+  test('exposes loading, empty, and unavailable states with a safe retry', () => {
+    expect(serverView).toContain("let logsLoadState = $state<ServerLogLoadState>('loading')");
+    expect(serverView).toContain('data-server-logs-state="loading"');
+    expect(serverView).toContain('role="status" aria-live="polite"');
+    expect(serverView).toContain('data-server-logs-state="empty"');
+    expect(serverView).toContain('data-server-logs-state="error"');
+    expect(serverView).toContain('role="alert"');
+    expect(serverView).toContain('onclick={retryLogs}');
+    expect(serverView).toContain('await window.murmurMain.getServerLogs()');
+    expect(serverView).toContain('SERVER_LOG_LOAD_ERROR');
+    expect(SERVER_LOG_LOAD_ERROR).toBe('Server logs are unavailable right now.');
+  });
+
+  test('keeps short content natural and bounds only long content to the nested log scroller', () => {
+    expect(serverView).toContain('data-log-size={logBodySize}');
+    expect(serverView).toContain("'max-h-64 overflow-y-auto overscroll-contain'");
+    expect(serverView).toContain("'min-h-16 overflow-hidden'");
+    expect(serverView).toContain('MAX_SERVER_LOG_ENTRIES');
+    expect(serverView).toContain('pendingLogs.length > MAX_SERVER_LOG_ENTRIES');
+  });
+
+  test('preserves privacy, keyboard access, auto-follow, copy guards, and listener cleanup', () => {
+    expect(serverView).toContain('data-server-logs-privacy');
+    expect(serverView).toContain('tabindex="0"');
+    expect(serverView).toContain('role="log"');
+    expect(serverView).toContain('aria-label="Server log output"');
+    expect(serverView).toContain('aria-describedby={privacyWarningId}');
+    expect(serverView).toContain('disabled={logsLoadState !== \'ready\' || logs.length === 0}');
+    expect(serverView).toContain('if (logsLoadState !== \'ready\' || logs.length === 0) return;');
+    expect(serverView).toContain('scrollAfterLogBatch ||= showLogs && isScrolledToBottom()');
+    expect(serverView).toContain('removeLogListener?.()');
+    expect(serverView).toContain('if (logsCopiedTimer !== null) clearTimeout(logsCopiedTimer);');
+  });
+
+  test('provides deterministic fixture states without private or random log content', () => {
+    for (const state of ['managed-short', 'managed-empty', 'managed-log-error', 'managed-log-loading']) {
+      expect(fixture).toContain(`'${state}'`);
+    }
+    expect(fixture).toContain('if (logLoading) return new Promise<ServerLogEntry[]>(() => {})');
+    expect(fixture).toContain("if (logError) throw new Error('fixture log retrieval failed')");
+    expect(fixture).toContain('Array.from({ length: logCount }');
+  });
+});

--- a/app/tests/server-log.test.ts
+++ b/app/tests/server-log.test.ts
@@ -46,6 +46,11 @@ describe('Server log state and sizing contracts', () => {
     expect(serverView).toContain('await window.murmurMain.getServerLogs()');
     expect(serverView).toContain('SERVER_LOG_LOAD_ERROR');
     expect(SERVER_LOG_LOAD_ERROR).toBe('Server logs are unavailable right now.');
+
+    const logPanelStart = serverView.indexOf('<div id={logOutputId} hidden={!showLogs}');
+    const logStateStart = serverView.indexOf('{#if logsLoadState === \'loading\'}');
+    expect(logPanelStart).toBeGreaterThanOrEqual(0);
+    expect(logStateStart).toBeGreaterThan(logPanelStart);
   });
 
   test('keeps short content natural and bounds only long content to the nested log scroller', () => {

--- a/app/tests/settings-layout.test.ts
+++ b/app/tests/settings-layout.test.ts
@@ -48,7 +48,7 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(settingsView).toContain('<PrimaryPage page="settings" scrollOwner="settings-page"');
     expect(settingsView).not.toContain('h-screen');
     expect(serverView).toContain("embedded ? 'min-w-0 space-y-6'");
-    expect(serverView).toContain('max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain');
+    expect(serverView).toContain("${logBodySize === 'long' ? 'max-h-64 overflow-y-auto overscroll-contain' : 'min-h-16 overflow-hidden'}");
   });
 
   test('keeps controls trailing at every width and contains control content', () => {

--- a/app/tests/settings-server-cohesion.test.ts
+++ b/app/tests/settings-server-cohesion.test.ts
@@ -43,7 +43,7 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(serverView).toContain('window.murmurMain.restartServer()');
   });
 
-  test('keeps factual status and diagnostics readable without creating another live announcer', () => {
+  test('keeps factual status and diagnostics readable without duplicating app announcements', () => {
     expect(serverView).toContain('data-server-health-status');
     expect(serverView).toContain('data-server-health-details');
     expect(serverView).toContain('md:grid-cols-[auto_minmax(0,1fr)_auto]');
@@ -52,7 +52,8 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(serverView).toContain('<ModelProgressCard state={modelDownload} announce={false} />');
     expect(serverView).toContain('aria-describedby={diagnosticsStatusId}');
     expect(serverView).toContain('id={diagnosticsStatusId}');
-    expect(serverView).not.toContain('aria-live="polite"');
+    expect(serverView.match(/aria-live="polite"/g)?.length).toBe(1);
+    expect(serverView).toContain('data-server-logs-loading role="status" aria-live="polite"');
     expect(serverView).not.toContain('aria-label={`Server status: ${statusDisplay.label}`}');
     expect(serverView).toContain('motion-safe:animate-ping');
     expect(settingsRow).toContain('focus-visible:ring-2');
@@ -71,7 +72,12 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(serverView).toContain('tabindex="0"');
     expect(serverView).toContain('role="log"');
     expect(serverView).toContain('aria-label="Server log output"');
-    expect(serverView).toContain('max-h-64 min-h-24 min-w-0 overflow-y-auto overscroll-contain');
+    expect(serverView).toContain('data-log-size={logBodySize}');
+    expect(serverView).toContain("${logBodySize === 'long' ? 'max-h-64 overflow-y-auto overscroll-contain' : 'min-h-16 overflow-hidden'}");
+    expect(serverView).toContain('data-server-logs-state="loading"');
+    expect(serverView).toContain('data-server-logs-state="error"');
+    expect(serverView).toContain('data-server-logs-state="empty"');
+    expect(serverView).toContain('SERVER_LOG_LOAD_ERROR');
     expect(serverView).not.toContain('data-server-logs-surface class="min-w-0 rounded-xl border border-white/10 bg-white/[0.025] p-4 focus-within');
     expect(serverView).toContain('focus:outline-offset-[-2px]');
     expect(serverView).not.toContain('opacity-45 pointer-events-none select-none');

--- a/app/tests/settings-server-rendered.test.mjs
+++ b/app/tests/settings-server-rendered.test.mjs
@@ -140,7 +140,7 @@ const { measurements } = result;
 
 describe('rendered Phase 3 Server and diagnostics fixture', () => {
   test('keeps one page scroll owner and no horizontal overflow at narrow/high zoom states', () => {
-    expect(measurements.length).toBe(30);
+    expect(measurements.length).toBe(54);
     for (const measurement of measurements) {
       expect(measurement.owner.overflowY).toBe('auto');
       expect(measurement.owner.scrollHeight).toBeGreaterThan(measurement.owner.clientHeight);
@@ -187,6 +187,41 @@ describe('rendered Phase 3 Server and diagnostics fixture', () => {
     expect(expanded.logsScroller.tabIndex).toBe(0);
     expect(expanded.logsScroller.role).toBe('log');
     expect(expanded.logsScroller.ariaLabel).toBe('Server log output');
+  });
+
+  test('distinguishes loading, empty, unavailable, short, and bounded long log states', () => {
+    const short = measurements.find((measurement) => measurement.state === 'managed-short' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const empty = measurements.find((measurement) => measurement.state === 'managed-empty' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const unavailable = measurements.find((measurement) => measurement.state === 'managed-log-error' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const loading = measurements.find((measurement) => measurement.state === 'managed-log-loading' && measurement.zoom === 1 && measurement.viewport.width === 960);
+    const long = measurements.find((measurement) => measurement.state === 'managed-long' && measurement.zoom === 1 && measurement.viewport.width === 960);
+
+    expect(short.logState).toBe('ready');
+    expect(short.logBodySize).toBe('short');
+    expect(short.logsScroller.overflowY).toBe('hidden');
+    expect(short.logCopyDisabled).toBeFalse();
+
+    expect(empty.logState).toBe('empty');
+    expect(empty.logEmpty).toBeTrue();
+    expect(empty.logCopyDisabled).toBeTrue();
+    expect(empty.logsScroller).toBeNull();
+
+    expect(unavailable.logState).toBe('error');
+    expect(unavailable.logError).toBeTrue();
+    expect(unavailable.logStateRole).toBe('alert');
+    expect(unavailable.logRetryVisible).toBeTrue();
+    expect(unavailable.logCopyDisabled).toBeTrue();
+    expect(unavailable.logsScroller).toBeNull();
+
+    expect(loading.logState).toBe('loading');
+    expect(loading.logStateRole).toBe('status');
+    expect(loading.logStateLive).toBe('polite');
+    expect(loading.logCopyDisabled).toBeTrue();
+    expect(loading.logsScroller).toBeNull();
+
+    expect(long.logBodySize).toBe('long');
+    expect(long.logsScroller.overflowY).toBe('auto');
+    expect(long.logsScroller.overscrollBehaviorY).toBe('contain');
   });
 
   test('keeps heading associations, visible focus, and long strings contained', () => {


### PR DESCRIPTION
## Scope

Implements the LAYOUT-03 server-log foundation from #57 without adding a new IPC surface:

- explicit loading, honest empty, and retrieval-error states with safe retry
- content-aware short-log sizing and bounded long-log nested scrolling
- preserved 500-entry cap, privacy warning, copy guards, keyboard focus, and auto-follow-at-bottom behavior
- accessible status/alert/log semantics and deterministic fixture/contract coverage

## Validation

- Full non-rendered app matrix: 204 passed, 0 failed, 1,592 expectations across 37 files
- Main/preload/Vite production builds passed (154 renderer modules)
- Focused server-log/layout/cohesion tests: 40 passed, 343 expectations
- Fixture scripts passed `node --check`
- `git diff --check` passed

The local Electron screenshot fixture was not rerun in this handoff; the expanded 54-measurement rendered matrix is included for hosted CI validation.

Refs #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved server log viewing with loading, empty, unavailable, error, and retry states.
  * Added adaptive log sizing, entry counts, and body-size indicators.
  * Disabled log copying while logs are loading or unavailable.
  * Added accessible status announcements and keyboard-friendly log behavior.
* **Bug Fixes**
  * Improved handling of long logs with bounded scrolling and auto-follow behavior.
  * Ensured copy controls and loading indicators reflect the current log state.
* **Tests**
  * Expanded coverage for accessibility, privacy, retries, copying, and log sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->