### PR TITLE
Add fail-closed packaged QA profile isolation

### DIFF
--- a/app/src/main/bootstrap.ts
+++ b/app/src/main/bootstrap.ts
@@ -2,10 +2,16 @@ import { app, dialog } from 'electron';
 import { bootstrapApplication } from './bootstrap-core.js';
 import { EVE_USER_DATA_DIRECTORY_NAME } from './identity.js';
 import { createLogger } from './lib/logger.js';
+import { resolveQaProfileIsolation } from './qa-profile-isolation.js';
 
 const log = createLogger('Bootstrap');
 
 try {
+  const qaProfileIsolation = resolveQaProfileIsolation(process.argv);
+  if (qaProfileIsolation) {
+    app.setPath('appData', qaProfileIsolation.appDataPath);
+  }
+
   await bootstrapApplication(app, () => import('./index.js'), {
     userDataDirectoryName: EVE_USER_DATA_DIRECTORY_NAME,
   });

--- a/app/src/main/qa-profile-isolation.ts
+++ b/app/src/main/qa-profile-isolation.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const EVE_QA_ISOLATION_SWITCH = '--eve-qa-isolation';
+export const EVE_QA_USER_DATA_ROOT_SWITCH = '--eve-qa-user-data-root';
+const ELECTRON_USER_DATA_DIR_SWITCH = '--user-data-dir';
+
+export interface QaProfileIsolation {
+  readonly appDataPath: string;
+}
+
+interface QaProfileIsolationFileSystem {
+  realpath(path: string): string;
+  stat(path: string): Pick<fs.Stats, 'isDirectory'>;
+}
+
+const nodeFileSystem: QaProfileIsolationFileSystem = {
+  realpath: (value) => fs.realpathSync.native(value),
+  stat: (value) => fs.statSync(value),
+};
+
+function isQaLookingArgument(argument: string): boolean {
+  return argument.toLowerCase().startsWith('--eve-qa-');
+}
+
+function isElectronUserDataDirArgument(argument: string): boolean {
+  const normalizedArgument = argument.toLowerCase();
+  return (
+    normalizedArgument === ELECTRON_USER_DATA_DIR_SWITCH ||
+    normalizedArgument.startsWith(`${ELECTRON_USER_DATA_DIR_SWITCH}=`)
+  );
+}
+
+function assertCanonicalQaUserDataRoot(value: string): string {
+  if (!value || value.includes('\0') || !path.isAbsolute(value)) {
+    throw new Error('QA user-data root must be an absolute path');
+  }
+
+  if (value.endsWith(path.sep) || value.endsWith('/') || value.endsWith('\\')) {
+    throw new Error('QA user-data root must not end with a path separator');
+  }
+
+  if (path.normalize(value) !== value) {
+    throw new Error('QA user-data root must be canonical');
+  }
+
+  if (path.basename(value).toLowerCase() !== 'eve') {
+    throw new Error('QA user-data root must name the Eve directory');
+  }
+
+  return value;
+}
+
+/**
+ * Parses the explicitly opt-in packaged-QA profile arguments. Any QA-looking
+ * argument is fail-closed so a malformed QA launch cannot fall back to a real
+ * user profile.
+ */
+export function parseQaProfileIsolationArguments(
+  argv: readonly string[]
+): string | null {
+  const qaArguments = argv.filter(isQaLookingArgument);
+  if (qaArguments.length === 0) {
+    return null;
+  }
+
+  const isolationArguments = qaArguments.filter(
+    (argument) => argument === EVE_QA_ISOLATION_SWITCH
+  );
+  const rootPrefix = `${EVE_QA_USER_DATA_ROOT_SWITCH}=`;
+  const rootArguments = qaArguments.filter((argument) =>
+    argument.startsWith(rootPrefix)
+  );
+
+  if (
+    qaArguments.length !== 2 ||
+    isolationArguments.length !== 1 ||
+    rootArguments.length !== 1 ||
+    argv.some(isElectronUserDataDirArgument)
+  ) {
+    throw new Error('Invalid packaged QA profile arguments');
+  }
+
+  const [rootArgument] = rootArguments;
+  if (!rootArgument) {
+    throw new Error('Invalid packaged QA profile arguments');
+  }
+
+  return assertCanonicalQaUserDataRoot(rootArgument.slice(rootPrefix.length));
+}
+
+/**
+ * Resolves the QA parent before Electron bootstrap. The existing bootstrap
+ * still creates and validates its direct Eve child with the normal defenses.
+ */
+export function resolveQaProfileIsolation(
+  argv: readonly string[],
+  fileSystem: QaProfileIsolationFileSystem = nodeFileSystem
+): QaProfileIsolation | null {
+  const userDataRoot = parseQaProfileIsolationArguments(argv);
+  if (!userDataRoot) {
+    return null;
+  }
+
+  const requestedAppDataPath = path.dirname(userDataRoot);
+  if (!fileSystem.stat(requestedAppDataPath).isDirectory()) {
+    throw new Error('QA app-data parent must be a directory');
+  }
+
+  return {
+    appDataPath: fileSystem.realpath(requestedAppDataPath),
+  };
+}

--- a/app/tests/eve-profile-boundary.test.ts
+++ b/app/tests/eve-profile-boundary.test.ts
@@ -285,7 +285,7 @@ const events = [];
     expect(qaSmokeState).toEqual({
       loaded: true,
       events: [
-        `get:appData:${qaAppData}`,
+        `get:appData:${qaCanonicalAppData}`,
         `set:userData:${qaEveRoot}`,
         `set:sessionData:${qaEveRoot}`,
         `lock:userData:${qaEveRoot}:sessionData:${qaEveRoot}`,

--- a/app/tests/eve-profile-boundary.test.ts
+++ b/app/tests/eve-profile-boundary.test.ts
@@ -9,6 +9,7 @@ import {
   readdirSync,
   realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
@@ -32,6 +33,24 @@ function createFixtureRoot(): string {
   return root;
 }
 
+function snapshotMetadata(root: string): Array<{ relative: string; size: number; mtimeMs: number }> {
+  const entries: Array<{ relative: string; size: number; mtimeMs: number }> = [];
+  const visit = (directory: string) => {
+    for (const name of readdirSync(directory)) {
+      const fullPath = path.join(directory, name);
+      const stats = statSync(fullPath);
+      const relative = path.relative(root, fullPath);
+      entries.push({ relative, size: stats.size, mtimeMs: stats.mtimeMs });
+      if (stats.isDirectory()) {
+        visit(fullPath);
+      }
+    }
+  };
+
+  visit(root);
+  return entries.sort((left, right) => left.relative.localeCompare(right.relative));
+}
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -51,6 +70,8 @@ describe('user-data root preparation', () => {
     const runnerPath = path.join(fixture, 'electron-bootstrap-smoke.cjs');
     const resultPath = path.join(fixture, 'electron-bootstrap-result.json');
     const preBootstrapUserData = path.join(fixture, 'PreBootstrapUserData');
+    const qaAppData = path.join(fixture, 'QaRoaming');
+    const qaRequestedUserData = path.join(qaAppData, 'eve');
     const electronPath = path.join(
       appRoot,
       'node_modules',
@@ -63,11 +84,23 @@ describe('user-data root preparation', () => {
     mkdirSync(localAppData);
     mkdirSync(userProfile);
     mkdirSync(temp);
+    mkdirSync(qaAppData);
     writeFileSync(legacySentinel, 'controlled legacy data');
 
     buildSync({
       entryPoints: [path.join(appRoot, 'src', 'main', 'bootstrap-core.ts')],
       outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      target: 'node20',
+      format: 'cjs',
+      logLevel: 'silent',
+    });
+
+    const qaBundlePath = path.join(fixture, 'qa-profile-isolation.cjs');
+    buildSync({
+      entryPoints: [path.join(appRoot, 'src', 'main', 'qa-profile-isolation.ts')],
+      outfile: qaBundlePath,
       bundle: true,
       platform: 'node',
       target: 'node20',
@@ -81,38 +114,40 @@ describe('user-data root preparation', () => {
 const fs = require('node:fs');
 const { app } = require('electron');
 const { bootstrapApplication } = require(${JSON.stringify(bundlePath)});
+const { resolveQaProfileIsolation } = require(${JSON.stringify(qaBundlePath)});
 
-app.setPath('appData', ${JSON.stringify(appData)});
-app.setName('Murmur');
 const events = [];
-const electronApp = {
-  getPath(name) {
-    const value = app.getPath(name);
-    events.push(\`get:\${name}:\${value}\`);
-    return value;
-  },
-  setPath(name, value) {
-    app.setPath(name, value);
-    events.push(\`set:\${name}:\${value}\`);
-  },
-  requestSingleInstanceLock() {
-    events.push(
-      \`lock:userData:\${app.getPath('userData')}:sessionData:\${app.getPath('sessionData')}\`
-    );
-    return app.requestSingleInstanceLock();
-  },
-  quit() {
-    events.push('quit');
-    app.quit();
-  },
-  setAppUserModelId(id) {
-    events.push(\`app-id:\${id}\`);
-    app.setAppUserModelId(id);
-  },
-};
 
 (async () => {
   try {
+    const qaProfileIsolation = resolveQaProfileIsolation(process.argv);
+    app.setPath('appData', qaProfileIsolation ? qaProfileIsolation.appDataPath : ${JSON.stringify(appData)});
+    app.setName('Murmur');
+    const electronApp = {
+      getPath(name) {
+        const value = app.getPath(name);
+        events.push(\`get:\${name}:\${value}\`);
+        return value;
+      },
+      setPath(name, value) {
+        app.setPath(name, value);
+        events.push(\`set:\${name}:\${value}\`);
+      },
+      requestSingleInstanceLock() {
+        events.push(
+          \`lock:userData:\${app.getPath('userData')}:sessionData:\${app.getPath('sessionData')}\`
+        );
+        return app.requestSingleInstanceLock();
+      },
+      quit() {
+        events.push('quit');
+        app.quit();
+      },
+      setAppUserModelId(id) {
+        events.push(\`app-id:\${id}\`);
+        app.setAppUserModelId(id);
+      },
+    };
     const loaded = await bootstrapApplication(
       electronApp,
       async () => {
@@ -201,6 +236,99 @@ const electronApp = {
       sessionData: eveRoot,
       lockHeld: true,
     });
+    expect(readFileSync(legacySentinel, 'utf8')).toBe('controlled legacy data');
+    expect(readdirSync(legacyRoot)).toEqual(['legacy-sentinel.txt']);
+
+    const normalProfileMetadataBeforeQa = snapshotMetadata(appData);
+    const qaResult = Bun.spawnSync({
+      cmd: [
+        electronPath,
+        '--eve-qa-isolation',
+        `--eve-qa-user-data-root=${qaRequestedUserData}`,
+        runnerPath,
+      ],
+      cwd: fixture,
+      env: {
+        APPDATA: appData,
+        LOCALAPPDATA: localAppData,
+        USERPROFILE: userProfile,
+        HOME: userProfile,
+        TEMP: temp,
+        TMP: temp,
+        PATH: process.env.PATH,
+        PATHEXT: process.env.PATHEXT,
+        SystemRoot: process.env.SystemRoot,
+        windir: process.env.windir,
+        ComSpec: process.env.ComSpec,
+        ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+      },
+      timeout: 30_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(qaResult.success).toBeTrue();
+    expect(qaResult.exitCode).toBe(0);
+
+    const qaSmoke = JSON.parse(readFileSync(resultPath, 'utf8')) as {
+      loaded: boolean;
+      events: string[];
+      userData: string;
+      sessionData: string;
+      lockHeld: boolean;
+      electronVersion: string;
+    };
+    const qaEveRoot = path.join(qaAppData, 'Eve');
+    const { electronVersion: qaElectronVersion, ...qaSmokeState } = qaSmoke;
+    expect(qaElectronVersion).toMatch(/^40\./);
+    expect(qaSmokeState).toEqual({
+      loaded: true,
+      events: [
+        `get:appData:${qaAppData}`,
+        `set:userData:${qaEveRoot}`,
+        `set:sessionData:${qaEveRoot}`,
+        `lock:userData:${qaEveRoot}:sessionData:${qaEveRoot}`,
+        'app-id:io.github.burntcookiedough.eve',
+        'load',
+      ],
+      userData: qaEveRoot,
+      sessionData: qaEveRoot,
+      lockHeld: true,
+    });
+    expect(snapshotMetadata(appData)).toEqual(normalProfileMetadataBeforeQa);
+    expect(readFileSync(legacySentinel, 'utf8')).toBe('controlled legacy data');
+    expect(readdirSync(legacyRoot)).toEqual(['legacy-sentinel.txt']);
+
+    const normalProfileMetadataBeforeInvalidQa = snapshotMetadata(appData);
+    const invalidQaResult = Bun.spawnSync({
+      cmd: [electronPath, '--eve-qa-isolation', runnerPath],
+      cwd: fixture,
+      env: {
+        APPDATA: appData,
+        LOCALAPPDATA: localAppData,
+        USERPROFILE: userProfile,
+        HOME: userProfile,
+        TEMP: temp,
+        TMP: temp,
+        PATH: process.env.PATH,
+        PATHEXT: process.env.PATHEXT,
+        SystemRoot: process.env.SystemRoot,
+        windir: process.env.windir,
+        ComSpec: process.env.ComSpec,
+        ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+      },
+      timeout: 30_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(invalidQaResult.success).toBeFalse();
+    expect(invalidQaResult.exitCode).toBe(1);
+    expect(JSON.parse(readFileSync(resultPath, 'utf8'))).toMatchObject({
+      events: [],
+      error: expect.stringMatching(/Invalid packaged QA profile arguments/),
+    });
+    expect(snapshotMetadata(appData)).toEqual(normalProfileMetadataBeforeInvalidQa);
     expect(readFileSync(legacySentinel, 'utf8')).toBe('controlled legacy data');
     expect(readdirSync(legacyRoot)).toEqual(['legacy-sentinel.txt']);
   });

--- a/app/tests/eve-profile-boundary.test.ts
+++ b/app/tests/eve-profile-boundary.test.ts
@@ -85,6 +85,7 @@ describe('user-data root preparation', () => {
     mkdirSync(userProfile);
     mkdirSync(temp);
     mkdirSync(qaAppData);
+    const qaCanonicalAppData = realpathSync.native(qaAppData);
     writeFileSync(legacySentinel, 'controlled legacy data');
 
     buildSync({
@@ -278,7 +279,7 @@ const events = [];
       lockHeld: boolean;
       electronVersion: string;
     };
-    const qaEveRoot = path.join(qaAppData, 'Eve');
+    const qaEveRoot = path.join(qaCanonicalAppData, 'Eve');
     const { electronVersion: qaElectronVersion, ...qaSmokeState } = qaSmoke;
     expect(qaElectronVersion).toMatch(/^40\./);
     expect(qaSmokeState).toEqual({

--- a/app/tests/qa-profile-isolation.test.ts
+++ b/app/tests/qa-profile-isolation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
+import {
+  EVE_QA_ISOLATION_SWITCH,
+  EVE_QA_USER_DATA_ROOT_SWITCH,
+  parseQaProfileIsolationArguments,
+  resolveQaProfileIsolation,
+} from '../src/main/qa-profile-isolation';
+
+const QA_ROOT = String.raw`C:\qa\Roaming\Eve`;
+
+function qaArguments(root = QA_ROOT): string[] {
+  return [
+    'Eve.exe',
+    EVE_QA_ISOLATION_SWITCH,
+    `${EVE_QA_USER_DATA_ROOT_SWITCH}=${root}`,
+  ];
+}
+
+describe('packaged QA profile isolation arguments', () => {
+  test('leaves normal launches unchanged', () => {
+    expect(parseQaProfileIsolationArguments(['Eve.exe'])).toBeNull();
+    expect(
+      parseQaProfileIsolationArguments([
+        'Eve.exe',
+        `--user-data-dir=${String.raw`C:\pre-bootstrap`}`,
+      ])
+    ).toBeNull();
+  });
+
+  test('accepts exactly one explicit gate and case-insensitive Eve leaf', () => {
+    expect(parseQaProfileIsolationArguments(qaArguments())).toBe(QA_ROOT);
+    expect(
+      parseQaProfileIsolationArguments(qaArguments(String.raw`C:\qa\Roaming\eve`))
+    ).toBe(String.raw`C:\qa\Roaming\eve`);
+  });
+
+  test('resolves the canonical existing parent before bootstrap', () => {
+    const requestedParent = String.raw`C:\qa\redirected-roaming`;
+    const canonicalParent = String.raw`C:\qa\actual-roaming`;
+    const resolved = resolveQaProfileIsolation(
+      qaArguments(path.win32.join(requestedParent, 'Eve')),
+      {
+        stat: (value) => {
+          expect(value).toBe(requestedParent);
+          return { isDirectory: () => true };
+        },
+        realpath: (value) => {
+          expect(value).toBe(requestedParent);
+          return canonicalParent;
+        },
+      }
+    );
+
+    expect(resolved).toEqual({ appDataPath: canonicalParent });
+  });
+
+  test.each([
+    ['missing gate', ['Eve.exe', `${EVE_QA_USER_DATA_ROOT_SWITCH}=${QA_ROOT}`]],
+    ['missing root', ['Eve.exe', EVE_QA_ISOLATION_SWITCH]],
+    [
+      'duplicate gate',
+      [
+        ...qaArguments(),
+        EVE_QA_ISOLATION_SWITCH,
+      ],
+    ],
+    [
+      'duplicate root',
+      [
+        ...qaArguments(),
+        `${EVE_QA_USER_DATA_ROOT_SWITCH}=${QA_ROOT}`,
+      ],
+    ],
+    [
+      'alternate gate form',
+      ['Eve.exe', '--eve-qa-isolation=true', `${EVE_QA_USER_DATA_ROOT_SWITCH}=${QA_ROOT}`],
+    ],
+    [
+      'uppercase gate',
+      ['Eve.exe', '--EVE-QA-ISOLATION', `${EVE_QA_USER_DATA_ROOT_SWITCH}=${QA_ROOT}`],
+    ],
+    [
+      'mixed-case root switch',
+      ['Eve.exe', EVE_QA_ISOLATION_SWITCH, `--eve-Qa-user-data-root=${QA_ROOT}`],
+    ],
+    [
+      'separate root value',
+      ['Eve.exe', EVE_QA_ISOLATION_SWITCH, EVE_QA_USER_DATA_ROOT_SWITCH, QA_ROOT],
+    ],
+    [
+      'standard Electron root collision',
+      [...qaArguments(), `--user-data-dir=${String.raw`C:\other`}`],
+    ],
+    [
+      'standard Electron separate collision',
+      [...qaArguments(), '--user-data-dir', String.raw`C:\other`],
+    ],
+    [
+      'mixed-case Electron root collision',
+      [...qaArguments(), `--UsEr-DaTa-DiR=${String.raw`C:\other`}`],
+    ],
+    ['relative root', qaArguments(String.raw`qa\Roaming\Eve`)],
+    ['wrong leaf', qaArguments(String.raw`C:\qa\Roaming\NotEve`)],
+    ['trailing separator', qaArguments(`${QA_ROOT}${path.win32.sep}`)],
+    ['noncanonical traversal', qaArguments(String.raw`C:\qa\Roaming\other\..\Eve`)],
+    ['unknown QA-looking switch', [...qaArguments(), '--eve-qa-unrelated']],
+    ['uppercase unknown QA-looking switch', [...qaArguments(), '--EVE-QA-UNRELATED']],
+  ])('fails closed for %s', (_name, argv) => {
+    expect(() => parseQaProfileIsolationArguments(argv)).toThrow(
+      /Invalid packaged QA profile arguments|QA user-data root/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add the explicit `--eve-qa-isolation` plus `--eve-qa-user-data-root=<absolute Eve path>` gate for packaged QA runs.
- Set Electron `appData` to the canonical synthetic parent before bootstrap while preserving normal and standard `--user-data-dir` behavior.
- Add parser, fail-closed argument, canonical-parent, single-instance, and profile-boundary coverage.

## Acceptance / incident context

Refs #57.

This contains the packaged QA isolation correction for the Phase-1 readiness incident: environment overrides alone did not redirect Electron userData, so the readiness attempt touched the real profile. The opt-in pair is exact and fail-closed; malformed or case-varied QA-looking arguments reject before normal profile bootstrap. Normal launches remain unchanged, and the boundary smoke uses synthetic roots and metadata-only checks.

## Validation

- Focused isolation/profile boundary: 30 passed, 63 expectations.
- Non-rendered app suite: 224 passed, 0 failed.
- History aggregate check, production build, Home rendered fixture (3), and Server rendered fixture (7) passed.
- Known baseline only: renderer `eve-dropdown.ts` TS18048 and main `history.ts` 747/755; Speech display capture unavailable locally. Hosted CI must cover the complete rendered/type-check matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added isolated profile support for packaged QA launches.
  * QA sessions now use a separate user-data location, protecting normal profiles and legacy data.
  * Invalid or conflicting QA launch options are rejected safely.

* **Bug Fixes**
  * Improved profile path validation and locking behavior for QA sessions.

* **Tests**
  * Added coverage for valid, invalid, conflicting, and noncanonical QA profile options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->