### PR TITLE
Ship a Whisper-only v0.8.1 alpha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ FastAPI/WebSocket service in `server/`. Read the relevant docs before changes.
 - Use the current clone path; do not copy environments or depend on user paths.
 - For app work: `Set-Location app; bun run <script>`.
 - For server work: `Set-Location server; uv sync --extra whisper --group dev --frozen; uv run pytest`.
-- Use `uv sync --extra all --frozen` only for release-runtime preparation.
+- Use `uv sync --extra release --frozen` for release-runtime preparation. The
+  `nemotron` extra remains available for deferred repair work and is not part
+  of the shipped alpha.
 
 ## Product and privacy boundaries
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ Models are downloaded from their public Hugging Face repositories the first time
 
 | Choice | Best for | Engine and model |
 | --- | --- | --- |
-| **Nemotron English Performance** | Focused English dictation on capable hardware | [NVIDIA Nemotron Speech Streaming](https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b) |
 | **Large V3 Turbo — Recommended Multilingual** | A balanced everyday multilingual option | [faster-whisper-large-v3-turbo](https://huggingface.co/mobiuslabsgmbh/faster-whisper-large-v3-turbo) |
 | **Large V3 — Maximum Multilingual Accuracy** | Quality-first multilingual work | [faster-whisper-large-v3](https://huggingface.co/Systran/faster-whisper-large-v3) |
 | **Small — Lightweight** | A smaller download for constrained hardware | [faster-whisper-small](https://huggingface.co/Systran/faster-whisper-small) |
 | **Medium / Tiny — Advanced** | Raw engine choices for users who want to tune the trade-off | [faster-whisper-medium](https://huggingface.co/Systran/faster-whisper-medium) / [faster-whisper-tiny](https://huggingface.co/Systran/faster-whisper-tiny) |
+
+The v0.8.1 alpha ships Faster-Whisper as its sole selectable engine. Nemotron
+remains in the source tree and optional `nemotron` dependency for deferred
+repair work; it is not shipped or user-selectable in this alpha.
 
 Eve derives device and precision availability from the installed PyTorch and CTranslate2 runtimes. `auto` is the safest starting point; a particular device/precision/model combination still depends on the local driver, VRAM, and runtime capabilities. The catalog is not a promise of every device-by-precision combination.
 
@@ -81,7 +84,7 @@ bun install
 bun run dev
 ```
 
-Use `uv sync --extra all --frozen` when preparing a release runtime with both shipped engines. See [the Windows build guide](docs/development/building.md), [docs/protocol.md](docs/protocol.md), and [contributing](.github/CONTRIBUTING.md).
+Use `uv sync --extra release --frozen` when preparing the Whisper-only shipped alpha runtime. See [the Windows build guide](docs/development/building.md), [docs/protocol.md](docs/protocol.md), and [contributing](.github/CONTRIBUTING.md).
 
 ## Compatibility and provenance
 

--- a/app/src/main/services/history.ts
+++ b/app/src/main/services/history.ts
@@ -740,19 +740,19 @@ export class HistoryService {
   private getDailyRows(dayStart: string | null): DailyRollupRow[] {
     if (!this.db) throw new Error('Database not initialized');
     if (dayStart === null) {
-      return this.db.prepare(`
+      return (this.db.prepare(`
         SELECT day, dictations, words, audioSeconds, processingMs, confidenceSum, confidenceCount
         FROM insights_daily_rollups
         ORDER BY day ASC
-      `).all().map(normalizeDailyRow);
+      `).all() as DailyRollupRow[]).map(normalizeDailyRow);
     }
 
-    return this.db.prepare(`
+    return (this.db.prepare(`
       SELECT day, dictations, words, audioSeconds, processingMs, confidenceSum, confidenceCount
       FROM insights_daily_rollups
       WHERE day >= @dayStart
       ORDER BY day ASC
-    `).all({ dayStart }).map(normalizeDailyRow);
+    `).all({ dayStart }) as DailyRollupRow[]).map(normalizeDailyRow);
   }
 
   private buildTrends(rows: DailyRollupRow[], range: InsightsRange, now: number): InsightsTrendPoint[] {

--- a/app/src/renderer/app/components/eve-dropdown.ts
+++ b/app/src/renderer/app/components/eve-dropdown.ts
@@ -56,7 +56,7 @@ export function findTypeaheadIndex<T extends { label: string; disabled?: boolean
   for (let offset = 1; offset <= options.length; offset += 1) {
     const index = (startIndex + offset + options.length) % options.length;
     const option = options[index];
-    if (!option?.disabled && option.label.toLocaleLowerCase().startsWith(normalized)) {
+    if (option && !option.disabled && option.label.toLocaleLowerCase().startsWith(normalized)) {
       return index;
     }
   }

--- a/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
@@ -16,12 +16,12 @@
   let compatibilityOpen = $state(params.get('compatibility') === 'expanded');
   let selectedPreset = $state<SpeechModelPreset>(
     fixtureState === 'ready' || fixtureState === 'external'
-      ? SPEECH_MODEL_PRESETS[1]!
-      : SPEECH_MODEL_PRESETS[2]!,
+      ? SPEECH_MODEL_PRESETS[0]!
+      : SPEECH_MODEL_PRESETS[1]!,
   );
 
-  const currentPreset = SPEECH_MODEL_PRESETS[1]!;
-  const targetPreset = SPEECH_MODEL_PRESETS[2]!;
+  const currentPreset = SPEECH_MODEL_PRESETS[0]!;
+  const targetPreset = SPEECH_MODEL_PRESETS[1]!;
   const currentEngineStatus: EngineStatus = {
     current: currentPreset.engine,
     status: 'ready',

--- a/app/src/renderer/app/speech-model-presets.ts
+++ b/app/src/renderer/app/speech-model-presets.ts
@@ -1,7 +1,7 @@
 import type { EngineStatus, ModelDownloadState } from '$shared/types';
 
 export interface SpeechModelPreset {
-  id: 'english-performance' | 'recommended-multilingual' | 'maximum-multilingual-accuracy' | 'lightweight';
+  id: 'recommended-multilingual' | 'maximum-multilingual-accuracy' | 'lightweight';
   label: string;
   engine: 'nemotron' | 'whisper';
   setting: 'nemotron_model' | 'whisper_model';
@@ -12,7 +12,6 @@ export interface SpeechModelPreset {
 }
 
 export const SPEECH_MODEL_PRESETS: readonly SpeechModelPreset[] = [
-  { id: 'english-performance', label: 'English Performance', engine: 'nemotron', setting: 'nemotron_model', model: 'nvidia/nemotron-speech-streaming-en-0.6b', sizeGb: 2.3, language: 'English only', summary: 'A focused English option for capable hardware.' },
   { id: 'recommended-multilingual', label: 'Recommended Multilingual', engine: 'whisper', setting: 'whisper_model', model: 'large-v3-turbo', sizeGb: 1.5, language: 'Multilingual', summary: 'A balanced multilingual option.' },
   { id: 'maximum-multilingual-accuracy', label: 'Maximum Multilingual Accuracy', engine: 'whisper', setting: 'whisper_model', model: 'large-v3', sizeGb: 2.9, language: 'Multilingual', summary: 'A larger multilingual option for quality-focused use.' },
   { id: 'lightweight', label: 'Lightweight', engine: 'whisper', setting: 'whisper_model', model: 'small', sizeGb: 0.5, language: 'Multilingual', summary: 'A smaller option for constrained hardware.' },

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -120,7 +120,7 @@
     return setting?.value as T | undefined;
   }
 
-  let selectedEngine = $derived(getSettingValue<string>('engine') ?? 'nemotron');
+  let selectedEngine = $derived(getSettingValue<string>('engine') ?? 'whisper');
   let draftWhisperDevice = $derived(getSettingValue<string>('whisper_device') ?? 'auto');
   let selectedPreset = $derived(SPEECH_MODEL_PRESETS.find((preset) =>
     getSettingValue<string>('engine') === preset.engine && getSettingValue<string>(preset.setting) === preset.model
@@ -132,7 +132,7 @@
   );
   let engineRevertDisabled = $derived(shouldDisableEngineRevert(enginePreparationActive));
 
-  // Whether the current engine supports hotwords (Whisper: yes, Nemotron: no)
+  // Whether the current engine supports hotwords, as reported by the server.
   let hotwordsSupported = $derived(sharedEngineStatus?.info?.supports_hotwords ?? true);
 
   // Check visibility: should a setting be shown based on visible_when?
@@ -735,8 +735,8 @@
                 <path d="M12 8h.01"/>
               </svg>
               <div>
-                <p class="text-zinc-300">Hotwords are not supported with the Nemotron engine.</p>
-                <p class="mt-1 text-xs text-zinc-500">Switch to Faster-Whisper to use hotwords.</p>
+                <p class="text-zinc-300">Hotwords are not supported by the current engine.</p>
+                <p class="mt-1 text-xs text-zinc-500">Choose a compatible engine to enable hotwords.</p>
               </div>
             </div>
           {/if}
@@ -967,17 +967,6 @@
           </SettingsRow>
         {/if}
 
-        {#if serverSettings.nemotron_model && isVisible(serverSettings.nemotron_model)}
-          <SettingsRow label={serverSettings.nemotron_model.label} description="Raw Nemotron model name or path">
-            <input
-              aria-label={serverSettings.nemotron_model.label}
-              value={getSettingValue<string>('nemotron_model') ?? String(serverSettings.nemotron_model.value)}
-              oninput={(e) => updateEngineSetting('nemotron_model', e.currentTarget.value)}
-              disabled={externalMode}
-              class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-56"
-            />
-          </SettingsRow>
-        {/if}
         {#if serverSettings.whisper_language && isVisible(serverSettings.whisper_language)}
           <SettingsRow label={serverSettings.whisper_language.label} description={serverSettings.whisper_language.description}>
             <input
@@ -987,20 +976,6 @@
               disabled={externalMode}
               class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-28"
             />
-          </SettingsRow>
-        {/if}
-        {#if serverSettings.nemotron_device && isVisible(serverSettings.nemotron_device)}
-          <SettingsRow label="Device" description="Hardware device for inference">
-            <EveDropdown
-              label="Nemotron device"
-              value={String(getSettingValue('nemotron_device') ?? serverSettings.nemotron_device.value)}
-              options={toDropdownOptions(getOptions('nemotron_device'))}
-              onchange={(value) => updateEngineSetting('nemotron_device', value)}
-              disabled={externalMode}
-            />
-            {#each disabledOptionReasons(getOptions('nemotron_device')) as reason}
-              <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
-            {/each}
           </SettingsRow>
         {/if}
         {#if serverSettings.whisper_device && isVisible(serverSettings.whisper_device)}

--- a/app/tests/server-setting-options.test.ts
+++ b/app/tests/server-setting-options.test.ts
@@ -70,6 +70,6 @@ describe('Server setting option compatibility metadata', () => {
     expect(settingsView).toContain('getWhisperComputeOptions()');
     expect(settingsView).toContain("disabledOptionReasons(getWhisperComputeOptions())");
     expect(settingsView).toContain("disabledOptionReasons(getOptions('whisper_device'))");
-    expect(settingsView).toContain("disabledOptionReasons(getOptions('nemotron_device'))");
+    expect(settingsView).not.toContain("disabledOptionReasons(getOptions('nemotron_device'))");
   });
 });

--- a/app/tests/settings-layout.test.ts
+++ b/app/tests/settings-layout.test.ts
@@ -98,7 +98,7 @@ describe('Phase 1 Settings layout contracts', () => {
     expect(settingsView).toContain('aria-pressed={settings.holdToTalk}');
     expect(settingsView).toContain('aria-pressed={!settings.holdToTalk}');
     expect(settingsView).toContain('data-hotwords-editor');
-    expect(settingsView.match(/<EveDropdown\b/g)?.length).toBe(7);
+    expect(settingsView.match(/<EveDropdown\b/g)?.length).toBe(6);
   });
 
   test('keeps the Phase 2 General subgroup foundation aligned with the row primitive', () => {

--- a/app/tests/settings-speech-cohesion.test.ts
+++ b/app/tests/settings-speech-cohesion.test.ts
@@ -70,7 +70,7 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(chooser).toContain('externalMode || unavailable(preset)');
     expect(settingsView).toContain("'whisper_compute_type'");
     expect(settingsView).toContain("'whisper_language'");
-    expect(settingsView).toContain("'nemotron_device'");
+    expect(settingsView).not.toContain("'nemotron_device'");
     expect(settingsView).toContain("'whisper_device'");
     expect(settingsView).toContain("'unload_before_swap'");
     expect(settingsView).toContain('data-compatibility-footer');

--- a/app/tests/settings-speech-rendered.test.mjs
+++ b/app/tests/settings-speech-rendered.test.mjs
@@ -1,9 +1,11 @@
 import { afterAll, describe, expect, test } from 'bun:test';
-import { existsSync, promises as fs } from 'node:fs';
+import { existsSync, promises as fs, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, isAbsolute, relative, resolve } from 'node:path';
 
 const appRoot = resolve(import.meta.dir, '..');
+const settingsViewSource = readFileSync(new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url), 'utf8');
+const settingsMarkup = settingsViewSource.replace(/<script[\s\S]*?<\/script>/, '');
 const fixtureTempRoot = resolve(tmpdir());
 const screenshotDir = resolve(fixtureTempRoot, 'eve-phase2-settings-screenshots');
 const vitePort = 52000 + (process.pid % 100);
@@ -39,7 +41,7 @@ async function cleanupUserData(target) {
 }
 
 async function waitForFixtureServer() {
-  for (let attempt = 0; attempt < 60; attempt += 1) {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
     try {
       const response = await fetch(fixtureUrl);
       if (response.ok) return;
@@ -92,6 +94,12 @@ const result = await runElectron();
 const { measurements } = result;
 
 describe('rendered Phase 2 Settings/Speech fixture', () => {
+  test('keeps the alpha Settings markup free of deferred engine names and controls', () => {
+    expect(settingsMarkup).not.toContain('Nemotron');
+    expect(settingsMarkup).not.toContain('nemotron_model');
+    expect(settingsMarkup).not.toContain('nemotron_device');
+  });
+
   test('keeps the General and Speech fixture inside one page scroll owner at all zooms', () => {
     expect(measurements.length).toBe(36);
     for (const measurement of measurements) {
@@ -108,7 +116,7 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
       const stateMeasurements = measurements.filter((measurement) => measurement.view === 'speech' && measurement.state === state && !measurement.compatibility);
       expect(stateMeasurements.length).toBe(6);
       for (const measurement of stateMeasurements) {
-        expect(measurement.optionCount).toBe(4);
+        expect(measurement.optionCount).toBe(3);
         expect(measurement.checkedCount).toBe(1);
         expect(measurement.optionContained).toBeTrue();
         expect(measurement.focus.focusWithin).toBeTrue();
@@ -136,9 +144,8 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
   });
 
   test('keeps the renderer mounted while selecting every curated model', () => {
-    expect(result.interactions).toHaveLength(4);
+    expect(result.interactions).toHaveLength(3);
     expect(result.interactions.map((interaction) => interaction.label)).toEqual([
-      'English Performance, Selected',
       'Recommended Multilingual, Current',
       'Maximum Multilingual Accuracy, Selected',
       'Lightweight, Selected',
@@ -146,7 +153,7 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
     for (const interaction of result.interactions) {
       expect(interaction.checked).toBeTrue();
       expect(interaction.panelPresent).toBeTrue();
-      expect(interaction.optionCount).toBe(4);
+      expect(interaction.optionCount).toBe(3);
       expect(interaction.rendererFailed).toBeFalse();
       expect(interaction.scrollDelta).toBeLessThanOrEqual(1);
     }

--- a/app/tests/shared-layout-dropdown.test.ts
+++ b/app/tests/shared-layout-dropdown.test.ts
@@ -99,7 +99,7 @@ describe('shared primary-page and dropdown foundation', () => {
   });
 
   test('skips a transiently missing option during typeahead', () => {
-    const sparseOptions = [undefined, { label: 'Alpha' }] as unknown as readonly typeof options;
+    const sparseOptions = [undefined, { label: 'Alpha' }] as unknown as Readonly<typeof options>;
 
     expect(findTypeaheadIndex(sparseOptions, 'a')).toBe(1);
   });

--- a/app/tests/shared-layout-dropdown.test.ts
+++ b/app/tests/shared-layout-dropdown.test.ts
@@ -98,6 +98,12 @@ describe('shared primary-page and dropdown foundation', () => {
     expect(findTypeaheadIndex(options, 'missing')).toBe(-1);
   });
 
+  test('skips a transiently missing option during typeahead', () => {
+    const sparseOptions = [undefined, { label: 'Alpha' }] as unknown as readonly typeof options;
+
+    expect(findTypeaheadIndex(sparseOptions, 'a')).toBe(1);
+  });
+
   test('constrains the listbox to the viewport and flips above near the bottom edge', () => {
     const below = calculateDropdownPosition({
       top: 80,

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -4,6 +4,11 @@ import { SPEECH_MODEL_PRESETS, hasPendingCompatibilityChanges, presetDownloadLab
 
 describe('speech model presets', () => {
   test('keeps the three exact shipped mappings and factual established sizes', () => {
+    expect(SPEECH_MODEL_PRESETS.map(({ id }) => id)).toEqual([
+      'recommended-multilingual',
+      'maximum-multilingual-accuracy',
+      'lightweight',
+    ]);
     expect(SPEECH_MODEL_PRESETS.map(({ label, engine, model, sizeGb }) => ({ label, engine, model, sizeGb }))).toEqual([
       { label: 'Recommended Multilingual', engine: 'whisper', model: 'large-v3-turbo', sizeGb: 1.5 },
       { label: 'Maximum Multilingual Accuracy', engine: 'whisper', model: 'large-v3', sizeGb: 2.9 },

--- a/app/tests/speech-model-presets.test.ts
+++ b/app/tests/speech-model-presets.test.ts
@@ -3,15 +3,15 @@ import { readFileSync } from 'node:fs';
 import { SPEECH_MODEL_PRESETS, hasPendingCompatibilityChanges, presetDownloadLabel, presetMatchesCurrentEngine, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../src/renderer/app/speech-model-presets';
 
 describe('speech model presets', () => {
-  test('keeps the four exact supported mappings and factual established sizes', () => {
+  test('keeps the three exact shipped mappings and factual established sizes', () => {
     expect(SPEECH_MODEL_PRESETS.map(({ label, engine, model, sizeGb }) => ({ label, engine, model, sizeGb }))).toEqual([
-      { label: 'English Performance', engine: 'nemotron', model: 'nvidia/nemotron-speech-streaming-en-0.6b', sizeGb: 2.3 },
       { label: 'Recommended Multilingual', engine: 'whisper', model: 'large-v3-turbo', sizeGb: 1.5 },
       { label: 'Maximum Multilingual Accuracy', engine: 'whisper', model: 'large-v3', sizeGb: 2.9 },
       { label: 'Lightweight', engine: 'whisper', model: 'small', sizeGb: 0.5 },
     ]);
-    expect(presetPatch(SPEECH_MODEL_PRESETS[0])).toEqual({ engine: 'nemotron', nemotron_model: 'nvidia/nemotron-speech-streaming-en-0.6b' });
-    expect(presetPatch(SPEECH_MODEL_PRESETS[1])).toEqual({ engine: 'whisper', whisper_model: 'large-v3-turbo' });
+    expect(SPEECH_MODEL_PRESETS.every((preset) => preset.engine === 'whisper')).toBeTrue();
+    expect(presetPatch(SPEECH_MODEL_PRESETS[0])).toEqual({ engine: 'whisper', whisper_model: 'large-v3-turbo' });
+    expect(presetPatch(SPEECH_MODEL_PRESETS[1])).toEqual({ engine: 'whisper', whisper_model: 'large-v3' });
   });
 
   test('does not warn for a pure staged preset patch but warns for an additional pending model', () => {
@@ -28,7 +28,7 @@ describe('speech model presets', () => {
   });
 
   test('promotes a selected preset only when its actual engine status is ready', () => {
-    const preset = SPEECH_MODEL_PRESETS[1];
+    const preset = SPEECH_MODEL_PRESETS[0];
     const oldWhisperDuringCrossEngineSwap = { current: 'whisper', status: 'loading', pending: { engine: 'nemotron' }, info: { id: 'whisper', name: 'Faster-Whisper', model: 'large-v3-turbo', languages: [], model_size_gb: 1.5 } };
     const oldTurboDuringSameEngineSwap = { current: 'whisper', status: 'loading', pending: { engine: 'whisper' }, info: { id: 'whisper', name: 'Faster-Whisper', model: 'large-v3-turbo', languages: [], model_size_gb: 1.5 } };
     expect(presetMatchesCurrentEngine(preset, oldWhisperDuringCrossEngineSwap)).toBeTrue();
@@ -41,12 +41,14 @@ describe('speech model presets', () => {
 
   test('keeps selection and preparation explicit in the Settings surface', () => {
     const settings = readFileSync(new URL('../src/renderer/app/views/SettingsView.svelte', import.meta.url), 'utf8');
+    const settingsMarkup = settings.replace(/<script[\s\S]*?<\/script>/, '');
     const chooser = readFileSync(new URL('../src/renderer/app/components/SpeechModelChooser.svelte', import.meta.url), 'utf8');
     const transaction = readFileSync(new URL('../src/renderer/app/engine-settings-transaction.ts', import.meta.url), 'utf8');
     expect(chooser).toContain('type="radio"');
     expect(chooser).toContain('name={`speech-model-preset-${componentId}`}');
     expect(chooser).toContain('Apply and prepare model confirms the change.');
     expect(settings).toContain('Apply and prepare model');
+    expect(settings).toContain("getSettingValue<string>('engine') ?? 'whisper'");
     expect(settings).toContain('serverStatusState');
     expect(settings).toContain('shouldRetryServerSettings');
     expect(settings).toContain('shouldClearServerSettings');
@@ -56,7 +58,9 @@ describe('speech model presets', () => {
     expect(transaction).toContain("status.pending?.status === 'error'");
     expect(settings).toContain('sharedEngineStatus?.pending?.message ?? sharedEngineStatus?.message');
     expect(settings).toContain("'Retry preparation'");
-    expect(settings).toContain("'nemotron_model'");
+    expect(settingsMarkup).not.toContain('Nemotron');
+    expect(settingsMarkup).not.toContain('nemotron_model');
+    expect(settingsMarkup).not.toContain('nemotron_device');
     expect(settings).toContain("'whisper_language'");
     const config = readFileSync(new URL('../../server/src/config.py', import.meta.url), 'utf8');
     expect(config).toContain('"medium"');
@@ -72,6 +76,6 @@ describe('speech model presets', () => {
     expect(stagedPresetFromPending({ whisper_compute_type: 'int8' })).toBeNull();
     expect(stagedPresetFromPending({ engine: 'whisper', whisper_model: 'medium' })).toBeNull();
     expect(stagedPresetFromPending({ engine: 'whisper', whisper_model: 'large-v3-turbo', whisper_compute_type: 'int8' })?.id).toBe('recommended-multilingual');
-    expect(stagedPresetFromPending({ engine: 'nemotron', nemotron_model: 'nvidia/nemotron-speech-streaming-en-0.6b', nemotron_device: 'cuda' })?.id).toBe('english-performance');
+    expect(stagedPresetFromPending({ engine: 'nemotron', nemotron_model: 'nvidia/nemotron-speech-streaming-en-0.6b', nemotron_device: 'cuda' })).toBeNull();
   });
 });

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -24,9 +24,10 @@ uv run pytest
 uv run python -m src.main
 ```
 
-Use `uv sync --extra all --frozen` only when preparing the shipped closure that
-includes both engines. Development commands must use the current clone, never a
-copied user environment.
+Use `uv sync --extra release --frozen` when preparing the shipped Whisper-only
+closure. The experimental `nemotron` extra remains available for deferred
+repair work, but is not shipped or user-selectable in this alpha. Development
+commands must use the current clone, never a copied user environment.
 
 ## Windows package preparation
 
@@ -34,7 +35,7 @@ The supported installer is `nsis-web`. Before a release-authorized package attem
 
 ```powershell
 Set-Location server
-uv sync --extra all --frozen
+uv sync --extra release --frozen
 ../scripts/prepare-python-runtime.ps1 -ServerDir .
 
 Set-Location ../app

--- a/docs/installer-dependencies.md
+++ b/docs/installer-dependencies.md
@@ -7,16 +7,16 @@
 
 ## Executive Summary
 
-The Murmur installer bundles a self-contained Python environment (no system Python needed) and the Electron app. GPU acceleration depends on CUDA runtime libraries that are bundled via PyTorch when both engines are installed, and **AI models are not included in the installer** — they download on first run. The release pipeline now installs all engines and ships a nsis-web installer with payload artifacts; remaining risk areas are GPU drivers, Visual C++ Redistributable availability, and first-run model download bandwidth.
+The Murmur installer bundles a self-contained Python environment (no system Python needed) and the Electron app. The v0.8.1 alpha ships Faster-Whisper as its sole selectable engine, with locked CUDA PyTorch in the `release` extra for GPU support. Nemotron remains source-only and deferred for repair work; it is not shipped or user-selectable. **AI models are not included in the installer** — they download on first run. Remaining risk areas are GPU drivers, Visual C++ Redistributable availability, and first-run model download bandwidth.
 
 ### Key Findings
 
 | Finding | Severity | Status |
 |---------|----------|--------|
-| Release workflow installs transcription engines | **Critical** | Resolved |
+| Release workflow installs the shipped Whisper closure | **Critical** | Resolved |
 | NSIS 2GB installer size limit vs. 5+ GB bundled venv | **Critical** | Resolved via nsis-web |
-| CUDA DLL gap when using Whisper-only (no PyTorch) | **High** | Mitigated (default build + diagnostics) |
-| NeMo Toolkit not officially supported on Windows pip | **Medium** | Known risk |
+| CUDA DLL gap when using the plain Whisper extra (no PyTorch) | **High** | Resolved for the shipped `release` extra |
+| NeMo Toolkit not officially supported on Windows pip | **Medium** | Deferred repair risk |
 | Visual C++ Redistributable check/bundling | **Low** | Resolved (runtime warning + link) |
 | Models download on first run (~2-4 GB) | **Info** | Documented + UI messaging |
 
@@ -44,14 +44,14 @@ Per the `extraResources` config in `app/package.json`:
 - dependency test suites, static `.lib` linker archives, and PyTorch headers
 - standalone-Python development/UI assets (`include`, `libs`, `idlelib`, `tkinter`, Tcl)
 
-These exclusions remove build-time material only. Release validation imports both
-engines and runs a WebSocket transcription smoke against the packaged runtime
-layout before publication.
+These exclusions remove build-time material only. Release validation imports the
+shipped Whisper closure, proves NeMo and torchaudio are absent, and checks that
+packaged engine discovery reports Whisper available and Nemotron unavailable.
 
 ### What's NOT in the installer at all
 
 - AI models (downloaded on first run)
-- CUDA toolkit / cuDNN (system dependency; not required for default build)
+- CUDA toolkit / cuDNN (not required as system dependencies; the release extra supplies the packaged runtime DLLs)
 - Visual C++ Redistributable (system dependency; app warns and links installer if missing)
 - GPU drivers (system dependency)
 
@@ -69,13 +69,15 @@ layout before publication.
 | **Internet** | Required for nsis-web install (payload download) and first-run model download |
 | **Visual C++ Redistributable** | Required by Electron native modules and Python C extensions. Usually pre-installed on Windows 10/11. If missing, the app warns and links to [vc_redist.x64.exe](https://aka.ms/vs/17/release/vc_redist.x64.exe). |
 
-### 2.2 For GPU Acceleration (Recommended)
+### 2.2 For Shipped Whisper GPU Acceleration (Recommended)
 
 | Requirement | Details |
 |-------------|---------|
 | **NVIDIA GPU** | Any CUDA-capable GPU (GTX 900 series or newer) |
 | **GPU Driver** | >= 525.x (for CUDA 12.4 compatibility). Current recommended: R535 LTS or R570+. The app warns if the driver is too old or `nvidia-smi` is unavailable. |
-| **VRAM** | Whisper: ~1.5 GB (int8) to ~2.5 GB (fp16). Nemotron: ~5 GB base + growth, 8 GB+ recommended |
+| **VRAM** | Whisper: ~1.5 GB (int8) to ~2.5 GB (fp16) |
+
+Nemotron has a larger VRAM profile but is deferred and not shipped or user-selectable in this alpha.
 
 ### 2.3 CPU-Only Mode
 
@@ -101,7 +103,7 @@ The release workflow verifies imports and starts `/health` with this exact split
 
 ## 4. CUDA Runtime Libraries and Diagnostics
 
-This is the most complex dependency story and the most likely source of end-user GPU failures. The default release build installs both engines, so PyTorch provides CUDA DLLs, and the app surfaces diagnostics if anything is missing.
+This is the most complex dependency story and the most likely source of end-user GPU failures. The release build installs Whisper plus locked CUDA PyTorch, so PyTorch provides the CUDA DLLs required by the shipped engine, and the app surfaces diagnostics if anything is missing.
 
 ### 4.1 How CUDA DLLs Are (or Aren't) Provided
 
@@ -118,10 +120,10 @@ When the server starts:
 
 1. The Electron server launcher prepends the packaged `.venv/Lib/site-packages/torch/lib/` directory to the child `PATH`.
 2. `runtime_paths.py` registers that same directory with `os.add_dll_directory()` before settings and optional engine imports load native code.
-3. When the engine manager constructs Nemotron, `nemotron.py` imports PyTorch/NeMo; Whisper imports PyTorch before CTranslate2. Both native paths therefore resolve against the same packaged directory.
-4. Nemotron runs a real CUDA/cuDNN convolution before a candidate engine is activated; DLL entry-point or device initialization failures become a recoverable preparation error.
+3. Whisper imports PyTorch before CTranslate2. Both native paths therefore resolve against the same packaged directory.
+4. Release verification checks the packaged Whisper import closure and engine discovery without importing the deferred Nemotron stack.
 
-**The boundary:** If only the Whisper extra is installed (no Nemotron/PyTorch), CTranslate2 has no bundled CUDA DLL set available, so GPU mode remains unavailable; CPU mode is unaffected.
+**The boundary:** The `release` extra adds locked CUDA PyTorch to `murmur[whisper]`, so the shipped Whisper path has its packaged CUDA DLL set. The plain `whisper` extra remains CPU-oriented. Nemotron retains a separate optional extra for deferred repair work and is not in the alpha runtime closure.
 
 ### 4.3 Runtime Diagnostics
 
@@ -135,29 +137,28 @@ These warnings are actionable and include guidance or links where possible.
 
 ### 4.4 Scenarios Matrix
 
-| Build Config | PyTorch? | cuBLAS/cuDNN available? | Whisper GPU? | Nemotron GPU? |
-|-------------|----------|------------------------|-------------|--------------|
-| `uv sync --extra all` | Yes (cu124) | Yes, via packaged torch/lib/ | Yes (if driver/runtime preflight passes) | Yes (if CUDA/cuDNN preflight passes) |
-| `uv sync --extra nemotron` | Yes (cu124) | Yes, via packaged torch/lib/ | N/A (not installed) | Yes (if CUDA/cuDNN preflight passes) |
-| `uv sync --extra whisper` | **No** | **No** | **No — GPU broken** | N/A (not installed) |
-| `uv sync` (bare) | **No** | **No** | N/A (not installed) | N/A (not installed) |
+| Build Config | PyTorch? | cuBLAS/cuDNN available? | Whisper GPU? | Nemotron |
+|-------------|----------|------------------------|-------------|----------|
+| `uv sync --extra release` | Yes (cu124) | Yes, via packaged torch/lib/ | Yes (if the driver supports it) | Deferred |
+| `uv sync --extra all` | Yes (cu124) | Yes, via packaged torch/lib/ | Yes (if the driver supports it) | Experimental only |
+| `uv sync --extra nemotron` | Yes (cu124) | Yes, via packaged torch/lib/ | N/A (not installed) | Deferred repair |
+| `uv sync --extra whisper` | **No** | **No** | CPU only | N/A |
+| `uv sync` (bare) | **No** | **No** | N/A (not installed) | N/A |
 
 ### 4.5 Recommendation
 
-Build with `--extra all` to ensure PyTorch's locked cu124 wheel and its bundled CUDA DLLs are available for both engines. Eve makes the packaged `torch/lib` directory first in the Windows search order and validates the Nemotron CUDA/cuDNN operation before activation.
+Build with `--extra release` to ensure the shipped Whisper alpha has PyTorch's locked cu124 wheel and its bundled CUDA DLLs. Eve makes the packaged `torch/lib` directory first in the Windows search order and release verification checks that Whisper is discoverable while Nemotron remains unavailable.
 
-For a whisper-only build, you would need to either:
-- Add `torch` as a dependency of the whisper extra (heavy, ~2.5 GB)
-- Install `nvidia-cublas-cu12` and `nvidia-cudnn-cu12` pip packages in the venv
-- Require the end-user to install CUDA Toolkit 12.x separately
+For the alpha's Whisper-only build, the `release` extra supplies the locked PyTorch
+CUDA runtime. No separate CUDA Toolkit or user-installed NeMo stack is required.
 
 ---
 
 ## 5. Build Pipeline Status (Resolved Blockers)
 
-### 5.1 Release Workflow Installs Engines (Resolved)
+### 5.1 Release Workflow Installs the Whisper Closure (Resolved)
 
-The release workflow now runs `uv sync --extra all`, so both Whisper and Nemotron extras are included in the packaged venv. This also ensures PyTorch's CUDA DLLs are present for GPU acceleration in the default build.
+The release workflow now runs `uv sync --extra release`, so the packaged venv contains Faster-Whisper and locked CUDA PyTorch without NeMo or torchaudio. This provides the CUDA DLLs needed for the shipped Whisper engine while keeping Nemotron deferred and unavailable in the alpha.
 
 ### 5.2 NSIS 2GB Installer Size Limit (Resolved via nsis-web)
 
@@ -170,9 +171,11 @@ NeMo Toolkit is **not officially supported on Windows via pip**. Known issues in
 - Dependency `mamba-ssm` fails to build on Windows
 - NVIDIA recommends Docker containers for NeMo
 
-The release workflow runs on `windows-latest`, so if any NeMo transitive dependency requires compilation from source, the build will fail.
+The shipped release workflow does not install this deferred extra. A separately
+authorized repair workflow would still need to account for Windows compilation
+failures if any NeMo transitive dependency requires source builds.
 
-**Mitigation:** Pre-built wheels exist for most NeMo dependencies on Windows. As long as `uv sync` resolves to pre-built wheels only, installation works. But this is fragile and could break with any NeMo version bump.
+**Mitigation for deferred work:** Pre-built wheels exist for most NeMo dependencies on Windows. As long as a repair-only `uv sync` resolves to pre-built wheels only, installation works. This remains fragile and is outside the shipped alpha closure.
 
 ---
 
@@ -182,8 +185,9 @@ Models are **not bundled** in the installer. They download from Hugging Face on 
 
 | Engine | Default Model | Download Size | Cache Location |
 |--------|--------------|---------------|----------------|
-| Nemotron | `nvidia/nemotron-speech-streaming-en-0.6b` | ~2.47 GB | `~/.cache/huggingface/hub/` |
 | Whisper | `large-v3-turbo` (CTranslate2 format) | ~1.6 GB | `~/.cache/huggingface/hub/` |
+
+The Nemotron checkpoint remains deferred and is not selectable or shipped in this alpha.
 
 ### Implications for End Users
 
@@ -207,21 +211,20 @@ From `server/src/transcription/vram.py`:
 
 | Engine | Base VRAM | Growth Rate | Min Recommended | Typical Usage |
 |--------|-----------|-------------|-----------------|---------------|
-| Nemotron | 5.0 GB | 100 MB/sec of audio | 8.0 GB | 5-8 GB for short recordings |
 | Whisper (fp16) | 3.1 GB | 57 MB/sec of audio | — | ~2.5 GB (benchmarked) |
 | Whisper (int8) | ~2.0 GB | ~40 MB/sec of audio | — | ~1.5 GB (benchmarked) |
 
-The server has VRAM-aware engine selection: if Nemotron is selected but VRAM is below 8 GB, it auto-falls back to Whisper (unless the user explicitly chose Nemotron).
+The server retains VRAM-aware engine logic for deferred engines, while the packaged alpha exposes Whisper only.
 
 ### GPU Compatibility Quick Guide
 
 | GPU | VRAM | Whisper | Nemotron |
 |-----|------|---------|----------|
-| GTX 1050/1650 (4 GB) | 4 GB | Yes (int8) | No (auto-fallback) |
-| GTX 1060/1660 (6 GB) | 6 GB | Yes | Marginal (short recordings) |
-| RTX 3060/4060 (8 GB) | 8 GB | Yes | Yes |
-| RTX 3070/4070 (8-12 GB) | 8-12 GB | Yes | Yes (comfortable) |
-| RTX 3080/4080+ (12-16 GB) | 12-16 GB | Yes | Yes (long recordings) |
+| GTX 1050/1650 (4 GB) | 4 GB | Yes (int8) | Deferred |
+| GTX 1060/1660 (6 GB) | 6 GB | Yes | Deferred |
+| RTX 3060/4060 (8 GB) | 8 GB | Yes | Deferred |
+| RTX 3070/4070 (8-12 GB) | 8-12 GB | Yes | Deferred |
+| RTX 3080/4080+ (12-16 GB) | 12-16 GB | Yes | Deferred |
 
 ---
 
@@ -257,7 +260,7 @@ https://aka.ms/vs/17/release/vc_redist.x64.exe
 
 ### Completed in the current release pipeline
 
-1. Release workflow installs engines with `uv sync --extra all`
+1. Release workflow installs the shipped Whisper closure with `uv sync --extra release`
 2. nsis-web packaging avoids the 2GB limit and ships payload artifacts with releases
 3. Runtime diagnostics warn about missing VC++ Redistributable, CUDA DLLs, or outdated drivers
 4. First-run model download UX includes status messaging and retry guidance
@@ -266,7 +269,7 @@ https://aka.ms/vs/17/release/vc_redist.x64.exe
 ### Remaining opportunities
 
 1. Offline model bundling option for air-gapped or enterprise deployments
-2. Optional smaller whisper-only build with clear GPU limitations
+2. Deferred Nemotron repair and a later optional engine build
 3. Additional CUDA DLL verification or auto-repair
 
 ---

--- a/docs/speech-model-selection.md
+++ b/docs/speech-model-selection.md
@@ -1,13 +1,16 @@
 # Speech model selection
 
-Eve v0.8 presents four curated choices over the engines already bundled with the app:
+The v0.8.1 alpha presents three curated Whisper choices. Nemotron remains in
+the source tree and optional `nemotron` extra for deferred repair work; it is
+not shipped or user-selectable in this alpha:
 
-- English Performance: Nemotron Speech with `nvidia/nemotron-speech-streaming-en-0.6b` (English only, approximately 2.3 GB).
 - Recommended Multilingual: Faster-Whisper `large-v3-turbo` (multilingual, approximately 1.5 GB).
 - Maximum Multilingual Accuracy: Faster-Whisper `large-v3` (multilingual, approximately 2.9 GB).
 - Lightweight: Faster-Whisper `small` (multilingual, approximately 0.5 GB).
 
-The labels describe relative use cases, not Eve benchmark claims. Engine availability comes from the running server; a missing engine runtime is not installed by this UI.
+The labels describe relative use cases, not Eve benchmark claims. The packaged
+alpha exposes Whisper only; engine availability still comes from the running
+server, and a missing engine runtime is not installed by this UI.
 
 Selecting a choice is local to the renderer. **Apply and prepare model** is the explicit action that persists the existing server settings and begins the existing engine/model swap path. Eve keeps the current engine active while the selected model downloads or loads where the server supports that behavior. A selected choice is not called current until the server reports that engine and model ready.
 

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -197,6 +197,14 @@ if ($LASTEXITCODE -ne 0) {
     throw "Packaged engine discovery probe failed with exit code $LASTEXITCODE"
 }
 $discovery = $discoveryOutput | ConvertFrom-Json
+$requiredEngineProperties = @("whisper", "nemotron")
+$discoveryPropertyNames = @($discovery.PSObject.Properties.Name)
+$missingEngineProperties = @(
+    $requiredEngineProperties | Where-Object { $_ -notin $discoveryPropertyNames }
+)
+if ($missingEngineProperties.Count -gt 0) {
+    throw "Packaged engine discovery omitted required properties: $($missingEngineProperties -join ', ')"
+}
 $whisperAvailable = [bool]$discovery.whisper
 $nemotronAvailable = [bool]$discovery.nemotron
 if (-not $whisperAvailable -or $nemotronAvailable) {

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -23,6 +23,20 @@ function Assert-Path {
     }
 }
 
+function Assert-NoPackage {
+    param([string]$SitePackages, [string]$Description)
+    $forbidden = @(Get-ChildItem -LiteralPath $SitePackages -Directory -Force -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Name -eq "nemo" -or
+            $_.Name -like "nemo_toolkit-*.dist-info" -or
+            $_.Name -eq "torchaudio" -or
+            $_.Name -like "torchaudio-*.dist-info"
+        })
+    if ($forbidden.Count -gt 0) {
+        throw "$Description found: $($forbidden.Name -join ', ')"
+    }
+}
+
 function Assert-Contains {
     param([string]$Value, [string]$Expected, [string]$Description)
     if ($Value -notlike "*$Expected*") {
@@ -126,11 +140,12 @@ Write-Step "Checking installed payload contents"
 $appExe = Join-Path $InstallDir "Eve.exe"
 $serverRoot = Join-Path $InstallDir "resources\server"
 $pythonExe = Join-Path $serverRoot ".runtime\python.exe"
+$sitePackages = Join-Path $serverRoot ".venv\Lib\site-packages"
 Assert-Path $appExe "Installed Eve.exe"
 Assert-Path $pythonExe "Bundled Python"
-Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\faster_whisper") "faster-whisper package"
-Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\torch") "torch package"
-Assert-Path (Join-Path $serverRoot ".venv\Lib\site-packages\nemo") "nemo package"
+Assert-Path (Join-Path $sitePackages "faster_whisper") "faster-whisper package"
+Assert-Path (Join-Path $sitePackages "torch") "torch package"
+Assert-NoPackage -SitePackages $sitePackages -Description "Deferred Nemotron packages"
 Assert-SelfContainedRuntime -RuntimePath (Join-Path $serverRoot ".runtime") -PythonExe $pythonExe
 
 Write-Step "Checking installed server health/version"
@@ -163,8 +178,30 @@ $env:MURMUR_WHISPER_DEVICE = "cpu"
 $env:MURMUR_WHISPER_COMPUTE_TYPE = "int8"
 $env:MURMUR_LOG_LEVEL = "INFO"
 $env:PYTHONNOUSERSITE = "1"
-$env:PYTHONPATH = Join-Path $serverRoot ".venv\Lib\site-packages"
-Invoke-Native $pythonExe -c "import faster_whisper, torch, nemo.collections.asr"
+$env:PYTHONPATH = $sitePackages
+Invoke-Native $pythonExe -c "import faster_whisper, torch"
+
+Write-Step "Checking packaged engine discovery"
+$discoveryProbe = @"
+import json
+import sys
+
+sys.path.insert(0, r"$serverRoot\src")
+from transcription.factory import discover_engines
+
+engines = {entry["id"]: bool(entry["available"]) for entry in discover_engines()}
+print(json.dumps(engines, sort_keys=True))
+"@
+$discoveryOutput = & $pythonExe -c $discoveryProbe
+if ($LASTEXITCODE -ne 0) {
+    throw "Packaged engine discovery probe failed with exit code $LASTEXITCODE"
+}
+$discovery = $discoveryOutput | ConvertFrom-Json
+$whisperAvailable = [bool]$discovery.whisper
+$nemotronAvailable = [bool]$discovery.nemotron
+if (-not $whisperAvailable -or $nemotronAvailable) {
+    throw "Packaged engine discovery mismatch: whisper=$whisperAvailable nemotron=$nemotronAvailable"
+}
 
 $process = Start-Process -FilePath $pythonExe `
     -ArgumentList @("src\main.py") `

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -22,6 +22,10 @@ nemotron = [
     "python-dateutil>=2.9.0.post0",
 ]
 all = ["murmur[whisper,nemotron]"]
+release = [
+    "murmur[whisper]",
+    "torch>=2.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -243,7 +243,9 @@ def test_packaged_resource_and_runtime_harness_guards() -> None:
     assert '"package": "bun run notices:generate && bun run build && electron-builder"' in package
     assert '"to": "legal"' in package
     assert ".runtime\\python.exe" in verify
-    assert "import faster_whisper, torch, nemo.collections.asr" in verify
+    assert "import faster_whisper, torch" in verify
+    assert "nemo.collections.asr" not in verify
+    assert "Deferred Nemotron packages" in verify
     assert 'Remove-Item -Path "env:$key"' in verify
 
 

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -191,12 +191,19 @@ def test_release_verification_requires_both_engine_discovery_properties() -> Non
     )
     required_properties = '$requiredEngineProperties = @("whisper", "nemotron")'
     missing_properties = "$missingEngineProperties"
+    missing_guard = "if ($missingEngineProperties.Count -gt 0) {"
+    missing_throw = 'throw "Packaged engine discovery omitted required properties: $($missingEngineProperties -join \', \')"'
     whisper_availability = "$whisperAvailable = [bool]$discovery.whisper"
 
     assert required_properties in contents
     assert missing_properties in contents
-    assert "Packaged engine discovery omitted required properties" in contents
-    assert contents.index(missing_properties) < contents.index(whisper_availability)
+    assert missing_guard in contents
+    assert missing_throw in contents
+    missing_properties_index = contents.index(missing_properties)
+    missing_guard_index = contents.index(missing_guard, missing_properties_index)
+    missing_throw_index = contents.index(missing_throw, missing_guard_index)
+    whisper_availability_index = contents.index(whisper_availability)
+    assert missing_properties_index < missing_guard_index < missing_throw_index < whisper_availability_index
 
 
 def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -161,6 +161,16 @@ def test_release_extra_is_whisper_torch_only_and_all_keeps_nemotron() -> None:
         {"name": "torch"},
     ]
 
+    locked_versions = {
+        package["name"]: package["version"]
+        for package in _load_server_lock()["package"]
+        if package["name"] in {"faster-whisper", "torch"}
+    }
+    assert locked_versions == {
+        "faster-whisper": "1.2.1",
+        "torch": "2.6.0+cu124",
+    }
+
 
 def test_release_verification_requires_only_the_shipped_engine_closure() -> None:
     contents = (ROOT / "scripts" / "release-verify.ps1").read_text(
@@ -173,6 +183,20 @@ def test_release_verification_requires_only_the_shipped_engine_closure() -> None
     assert "Deferred Nemotron packages" in contents
     assert "torchaudio" in contents
     assert "nemo.collections.asr" not in contents
+
+
+def test_release_verification_requires_both_engine_discovery_properties() -> None:
+    contents = (ROOT / "scripts" / "release-verify.ps1").read_text(
+        encoding="utf-8"
+    )
+    required_properties = '$requiredEngineProperties = @("whisper", "nemotron")'
+    missing_properties = "$missingEngineProperties"
+    whisper_availability = "$whisperAvailable = [bool]$discovery.whisper"
+
+    assert required_properties in contents
+    assert missing_properties in contents
+    assert "Packaged engine discovery omitted required properties" in contents
+    assert contents.index(missing_properties) < contents.index(whisper_availability)
 
 
 def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -7,6 +7,7 @@ from fnmatch import fnmatchcase
 from pathlib import Path
 import subprocess
 import sys
+import tomllib
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -16,6 +17,16 @@ def _load_package_json() -> dict:
     package_path = ROOT / "app" / "package.json"
     with package_path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def _load_server_pyproject() -> dict:
+    with (ROOT / "server" / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _load_server_lock() -> dict:
+    with (ROOT / "server" / "uv.lock").open("rb") as handle:
+        return tomllib.load(handle)
 
 
 def _extract_targets(target_value: object) -> list[str]:
@@ -129,6 +140,39 @@ def test_release_verification_targets_eve_with_legacy_payload_name() -> None:
     assert '"Eve.Web.Setup.$ExpectedVersion.exe"' in contents
     assert '"Eve.exe"' in contents
     assert '"murmur-$ExpectedVersion-x64.nsis.7z"' in contents
+
+
+def test_release_extra_is_whisper_torch_only_and_all_keeps_nemotron() -> None:
+    project = _load_server_pyproject()["project"]
+    extras = project["optional-dependencies"]
+
+    assert extras["release"] == ["murmur[whisper]", "torch>=2.0"]
+    assert extras["all"] == ["murmur[whisper,nemotron]"]
+    assert "nemo_toolkit[asr]>=2.2.0" in extras["nemotron"]
+    assert "torchaudio>=2.0" in extras["nemotron"]
+
+    murmur = next(
+        package
+        for package in _load_server_lock()["package"]
+        if package["name"] == "murmur"
+    )
+    assert murmur["optional-dependencies"]["release"] == [
+        {"name": "faster-whisper"},
+        {"name": "torch"},
+    ]
+
+
+def test_release_verification_requires_only_the_shipped_engine_closure() -> None:
+    contents = (ROOT / "scripts" / "release-verify.ps1").read_text(
+        encoding="utf-8"
+    )
+    assert 'Join-Path $sitePackages "faster_whisper"' in contents
+    assert 'Join-Path $sitePackages "torch"' in contents
+    assert "import faster_whisper, torch" in contents
+    assert "discover_engines" in contents
+    assert "Deferred Nemotron packages" in contents
+    assert "torchaudio" in contents
+    assert "nemo.collections.asr" not in contents
 
 
 def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2417,6 +2417,10 @@ nemotron = [
     { name = "torch" },
     { name = "torchaudio" },
 ]
+release = [
+    { name = "faster-whisper" },
+    { name = "torch" },
+]
 ui = [
     { name = "pyside6" },
     { name = "sounddevice" },
@@ -2443,6 +2447,7 @@ ui = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "faster-whisper", marker = "extra == 'whisper'", specifier = ">=1.1.0" },
+    { name = "murmur", extras = ["whisper"], marker = "extra == 'release'" },
     { name = "murmur", extras = ["whisper", "nemotron"], marker = "extra == 'all'" },
     { name = "nemo-toolkit", extras = ["asr"], marker = "extra == 'nemotron'", specifier = ">=2.2.0" },
     { name = "numpy", specifier = ">=1.26.0" },
@@ -2456,12 +2461,13 @@ requires-dist = [
     { name = "sounddevice", marker = "extra == 'ui'", specifier = ">=0.4.6" },
     { name = "soundfile", specifier = ">=0.12.0" },
     { name = "torch", marker = "extra == 'nemotron'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu124" },
+    { name = "torch", marker = "extra == 'release'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu124" },
     { name = "torchaudio", marker = "extra == 'nemotron'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu124" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", marker = "extra == 'dev'", specifier = ">=13.0" },
     { name = "websockets", marker = "extra == 'ui'", specifier = ">=13.0" },
 ]
-provides-extras = ["whisper", "nemotron", "all", "dev", "ui"]
+provides-extras = ["whisper", "nemotron", "all", "release", "dev", "ui"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

This PR ships a Whisper-only v0.8.1 alpha.

- The packaged Nemotron cold-load failure is documented by the preserved evidence: CTranslate2 4.6.3 shipped ctranslate2\cudnn64_9.dll 9.10.2.21 (SHA256 9EDBCDFF73B0AF070EB160B2CE66E59FECA04AA017351D8EEDCC5E8E149967D2), while Torch 2.6.0+cu124 shipped torch\lib\cudnn64_9.dll 9.1.0.70 (SHA256 C07CC47F2FA4A566593C7AF4AA7E57EDF09A985A0FDDD14CB8D6F456E252AF05). Windows Event 1000 faulted the CTranslate2 DLL with 0xc0000409 during Nemotron cold load. This alpha defers Nemotron and does not claim to fix that incompatibility.
- The release dependency closure ships Whisper plus locked CUDA Torch: offline export contains faster-whisper==1.2.1 and torch==2.6.0+cu124, and excludes nemo-toolkit and torchaudio.
- Nemotron remains in backend source and optional extras for later repair; user model caches and profiles are untouched.
- Curated presets and Advanced Settings expose Whisper only; Nemotron is not user-selectable in the alpha UI.
- Includes two minimal TypeScript baseline fixes: an explicit dropdown-option guard for noUncheckedIndexedAccess, and a trusted better-sqlite3 daily-rollup row cast at the DailyRollupRow[] query boundary.

## Local verification

- App tests: 245/245 passed.
- Server tests: 214/214 passed.
- bunx tsc -p tsconfig.json --noEmit: passed.
- bunx tsc -p tsconfig.main.json --noEmit: passed.
- Production build: passed.
- uv lock --check --offline: passed.
- Release closure proof: faster-whisper==1.2.1 and torch==2.6.0+cu124 present; nemo-toolkit and torchaudio absent.
- git diff --check: passed.

Refs #57

Issue #57 remains open; this PR does not close it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three curated Whisper speech-model options.
  * Set Whisper as the default speech engine.
  * Simplified advanced speech settings by removing unavailable Nemotron controls.
  * Improved typeahead behavior when options are temporarily unavailable.
  * Added Whisper-focused release packaging and verification.

* **Bug Fixes**
  * Corrected daily history results across date-filtered and all-time views.

* **Documentation**
  * Updated release, installation, model-selection, and build guidance for the Whisper-only alpha.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->