### PR TITLE
Fix release artifact manifest creation

### DIFF
--- a/scripts/release-artifacts.ps1
+++ b/scripts/release-artifacts.ps1
@@ -15,13 +15,14 @@ $version=$Matches[1]
 if($ExpectedCommit -notmatch '^[0-9a-f]{40}$'){throw 'ExpectedCommit must be a lowercase 40-character SHA.'}
 if($Mode -eq 'Verify' -and $ExpectedManifestSha256 -notmatch '^[0-9a-fA-F]{64}$'){throw 'ExpectedManifestSha256 must be 64 hex characters.'}
 $names=@("Eve.Web.Setup.$version.exe","murmur-$version-x64.nsis.7z",'latest.yml',"eve-v$version-artifact-manifest.json",'SHA256SUMS.txt','SHA512SUMS.txt','THIRD_PARTY_NOTICES.txt')
+$manifest=Join-Path $dir "eve-v$version-artifact-manifest.json"
+$requiredNames=@(if($Mode -eq 'Create'){$names | Where-Object {$_ -ne (Split-Path $manifest -Leaf)}}else{$names})
 $files=Get-ChildItem $dir -File
-$actual=@($files.Name | Sort-Object); $expected=@($names | Sort-Object)
-if((Compare-Object $actual $expected)){throw "Release asset allowlist mismatch. Expected exactly: $($names -join ', ')"}
+$actual=@($files.Name | Sort-Object); $expected=@($requiredNames | Sort-Object)
+if((Compare-Object $actual $expected)){throw "Release asset allowlist mismatch. Expected exactly: $($requiredNames -join ', ')"}
 foreach($file in $files){if($file.Length -ge 2100000000){throw "Asset exceeds 2.10 GB safety ceiling: $($file.Name)"}}
 $payload=Get-Item (Join-Path $dir "murmur-$version-x64.nsis.7z")
 if($payload.Length -ge 2050000000){throw "NSIS-web payload exceeds 2.05 GB release target: $($payload.Name)"}
-$manifest=Join-Path $dir "eve-v$version-artifact-manifest.json"
 if($Mode -eq 'Create'){
   $entries=@(); foreach($name in $names | Where-Object {$_ -ne (Split-Path $manifest -Leaf)}){$f=Get-Item (Join-Path $dir $name);$entries += [ordered]@{name=$f.Name;bytes=$f.Length;sha256=(Get-FileHash $f -Algorithm SHA256).Hash.ToLowerInvariant();sha512=(Get-FileHash $f -Algorithm SHA512).Hash.ToLowerInvariant()}}
   [ordered]@{schema=1;tag=$ExpectedTag;commit=$ExpectedCommit;version=$version;assets=$entries}|ConvertTo-Json -Depth 5|Set-Content $manifest -Encoding utf8

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -120,6 +120,30 @@ def _verify_release_fixture(
     )
 
 
+def _create_release_fixture(directory: Path) -> subprocess.CompletedProcess[str]:
+    pwsh = shutil.which("pwsh")
+    assert pwsh, "PowerShell 7 is required for release-control tests."
+    return subprocess.run(
+        [
+            pwsh,
+            "-NoProfile",
+            "-File",
+            str(ROOT / "scripts" / "release-artifacts.ps1"),
+            "-Mode",
+            "Create",
+            "-ArtifactDir",
+            str(directory),
+            "-ExpectedTag",
+            "v1.2.3",
+            "-ExpectedCommit",
+            RELEASE_COMMIT,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_release_workflow_is_manual_and_never_builds_or_uploads() -> None:
     workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     assert "workflow_dispatch:" in workflow
@@ -258,6 +282,21 @@ def test_release_artifacts_accepts_electron_builder_latest_yml_ordering(
     )
     result = _verify_release_fixture(tmp_path, manifest_sha256)
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_release_artifacts_create_generates_and_verifies_manifest_from_six_inputs(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "eve-v1.2.3-artifact-manifest.json"
+    _write_release_fixture(tmp_path, _latest_yml())
+    manifest_path.unlink()
+
+    create = _create_release_fixture(tmp_path)
+
+    assert create.returncode == 0, create.stdout + create.stderr
+    assert manifest_path.is_file()
+    verify = _verify_release_fixture(tmp_path, _digest(manifest_path, "sha256"))
+    assert verify.returncode == 0, verify.stdout + verify.stderr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refs #57

Create now accepts exactly the six staged pre-manifest inputs, writes the manifest, and Verify continues to require the exact seven-file artifact set.

- Adds a Create-to-Verify regression.
- No packaging rerun or release-asset mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release packages can now generate their artifact manifest automatically from the required release inputs.
  * Generated manifests are validated during verification to confirm package completeness and integrity.

* **Bug Fixes**
  * Improved release validation so manifest requirements are applied correctly during package creation and verification.
  * Existing asset size and payload checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->