### PR TITLE
Prepare v0.8.2-alpha.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eve for Windows
 
-<p><img src="https://img.shields.io/badge/v0.8.2-alpha.1-orange?style=flat-square" alt="v0.8.2-alpha.1"> <strong>Source status: v0.8.1 pre-alpha · unreleased</strong></p>
+<p><img src="https://img.shields.io/badge/v0.8.2-alpha.1-orange?style=flat-square" alt="v0.8.2-alpha.1"> <strong>Source status: v0.8.2-alpha.1 pre-alpha · unreleased</strong></p>
 
 ## Local-first dictation that stays in your flow
 
@@ -38,7 +38,7 @@ Models are downloaded from their public Hugging Face repositories the first time
 | **Small — Lightweight** | A smaller download for constrained hardware | [faster-whisper-small](https://huggingface.co/Systran/faster-whisper-small) |
 | **Medium / Tiny — Advanced** | Raw engine choices for users who want to tune the trade-off | [faster-whisper-medium](https://huggingface.co/Systran/faster-whisper-medium) / [faster-whisper-tiny](https://huggingface.co/Systran/faster-whisper-tiny) |
 
-The v0.8.1 alpha ships Faster-Whisper as its sole selectable engine. Nemotron
+The v0.8.2-alpha.1 alpha ships Faster-Whisper as its sole selectable engine. Nemotron
 remains in the source tree and optional `nemotron` dependency for deferred
 repair work; it is not shipped or user-selectable in this alpha.
 
@@ -64,7 +64,7 @@ The [v0.7.0 release record](https://github.com/burntcookiedough/eve-windows-dict
 | `murmur-0.7.0-x64.nsis.7z` | 2,033,658,084 | `9f3137a096ac2183828e393a41b19e23a0b7387c2f44d40f6285d059ae2ae619` |
 | `latest.yml` | 558 | `fd23678bbed97980152fe9495c27f39081e61c1207f76f0eb614afac9d5c6221` |
 
-The current source tree also contains **Eve v0.8.1 pre-alpha work**. It is unreleased source work, not a published version or downloadable artifact; use the [development setup](#development) below to run it locally.
+The current source tree also contains **Eve v0.8.2-alpha.1 pre-alpha work**. It is unreleased source work, not a published version or downloadable artifact; use the [development setup](#development) below to run it locally.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eve for Windows
 
-<p><img src="https://img.shields.io/badge/v0.8.1-orange?style=flat-square" alt="v0.8.1"> <strong>Source status: v0.8.1 pre-alpha · unreleased</strong></p>
+<p><img src="https://img.shields.io/badge/v0.8.2-alpha.1-orange?style=flat-square" alt="v0.8.2-alpha.1"> <strong>Source status: v0.8.1 pre-alpha · unreleased</strong></p>
 
 ## Local-first dictation that stays in your flow
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.8.1",
+  "version": "0.8.2-alpha.1",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -259,7 +259,7 @@ describe('Home and shared server status', () => {
   test('preserves the frozen Eve identity and cross-runtime version baseline', () => {
     const appVersion = (JSON.parse(packageJson) as { version: string }).version;
     const backendVersion = serverVersion.match(/^SERVER_VERSION = "([^"]+)"$/m)?.[1];
-    expect(appVersion).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(appVersion).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
     expect(appVersion).toBe(backendVersion);
     expect(packageJson).toContain('"appId": "io.github.burntcookiedough.eve"');
     expect(packageJson).toContain('"guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204"');

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -259,7 +259,14 @@ describe('Home and shared server status', () => {
   test('preserves the frozen Eve identity and cross-runtime version baseline', () => {
     const appVersion = (JSON.parse(packageJson) as { version: string }).version;
     const backendVersion = serverVersion.match(/^SERVER_VERSION = "([^"]+)"$/m)?.[1];
-    expect(appVersion).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+    const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+    for (const version of ['1.2.3-beta.2+exp.sha.5114f85', '0.8.2-alpha.1']) {
+      expect(version).toMatch(semverPattern);
+    }
+    for (const version of ['1.2.3-', '1.2.3-alpha.', '1.2.3-alpha..1', '1.2.3-alpha.01']) {
+      expect(version).not.toMatch(semverPattern);
+    }
+    expect(appVersion).toMatch(semverPattern);
     expect(appVersion).toBe(backendVersion);
     expect(packageJson).toContain('"appId": "io.github.burntcookiedough.eve"');
     expect(packageJson).toContain('"guid": "0204d005-75b3-5b31-b1f6-ef2831e2b204"');

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$ExpectedVersion = "0.8.1",
+    [string]$ExpectedVersion = "0.8.2-alpha.1",
     [string]$InstallerDir = "E:\EveRelease\release-prep\full-nsis-web\nsis-web",
     [string]$InstallDir = "E:\EveRelease\release-prep\smoke-install\Eve",
     [string]$BaseBranch = "trunk",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.8.1"
+version = "0.8.2-alpha.1"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.8.1"
+SERVER_VERSION = "0.8.2-alpha.1"

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "murmur"
-version = "0.8.1"
+version = "0.8.2-alpha.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Prepare the next alpha version metadata only.

- Updates the repository-managed version set to 0.8.2-alpha.1.
- Keeps product behavior, dependencies, UI, release workflow, and release assets unchanged.
- Adjusts the existing cross-runtime app test to accept valid prerelease SemVer.
- Validation: version check, server release-config tests (18 passed), uv lock --check --offline, PowerShell release-verifier syntax, config parsing, and git diff checks passed.
- The focused app test was attempted but could not load because this fresh worktree has no node_modules; no install was performed.

Refs #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and server version to **0.8.2-alpha.1**.
  * Updated displayed version information and release verification checks.
  * Version validation now supports prerelease suffixes while maintaining backend consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->