### PR TITLE
Stabilize capture, long dictation, and packaged local server flow

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -4,7 +4,7 @@ Eve is currently maintained as an engineering project, not a staffed support ser
 
 Before reporting a problem:
 
-1. Confirm the exact release version and whether the app is using the packaged local service or an external server.
+1. Confirm the exact release version and whether the app is using the packaged local service or a separately started localhost development service.
 2. Read [the build guide](../docs/development/building.md) for development and packaging failures.
 3. Use the app's bounded diagnostics summary where available. Review it before sharing.
 4. Remove transcript text, clipboard contents, device labels, tokens, usernames, and full local paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ FastAPI/WebSocket service in `server/`. Read the relevant docs before changes.
 - Use the current clone path; do not copy environments or depend on user paths.
 - For app work: `Set-Location app; bun run <script>`.
 - For server work: `Set-Location server; uv sync --extra whisper --group dev --frozen; uv run pytest`.
-- Use `uv sync --extra release --frozen` for release-runtime preparation. The
-  `nemotron` extra remains available for deferred repair work and is not part
-  of the shipped alpha.
+- Use `uv sync --python 3.11 --no-dev --extra release --frozen` for release-runtime
+  preparation. The `nemotron` extra remains available for deferred repair work
+  and is not part of the shipped alpha.
 
 ## Product and privacy boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ FastAPI/WebSocket service in `server/`. Read the relevant docs before changes.
 
 ## Product and privacy boundaries
 
-- Default processing is local; an external server is an explicit user choice.
+- Packaged processing is local; development may connect to a separately started localhost server.
 - Never commit or inspect private audio, transcripts, clipboard data, tokens,
   personal profiles, caches, or unredacted user paths.
 - Preserve frozen Eve identity and Murmur compatibility: appId, NSIS GUID,

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,9 +8,9 @@ Network access is still required in these cases:
 
 - the NSIS web installer downloads the application payload from GitHub Releases;
 - an engine downloads its model files from Hugging Face on first use;
-- a developer or user deliberately configures external-server mode.
+- a developer runs a separately started localhost speech service during development.
 
-External-server mode changes the trust boundary because captured audio is sent to the configured server URL. Users are responsible for the operator and privacy terms of that endpoint.
+Packaged Eve keeps speech processing on its bundled local service. It does not expose a configurable external-server endpoint.
 
 ## Local data
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ bun install
 bun run dev
 ```
 
-Use `uv sync --extra release --frozen` when preparing the Whisper-only shipped alpha runtime. See [the Windows build guide](docs/development/building.md), [docs/protocol.md](docs/protocol.md), and [contributing](.github/CONTRIBUTING.md).
+Use `uv sync --python 3.11 --no-dev --extra release --frozen` when preparing the Whisper-only shipped alpha runtime. See [the Windows build guide](docs/development/building.md), [docs/protocol.md](docs/protocol.md), and [contributing](.github/CONTRIBUTING.md).
 
 ## Compatibility and provenance
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Eve derives device and precision availability from the installed PyTorch and CTr
 
 ## Local-first, with clear network boundaries
 
-The default packaged path keeps captured audio and transcription on the local machine. Network access is used for the small installer to fetch its application payload and for the selected model's first-use download from Hugging Face. External-server mode is an explicit choice: when enabled, audio is sent to the server URL configured by the user rather than the packaged local service.
+The packaged path keeps captured audio and transcription on the local machine. Network access is used for the small installer to fetch its application payload and for the selected model's first-use download from Hugging Face. During development, Eve may connect to a separately started localhost speech service; packaged builds use the bundled local service only.
 
 Read the full data boundary in [PRIVACY.md](PRIVACY.md). Do not include private audio, transcript text, clipboard contents, access tokens, or unredacted local paths in support or security reports; see [support](.github/SUPPORT.md) and [SECURITY.md](.github/SECURITY.md).
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -13,6 +13,7 @@ import { ServerManager } from './services/server-manager.js';
 import { processFinalTranscription } from './services/pipeline.js';
 import { getForegroundWindowHandle } from './services/clipboard.js';
 import { getSettings, getSetting } from './services/settings.js';
+import { LOCAL_SERVER_URL } from './services/server-api-url.js';
 import type { TextFrameFinal } from '../shared/protocol.js';
 import { IPC_CHANNELS } from '../shared/constants.js';
 import { buildHotwordsPrompt } from '../shared/hotwords.js';
@@ -165,12 +166,10 @@ function getRecordingDebugState(): RecordingDebugState {
 async function startRecording(source: 'lab' | 'normal', sessionMode: DictationSessionMode = 'quick') {
   if (isRecording || isStopping || !overlayWindow) return;
 
-  const useExternalServer = getSetting('useExternalServer');
-
-  // In packaged builds, require managed server discovery unless external mode is enabled.
+  // Packaged builds only trust the URL discovered from the managed server.
   const serverState = serverManager?.getState();
   const discoveredServerUrl = serverState?.wsUrl;
-  if (app.isPackaged && !useExternalServer && !discoveredServerUrl) {
+  if (app.isPackaged && !discoveredServerUrl) {
     log.error('Cannot start recording: managed server URL unavailable', {
       serverStatus: serverState?.status,
       managed: serverState?.managed,
@@ -180,7 +179,6 @@ async function startRecording(source: 'lab' | 'normal', sessionMode: DictationSe
 
   if (
     app.isPackaged &&
-    !useExternalServer &&
     serverState?.engineStatus?.status !== 'ready'
   ) {
     const engineStatus = serverState?.engineStatus;
@@ -224,9 +222,8 @@ async function startRecording(source: 'lab' | 'normal', sessionMode: DictationSe
   const settings = getSettings();
   const hotwords = settings.hotwordsEnabled ? buildHotwordsPrompt(settings.hotwordsCsl) : undefined;
 
-  const serverUrl = useExternalServer
-    ? getSetting('serverUrl')
-    : (discoveredServerUrl ?? getSetting('serverUrl'));
+  // Development can connect to a separately started localhost server.
+  const serverUrl = discoveredServerUrl ?? LOCAL_SERVER_URL;
 
   const service = new TranscriptionService(
     serverUrl,
@@ -599,9 +596,6 @@ async function startApplication(): Promise<void> {
   if (isDev) {
     // Development mode: just detect existing server, don't spawn
     log.info('Development mode: detecting existing server');
-    await serverManager.detectExisting();
-  } else if (getSetting('useExternalServer')) {
-    log.info('Production mode: using external server, skipping managed auto-start');
     await serverManager.detectExisting();
   } else {
     // Production mode: auto-start if enabled

--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -31,7 +31,12 @@ let historyServiceRef: HistoryService | null = null;
 let serverManagerRef: ServerManager | null = null;
 
 function getServerApiUrl(): string {
-  return resolveServerApiUrl(LOCAL_SERVER_URL, serverManagerRef?.getState());
+  const configuredUrl = app.isPackaged ? undefined : LOCAL_SERVER_URL;
+  const serverUrl = resolveServerApiUrl(configuredUrl, serverManagerRef?.getState());
+  if (!serverUrl) {
+    throw new Error('Managed server URL unavailable');
+  }
+  return serverUrl;
 }
 
 export function setupIpcHandlers(historyService?: HistoryService, serverManager?: ServerManager): void {

--- a/app/src/main/ipc/handlers.ts
+++ b/app/src/main/ipc/handlers.ts
@@ -10,7 +10,7 @@ import { copyToClipboard } from '../services/clipboard.js';
 import { formatDiagnosticsReport } from '../services/diagnostics-report.js';
 import type { HistoryService } from '../services/history.js';
 import type { ServerManager } from '../services/server-manager.js';
-import { getSetting, getSettings, updateSetting } from '../services/settings.js';
+import { getSettings, updateSetting } from '../services/settings.js';
 import {
   getServerSettings,
   updateServerSettings,
@@ -19,7 +19,7 @@ import {
 } from '../services/server-settings.js';
 import { startHotkeyCapture, cancelHotkeyCapture } from '../services/hotkey.js';
 import { formatHotkey } from '../services/keycodes.js';
-import { resolveServerApiUrl } from '../services/server-api-url.js';
+import { LOCAL_SERVER_URL, resolveServerApiUrl } from '../services/server-api-url.js';
 import { createLogger } from '../lib/logger.js';
 import {
   applyLaunchOnBoot,
@@ -31,12 +31,7 @@ let historyServiceRef: HistoryService | null = null;
 let serverManagerRef: ServerManager | null = null;
 
 function getServerApiUrl(): string {
-  const configuredUrl = getSetting('serverUrl');
-  return resolveServerApiUrl(
-    configuredUrl,
-    serverManagerRef?.getState(),
-    getSetting('useExternalServer'),
-  );
+  return resolveServerApiUrl(LOCAL_SERVER_URL, serverManagerRef?.getState());
 }
 
 export function setupIpcHandlers(historyService?: HistoryService, serverManager?: ServerManager): void {
@@ -88,7 +83,7 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
   // Handle setting updates
   ipcMain.handle(
     IPC_CHANNELS.UPDATE_SETTING,
-    async (_event, key: keyof Settings, value: Settings[keyof Settings]) => {
+    (_event, key: keyof Settings, value: Settings[keyof Settings]) => {
       if (key === 'launchOnBoot') {
         const result = applyLaunchOnBoot(app, value, {
           localAppData: process.env.LOCALAPPDATA,
@@ -101,10 +96,6 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
       }
 
       updateSetting(key, value);
-
-      if (key === 'useExternalServer' && value === true && serverManagerRef) {
-        await serverManagerRef.stop();
-      }
     }
   );
 
@@ -227,9 +218,6 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
   });
 
   ipcMain.handle(IPC_CHANNELS.SERVER_START, async () => {
-    if (getSetting('useExternalServer')) {
-      throw new Error('Server management is disabled while external server mode is enabled');
-    }
     if (!serverManagerRef) {
       throw new Error('Server manager not initialized');
     }
@@ -246,9 +234,6 @@ export function setupIpcHandlers(historyService?: HistoryService, serverManager?
   });
 
   ipcMain.handle(IPC_CHANNELS.SERVER_RESTART, async () => {
-    if (getSetting('useExternalServer')) {
-      throw new Error('Server management is disabled while external server mode is enabled');
-    }
     if (!serverManagerRef) {
       throw new Error('Server manager not initialized');
     }

--- a/app/src/main/services/clipboard.ts
+++ b/app/src/main/services/clipboard.ts
@@ -16,6 +16,15 @@ const FOREGROUND_WINDOW_TIMEOUT_MS = 2000;
 let pasteScriptPath: string | null = null;
 let sendInputScriptPath: string | null = null;
 let latestPasteGeneration = 0;
+let pasteCriticalSection: Promise<void> = Promise.resolve();
+
+interface PasteSequence {
+  baselineText: string;
+  ownedSignature: string;
+  restoreTimer: ReturnType<typeof setTimeout> | null;
+}
+
+let activePasteSequence: PasteSequence | null = null;
 
 function ensurePasteScript(): string {
   if (pasteScriptPath) return pasteScriptPath;
@@ -299,35 +308,166 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function pasteText(text: string, options: PasteTextOptions): Promise<void> {
-  const pasteGeneration = ++latestPasteGeneration;
-  const previous = clipboard.readText();
-  clipboard.writeText(text);
-  const clipboardOwnershipSignature = readClipboardOwnershipSignature();
-  try {
-    await delay(PASTE_FOCUS_SETTLE_DELAY_MS);
+function discardPasteSequence(sequence: PasteSequence): void {
+  if (sequence.restoreTimer) {
+    clearTimeout(sequence.restoreTimer);
+    sequence.restoreTimer = null;
+  }
+  if (activePasteSequence === sequence) {
+    activePasteSequence = null;
+  }
+}
+
+function beginPasteOperation(): { sequence: PasteSequence | null; baselineText: string } {
+  const currentSignature = readClipboardOwnershipSignature();
+  const currentSequence = activePasteSequence;
+
+  if (currentSequence) {
+    if (currentSequence.ownedSignature === currentSignature) {
+      if (currentSequence.restoreTimer) {
+        clearTimeout(currentSequence.restoreTimer);
+        currentSequence.restoreTimer = null;
+      }
+      return { sequence: currentSequence, baselineText: currentSequence.baselineText };
+    }
+    discardPasteSequence(currentSequence);
+  }
+
+  return {
+    sequence: null,
+    baselineText: clipboard.readText(),
+  };
+}
+
+function activatePasteSequence(
+  baselineText: string,
+  ownedSignature: string
+): PasteSequence {
+  const sequence: PasteSequence = {
+    baselineText,
+    ownedSignature,
+    restoreTimer: null,
+  };
+  activePasteSequence = sequence;
+  return sequence;
+}
+
+function schedulePasteRestore(
+  sequence: PasteSequence,
+  pasteGeneration: number,
+  clipboardOwnershipSignature: string,
+  restoreDelayMs: number
+): void {
+  if (
+    activePasteSequence !== sequence ||
+    pasteGeneration !== latestPasteGeneration ||
+    sequence.restoreTimer
+  ) {
+    return;
+  }
+
+  const restoreTimer = setTimeout(() => {
+    if (sequence.restoreTimer === restoreTimer) {
+      sequence.restoreTimer = null;
+    }
+
     if (
-      pasteGeneration !== latestPasteGeneration ||
-      readClipboardOwnershipSignature() !== clipboardOwnershipSignature
+      activePasteSequence !== sequence ||
+      pasteGeneration !== latestPasteGeneration
     ) {
       return;
     }
-    await simulatePaste(options.method, options.targetWindowHandle);
-  } finally {
-    if (options.restoreClipboard) {
-      setTimeout(() => {
-        if (
-          pasteGeneration !== latestPasteGeneration ||
-          readClipboardOwnershipSignature() !== clipboardOwnershipSignature
-        ) {
-          return;
-        }
-        try {
-          clipboard.writeText(previous);
-        } catch (error) {
-          log.error('Failed to restore clipboard', { error: error as Error });
-        }
-      }, Math.max(MIN_RESTORE_DELAY_MS, options.restoreDelayMs));
+
+    if (readClipboardOwnershipSignature() !== clipboardOwnershipSignature) {
+      discardPasteSequence(sequence);
+      return;
     }
-  }
+
+    try {
+      clipboard.writeText(sequence.baselineText);
+    } catch (error) {
+      log.error('Failed to restore clipboard', { error: error as Error });
+    }
+    if (activePasteSequence === sequence) {
+      activePasteSequence = null;
+    }
+  }, Math.max(MIN_RESTORE_DELAY_MS, restoreDelayMs));
+  sequence.restoreTimer = restoreTimer;
+}
+
+function enqueuePasteCriticalSection(operation: () => Promise<void>): Promise<void> {
+  const queuedOperation = pasteCriticalSection.then(operation);
+  pasteCriticalSection = queuedOperation.catch(() => {});
+  return queuedOperation;
+}
+
+export async function pasteText(text: string, options: PasteTextOptions): Promise<void> {
+  const pasteGeneration = ++latestPasteGeneration;
+  const operation = beginPasteOperation();
+  let sequence = operation.sequence;
+
+  return enqueuePasteCriticalSection(async () => {
+    let clipboardOwnershipSignature: string | null = null;
+    try {
+      if (sequence && activePasteSequence !== sequence) {
+        sequence = null;
+        operation.baselineText = clipboard.readText();
+      }
+      if (sequence && activePasteSequence === sequence) {
+        const currentSignature = readClipboardOwnershipSignature();
+        if (currentSignature !== sequence.ownedSignature) {
+          if (sequence.restoreTimer) {
+            clearTimeout(sequence.restoreTimer);
+            sequence.restoreTimer = null;
+          }
+          sequence.baselineText = clipboard.readText();
+          sequence.ownedSignature = currentSignature;
+        }
+      }
+
+      clipboard.writeText(text);
+      clipboardOwnershipSignature = readClipboardOwnershipSignature();
+      if (!sequence && pasteGeneration === latestPasteGeneration) {
+        sequence = activatePasteSequence(operation.baselineText, clipboardOwnershipSignature);
+      } else if (sequence && activePasteSequence === sequence) {
+        sequence.ownedSignature = clipboardOwnershipSignature;
+      }
+
+      await delay(PASTE_FOCUS_SETTLE_DELAY_MS);
+      const clipboardStillOwned =
+        readClipboardOwnershipSignature() === clipboardOwnershipSignature;
+      if (!clipboardStillOwned) {
+        if (sequence && activePasteSequence === sequence) {
+          discardPasteSequence(sequence);
+        }
+        return;
+      }
+      if (pasteGeneration !== latestPasteGeneration) return;
+      await simulatePaste(options.method, options.targetWindowHandle);
+    } finally {
+      if (sequence && activePasteSequence === sequence) {
+        if (
+          options.restoreClipboard &&
+          pasteGeneration === latestPasteGeneration &&
+          clipboardOwnershipSignature
+        ) {
+          if (sequence.restoreTimer) {
+            clearTimeout(sequence.restoreTimer);
+            sequence.restoreTimer = null;
+          }
+          schedulePasteRestore(
+            sequence,
+            pasteGeneration,
+            clipboardOwnershipSignature,
+            options.restoreDelayMs
+          );
+        } else if (
+          pasteGeneration === latestPasteGeneration &&
+          activePasteSequence === sequence
+        ) {
+          activePasteSequence = null;
+        }
+      }
+    }
+  });
 }

--- a/app/src/main/services/clipboard.ts
+++ b/app/src/main/services/clipboard.ts
@@ -15,6 +15,7 @@ const FOREGROUND_WINDOW_TIMEOUT_MS = 2000;
 // Written to userData once and reused via cscript.
 let pasteScriptPath: string | null = null;
 let sendInputScriptPath: string | null = null;
+let latestPasteGeneration = 0;
 
 function ensurePasteScript(): string {
   if (pasteScriptPath) return pasteScriptPath;
@@ -292,6 +293,7 @@ function delay(ms: number): Promise<void> {
 }
 
 export async function pasteText(text: string, options: PasteTextOptions): Promise<void> {
+  const pasteGeneration = ++latestPasteGeneration;
   const previous = clipboard.readText();
   clipboard.writeText(text);
   try {
@@ -300,6 +302,9 @@ export async function pasteText(text: string, options: PasteTextOptions): Promis
   } finally {
     if (options.restoreClipboard) {
       setTimeout(() => {
+        if (pasteGeneration !== latestPasteGeneration || clipboard.readText() !== text) {
+          return;
+        }
         try {
           clipboard.writeText(previous);
         } catch (error) {

--- a/app/src/main/services/clipboard.ts
+++ b/app/src/main/services/clipboard.ts
@@ -185,6 +185,13 @@ export function readFromClipboard(): string {
   return clipboard.readText();
 }
 
+function readClipboardOwnershipSignature(): string {
+  return JSON.stringify({
+    text: clipboard.readText(),
+    formats: [...clipboard.availableFormats()].sort(),
+  });
+}
+
 export function getForegroundWindowHandle(): Promise<number | null> {
   return new Promise((resolve) => {
     execFile(
@@ -296,13 +303,17 @@ export async function pasteText(text: string, options: PasteTextOptions): Promis
   const pasteGeneration = ++latestPasteGeneration;
   const previous = clipboard.readText();
   clipboard.writeText(text);
+  const clipboardOwnershipSignature = readClipboardOwnershipSignature();
   try {
     await delay(PASTE_FOCUS_SETTLE_DELAY_MS);
     await simulatePaste(options.method, options.targetWindowHandle);
   } finally {
     if (options.restoreClipboard) {
       setTimeout(() => {
-        if (pasteGeneration !== latestPasteGeneration || clipboard.readText() !== text) {
+        if (
+          pasteGeneration !== latestPasteGeneration ||
+          readClipboardOwnershipSignature() !== clipboardOwnershipSignature
+        ) {
           return;
         }
         try {

--- a/app/src/main/services/clipboard.ts
+++ b/app/src/main/services/clipboard.ts
@@ -306,6 +306,12 @@ export async function pasteText(text: string, options: PasteTextOptions): Promis
   const clipboardOwnershipSignature = readClipboardOwnershipSignature();
   try {
     await delay(PASTE_FOCUS_SETTLE_DELAY_MS);
+    if (
+      pasteGeneration !== latestPasteGeneration ||
+      readClipboardOwnershipSignature() !== clipboardOwnershipSignature
+    ) {
+      return;
+    }
     await simulatePaste(options.method, options.targetWindowHandle);
   } finally {
     if (options.restoreClipboard) {

--- a/app/src/main/services/diagnostics-report.ts
+++ b/app/src/main/services/diagnostics-report.ts
@@ -116,7 +116,7 @@ export function formatDiagnosticsReport(input: DiagnosticsReportInput): string {
   const appVersion = matchingString(input.appVersion, SAFE_VERSION) ?? 'unknown';
   const windowsRelease = matchingString(input.windowsRelease, SAFE_WINDOWS_RELEASE) ?? 'unknown';
   const architecture = enumString(input.architecture, new Set(['x64', 'arm64', 'ia32'])) ?? 'unknown';
-  const managed = typeof state?.managed === 'boolean' ? (state.managed ? 'managed' : 'external') : 'unknown';
+  const managed = typeof state?.managed === 'boolean' ? (state.managed ? 'managed' : 'detected') : 'unknown';
   const serverStatus = enumString(state?.status, SERVER_STATUSES) ?? 'unknown';
   const lines = [
     'Eve diagnostics',

--- a/app/src/main/services/hotkey.ts
+++ b/app/src/main/services/hotkey.ts
@@ -153,27 +153,45 @@ export function resetKeyState(): void {
 
 // --- Hotkey Capture ---
 
-let captureListener: ((e: UiohookKeyboardEvent) => void) | null = null;
+type HotkeyCaptureResult = { hotkey: Hotkey; displayName: string };
+
+interface HotkeyCapture {
+  listener: (e: UiohookKeyboardEvent) => void;
+  resolve: (value: HotkeyCaptureResult) => void;
+  reject: (reason?: unknown) => void;
+}
+
+let activeCapture: HotkeyCapture | null = null;
 
 /**
  * Start capturing a hotkey. The next non-modifier key press will be captured.
  * Returns a promise that resolves with the captured hotkey and its display name.
  */
-export function startHotkeyCapture(): Promise<{ hotkey: Hotkey; displayName: string }> {
-  return new Promise((resolve) => {
-    // Remove any existing capture listener
-    if (captureListener) {
-      uIOhook.off('keydown', captureListener);
-    }
+export function startHotkeyCapture(): Promise<HotkeyCaptureResult> {
+  if (activeCapture) {
+    rejectCapturedHotkey(activeCapture, 'replaced');
+  }
 
-    captureListener = (e: UiohookKeyboardEvent) => {
+  return new Promise((resolve, reject) => {
+    const capture: HotkeyCapture = {
+      listener: () => undefined,
+      resolve,
+      reject,
+    };
+
+    capture.listener = (e: UiohookKeyboardEvent) => {
+      // A key event already queued for an older request must not affect a newer one.
+      if (activeCapture !== capture) {
+        return;
+      }
+
       if (isModifierKey(e.keycode)) {
         const modifierHotkey = captureModifierChord(eventSnapshot(e));
         if (!modifierHotkey) {
           return;
         }
 
-        resolveCapturedHotkey(modifierHotkey, resolve);
+        resolveCapturedHotkey(capture, modifierHotkey);
         return;
       }
 
@@ -185,34 +203,46 @@ export function startHotkeyCapture(): Promise<{ hotkey: Hotkey; displayName: str
         metaKey: e.metaKey,
       };
 
-      resolveCapturedHotkey(hotkey, resolve);
+      resolveCapturedHotkey(capture, hotkey);
     };
 
-    uIOhook.on('keydown', captureListener);
+    activeCapture = capture;
+    uIOhook.on('keydown', capture.listener);
   });
 }
 
 function resolveCapturedHotkey(
+  capture: HotkeyCapture,
   hotkey: Hotkey,
-  resolve: (value: { hotkey: Hotkey; displayName: string }) => void,
 ): void {
-  const displayName = formatHotkey(hotkey);
-
-  if (captureListener) {
-    uIOhook.off('keydown', captureListener);
-    captureListener = null;
+  if (activeCapture !== capture) {
+    return;
   }
 
+  const displayName = formatHotkey(hotkey);
+
+  uIOhook.off('keydown', capture.listener);
+  activeCapture = null;
+
   resetKeyState();
-  resolve({ hotkey, displayName });
+  capture.resolve({ hotkey, displayName });
+}
+
+function rejectCapturedHotkey(capture: HotkeyCapture, reason: 'cancelled' | 'replaced'): void {
+  if (activeCapture !== capture) {
+    return;
+  }
+
+  uIOhook.off('keydown', capture.listener);
+  activeCapture = null;
+  capture.reject(new Error(`Hotkey capture ${reason}`));
 }
 
 /**
  * Cancel an in-progress hotkey capture
  */
 export function cancelHotkeyCapture(): void {
-  if (captureListener) {
-    uIOhook.off('keydown', captureListener);
-    captureListener = null;
+  if (activeCapture) {
+    rejectCapturedHotkey(activeCapture, 'cancelled');
   }
 }

--- a/app/src/main/services/server-api-url.ts
+++ b/app/src/main/services/server-api-url.ts
@@ -1,18 +1,18 @@
 import type { ServerStatePayload } from '../../shared/types.js';
 
+export const LOCAL_SERVER_URL = 'ws://localhost:51717/transcribe';
+
 /**
  * Resolve the HTTP API endpoint for server settings and engine operations.
  *
- * Managed production servers bind an available port and publish it through
- * ServerManager. External-server mode must continue to use the user's saved
- * endpoint instead.
+ * Managed servers bind an available port and publish it through ServerManager.
+ * The localhost URL is only a development fallback while no server is running.
  */
 export function resolveServerApiUrl(
   configuredUrl: string,
   state: Pick<ServerStatePayload, 'status' | 'wsUrl'> | null | undefined,
-  useExternalServer: boolean,
 ): string {
-  if (!useExternalServer && state?.status === 'running' && state.wsUrl) {
+  if (state?.status === 'running' && state.wsUrl) {
     return state.wsUrl;
   }
   return configuredUrl;

--- a/app/src/main/services/server-api-url.ts
+++ b/app/src/main/services/server-api-url.ts
@@ -6,12 +6,13 @@ export const LOCAL_SERVER_URL = 'ws://localhost:51717/transcribe';
  * Resolve the HTTP API endpoint for server settings and engine operations.
  *
  * Managed servers bind an available port and publish it through ServerManager.
- * The localhost URL is only a development fallback while no server is running.
+ * Callers may provide a fallback for development; packaged callers must omit it
+ * until a managed endpoint has been discovered.
  */
 export function resolveServerApiUrl(
-  configuredUrl: string,
+  configuredUrl: string | undefined,
   state: Pick<ServerStatePayload, 'status' | 'wsUrl'> | null | undefined,
-): string {
+): string | undefined {
   if (state?.status === 'running' && state.wsUrl) {
     return state.wsUrl;
   }

--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -368,7 +368,7 @@ export class ServerManager {
     this.setDiagnostics(health.diagnostics);
     this.setModelDownload(health.modelDownload);
     this.setEngineStatus(health.engineStatus);
-    this.managed = false; // External server
+    this.managed = false; // The server was detected rather than spawned by Eve.
     this.updateStatus('running');
     this.startHealthPolling(pidData.port);
 
@@ -674,7 +674,7 @@ export class ServerManager {
     }
 
     if (!this.managed) {
-      log.info('Server is not managed (external), cannot stop');
+      log.info('Server is not managed, cannot stop a detected process');
       return;
     }
 
@@ -760,7 +760,7 @@ export class ServerManager {
    */
   async restart(): Promise<void> {
     if (!this.managed) {
-      log.info('Server is not managed (external), cannot restart');
+      log.info('Server is not managed, cannot restart a detected process');
       return;
     }
 

--- a/app/src/main/services/server-settings.ts
+++ b/app/src/main/services/server-settings.ts
@@ -1,6 +1,6 @@
 import type { ServerSettingsResponse, EngineStatus, AvailableEngine } from '../../shared/types.js';
-import { getSetting } from './settings.js';
 import { createLogger } from '../lib/logger.js';
+import { LOCAL_SERVER_URL } from './server-api-url.js';
 
 const log = createLogger('ServerSettings');
 
@@ -9,7 +9,7 @@ const log = createLogger('ServerSettings');
  * e.g. "ws://localhost:51717/transcribe" → "http://localhost:51717"
  */
 function getBaseUrl(serverUrl?: string): string {
-  const wsUrl = serverUrl ?? getSetting('serverUrl');
+  const wsUrl = serverUrl ?? LOCAL_SERVER_URL;
   const url = new URL(wsUrl);
   url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
   // Strip path (e.g. /transcribe) to get the base

--- a/app/src/main/services/server-settings.ts
+++ b/app/src/main/services/server-settings.ts
@@ -1,6 +1,5 @@
 import type { ServerSettingsResponse, EngineStatus, AvailableEngine } from '../../shared/types.js';
 import { createLogger } from '../lib/logger.js';
-import { LOCAL_SERVER_URL } from './server-api-url.js';
 
 const log = createLogger('ServerSettings');
 
@@ -8,16 +7,15 @@ const log = createLogger('ServerSettings');
  * Derive the server base URL from a WebSocket endpoint.
  * e.g. "ws://localhost:51717/transcribe" → "http://localhost:51717"
  */
-function getBaseUrl(serverUrl?: string): string {
-  const wsUrl = serverUrl ?? LOCAL_SERVER_URL;
-  const url = new URL(wsUrl);
+function getBaseUrl(serverUrl: string): string {
+  const url = new URL(serverUrl);
   url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
   // Strip path (e.g. /transcribe) to get the base
   url.pathname = '';
   return url.origin;
 }
 
-async function fetchJson<T>(path: string, options?: RequestInit, serverUrl?: string): Promise<T> {
+async function fetchJson<T>(path: string, options: RequestInit | undefined, serverUrl: string): Promise<T> {
   const base = getBaseUrl(serverUrl);
   const url = `${base}${path}`;
   log.debug('Fetching', { url, method: options?.method ?? 'GET' });
@@ -38,13 +36,13 @@ async function fetchJson<T>(path: string, options?: RequestInit, serverUrl?: str
   return response.json() as Promise<T>;
 }
 
-export async function getServerSettings(serverUrl?: string): Promise<ServerSettingsResponse> {
+export async function getServerSettings(serverUrl: string): Promise<ServerSettingsResponse> {
   return fetchJson<ServerSettingsResponse>('/settings', undefined, serverUrl);
 }
 
 export async function updateServerSettings(
   patch: Record<string, unknown>,
-  serverUrl?: string,
+  serverUrl: string,
 ): Promise<ServerSettingsResponse> {
   return fetchJson<ServerSettingsResponse>('/settings', {
     method: 'PATCH',
@@ -52,11 +50,11 @@ export async function updateServerSettings(
   }, serverUrl);
 }
 
-export async function getEngineStatus(serverUrl?: string): Promise<EngineStatus> {
+export async function getEngineStatus(serverUrl: string): Promise<EngineStatus> {
   return fetchJson<EngineStatus>('/engine/status', undefined, serverUrl);
 }
 
-export async function getAvailableEngines(serverUrl?: string): Promise<AvailableEngine[]> {
+export async function getAvailableEngines(serverUrl: string): Promise<AvailableEngine[]> {
   const data = await fetchJson<{ engines: AvailableEngine[] }>('/engines', undefined, serverUrl);
   return data.engines;
 }

--- a/app/src/main/services/settings.ts
+++ b/app/src/main/services/settings.ts
@@ -56,7 +56,6 @@ export function getSettings(): Settings {
     clipboardRestoreDelayMs: store.get('clipboardRestoreDelayMs'),
     pasteMethod: store.get('pasteMethod'),
     silenceTimeout: store.get('silenceTimeout'),
-    serverUrl: store.get('serverUrl'),
     appendPeriod: store.get('appendPeriod'),
     appendSpace: store.get('appendSpace'),
     dictationMode: store.get('dictationMode'),
@@ -64,7 +63,6 @@ export function getSettings(): Settings {
     launchOnBoot: store.get('launchOnBoot'),
     startMinimized: store.get('startMinimized'),
     serverAutoStart: store.get('serverAutoStart'),
-    useExternalServer: store.get('useExternalServer'),
     hotwordsEnabled: store.get('hotwordsEnabled'),
     hotwordsCsl: store.get('hotwordsCsl'),
   };

--- a/app/src/renderer/app/app.css
+++ b/app/src/renderer/app/app.css
@@ -77,15 +77,6 @@
     animation: none;
   }
 
-  ::view-transition-group(external-server-panel) {
-    animation-duration: 180ms;
-    animation-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
-  }
-
-  ::view-transition-old(external-server-panel),
-  ::view-transition-new(external-server-panel) {
-    animation: none;
-  }
 }
 
 @media (prefers-reduced-transparency: reduce) {

--- a/app/src/renderer/app/components/HotkeyCaptureModal.svelte
+++ b/app/src/renderer/app/components/HotkeyCaptureModal.svelte
@@ -13,10 +13,12 @@
   let dialogRef: HTMLDivElement | null = $state(null);
   let cancelButton: HTMLButtonElement | null = $state(null);
   let returnFocus: HTMLElement | null = null;
+  let cancellationRequested = false;
   let wasOpen = false;
 
   $effect(() => {
     if (isOpen && !wasOpen) {
+      cancellationRequested = false;
       returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
       queueMicrotask(() => cancelButton?.focus());
     } else if (!isOpen && wasOpen) {
@@ -38,15 +40,18 @@
       const result = await window.murmurMain.startHotkeyCapture();
       onCapture(result.hotkey, result.displayName);
     } catch (error) {
-      console.error('Hotkey capture failed:', error);
-      onCancel();
+      if (!cancellationRequested) {
+        console.error('Hotkey capture failed:', error);
+        onCancel();
+      }
     } finally {
       isCapturing = false;
     }
   }
 
   function handleCancel() {
-    window.murmurMain.cancelHotkeyCapture();
+    cancellationRequested = true;
+    void window.murmurMain.cancelHotkeyCapture();
     onCancel();
   }
 

--- a/app/src/renderer/app/components/HotkeyCaptureModal.svelte
+++ b/app/src/renderer/app/components/HotkeyCaptureModal.svelte
@@ -13,12 +13,11 @@
   let dialogRef: HTMLDivElement | null = $state(null);
   let cancelButton: HTMLButtonElement | null = $state(null);
   let returnFocus: HTMLElement | null = null;
-  let cancellationRequested = false;
+  let captureGeneration = 0;
   let wasOpen = false;
 
   $effect(() => {
     if (isOpen && !wasOpen) {
-      cancellationRequested = false;
       returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
       queueMicrotask(() => cancelButton?.focus());
     } else if (!isOpen && wasOpen) {
@@ -35,22 +34,26 @@
   });
 
   async function startCapture() {
+    const generation = ++captureGeneration;
     isCapturing = true;
     try {
       const result = await window.murmurMain.startHotkeyCapture();
+      if (generation !== captureGeneration) return;
       onCapture(result.hotkey, result.displayName);
     } catch (error) {
-      if (!cancellationRequested) {
-        console.error('Hotkey capture failed:', error);
-        onCancel();
-      }
+      if (generation !== captureGeneration) return;
+      console.error('Hotkey capture failed:', error);
+      onCancel();
     } finally {
-      isCapturing = false;
+      if (generation === captureGeneration) {
+        isCapturing = false;
+      }
     }
   }
 
   function handleCancel() {
-    cancellationRequested = true;
+    captureGeneration += 1;
+    isCapturing = false;
     void window.murmurMain.cancelHotkeyCapture();
     onCancel();
   }

--- a/app/src/renderer/app/components/ModelProgressBanner.svelte
+++ b/app/src/renderer/app/components/ModelProgressBanner.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   import { shouldShowModelProgress } from '$shared/model-progress';
   import ModelProgressCard from './ModelProgressCard.svelte';
-  import { getServerManagementMode, serverStatusState } from '../server-status';
+  import { serverStatusState } from '../server-status';
 
   let { visible = true }: { visible?: boolean } = $props();
   let modelDownload = $derived($serverStatusState.state?.modelDownload);
   let showBanner = $derived(
     modelDownload?.status === 'error' || shouldShowModelProgress(modelDownload)
   );
-  let managementMode = $derived(getServerManagementMode($serverStatusState));
 </script>
 
 {#if visible && modelDownload && showBanner}
@@ -22,13 +21,6 @@
         <p class="text-sm font-medium text-red-200 text-pretty">Speech model setup failed</p>
         <p class="mt-1 text-xs text-red-200/80 text-pretty [overflow-wrap:anywhere]">
           {modelDownload.detail ?? 'Check your connection.'} Open Settings &gt; Server &amp; diagnostics for details.
-          {#if managementMode === 'managed'}
-            You can restart the managed server there.
-          {:else if managementMode === 'external'}
-            Eve cannot restart an external server.
-          {:else}
-            Management mode cannot be confirmed yet.
-          {/if}
         </p>
       </div>
     {:else}

--- a/app/src/renderer/app/components/SpeechModelChooser.svelte
+++ b/app/src/renderer/app/components/SpeechModelChooser.svelte
@@ -9,7 +9,6 @@
     availabilityKnown: boolean;
     engineStatus: EngineStatus | null;
     modelDownload?: ModelDownloadState;
-    externalMode: boolean;
     preparationFailed: boolean;
     onSelect: (preset: SpeechModelPreset) => void;
     children?: Snippet;
@@ -21,7 +20,6 @@
     availabilityKnown,
     engineStatus,
     modelDownload,
-    externalMode,
     preparationFailed,
     onSelect,
     children,
@@ -99,49 +97,43 @@
       Select a curated model to stage. Apply and prepare model confirms the change. The current engine stays active until the selected model is ready.
     </p>
 
-    {#if externalMode}
-      <div data-speech-model-external role="status" class="mt-4 border-t border-white/[0.08] pt-4 text-xs leading-5 text-zinc-400">
-        An external server controls model preparation. Manage its model through that server's own endpoint.
-      </div>
-    {:else}
-      <div data-speech-model-list role="radiogroup" aria-label="Curated speech models" class="mt-4 divide-y divide-white/[0.08]">
-        {#each SPEECH_MODEL_PRESETS as preset}
-          {@const disabled = externalMode || unavailable(preset)}
-          {@const checked = selected?.id === preset.id}
-          {@const label = stateLabel(preset)}
-          <label
-            data-speech-model-option
-            class="flex min-w-0 items-start gap-3 rounded-lg px-2 py-3 first:pt-2 last:pb-2 focus-within:outline focus-within:outline-2 focus-within:outline-offset-[-2px] focus-within:outline-zinc-100
-              {disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}"
-          >
-            <input
-              class="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-100 disabled:cursor-not-allowed"
-              type="radio"
-              name={`speech-model-preset-${componentId}`}
-              checked={checked}
-              disabled={disabled}
-              onchange={() => onSelect(preset)}
-              aria-label={`${preset.label}, ${label}`}
-              aria-describedby={detailId(preset.id)}
-            />
-            <span class="min-w-0 flex-1">
-              <span class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-x-3 sm:gap-y-1">
-                <span class="min-w-0 text-sm font-medium text-zinc-100 [overflow-wrap:anywhere]">{preset.label}</span>
-                <span data-speech-model-state class="max-w-full text-xs [overflow-wrap:anywhere] {stateClass(label)}">{label}</span>
-              </span>
-              <span id={detailId(preset.id)} class="mt-1 block text-xs leading-5 text-zinc-400 [overflow-wrap:anywhere]">
-                {preset.language} · approx. {preset.sizeGb} GB. {preset.summary}
-              </span>
-              {#if disabled}
-                <span class="mt-1 block text-xs text-amber-300">This server does not have the required {preset.engine} runtime.</span>
-              {:else if isError(preset)}
-                <span class="mt-1 block text-xs text-red-300">Preparation failed. Use Retry preparation or Revert below.</span>
-              {/if}
+    <div data-speech-model-list role="radiogroup" aria-label="Curated speech models" class="mt-4 divide-y divide-white/[0.08]">
+      {#each SPEECH_MODEL_PRESETS as preset}
+        {@const disabled = unavailable(preset)}
+        {@const checked = selected?.id === preset.id}
+        {@const label = stateLabel(preset)}
+        <label
+          data-speech-model-option
+          class="flex min-w-0 items-start gap-3 rounded-lg px-2 py-3 first:pt-2 last:pb-2 focus-within:outline focus-within:outline-2 focus-within:outline-offset-[-2px] focus-within:outline-zinc-100
+            {disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}"
+        >
+          <input
+            class="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-100 disabled:cursor-not-allowed"
+            type="radio"
+            name={`speech-model-preset-${componentId}`}
+            checked={checked}
+            disabled={disabled}
+            onchange={() => onSelect(preset)}
+            aria-label={`${preset.label}, ${label}`}
+            aria-describedby={detailId(preset.id)}
+          />
+          <span class="min-w-0 flex-1">
+            <span class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-x-3 sm:gap-y-1">
+              <span class="min-w-0 text-sm font-medium text-zinc-100 [overflow-wrap:anywhere]">{preset.label}</span>
+              <span data-speech-model-state class="max-w-full text-xs [overflow-wrap:anywhere] {stateClass(label)}">{label}</span>
             </span>
-          </label>
-        {/each}
-      </div>
-    {/if}
+            <span id={detailId(preset.id)} class="mt-1 block text-xs leading-5 text-zinc-400 [overflow-wrap:anywhere]">
+              {preset.language} · approx. {preset.sizeGb} GB. {preset.summary}
+            </span>
+            {#if disabled}
+              <span class="mt-1 block text-xs text-amber-300">This server does not have the required {preset.engine} runtime.</span>
+            {:else if isError(preset)}
+              <span class="mt-1 block text-xs text-red-300">Preparation failed. Use Retry preparation or Revert below.</span>
+            {/if}
+          </span>
+        </label>
+      {/each}
+    </div>
   </fieldset>
 
   {#if children}

--- a/app/src/renderer/app/fixtures/SettingsServerFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsServerFixture.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
-  import SettingsRow from '../components/SettingsRow.svelte';
   import SettingsSection from '../components/SettingsSection.svelte';
   import ServerView from '../views/ServerView.svelte';
-  import Toggle from '../components/Toggle.svelte';
 
   type FixtureState =
     | 'managed-ready'
     | 'managed-error'
-    | 'external-ready'
     | 'managed-long'
     | 'managed-short'
     | 'managed-empty'
@@ -16,14 +13,7 @@
 
   const params = new URLSearchParams(globalThis.location.search);
   const fixtureState = (params.get('state') ?? 'managed-ready') as FixtureState;
-  const externalMode = fixtureState === 'external-ready';
   const longStrings = fixtureState === 'managed-long';
-  const endpoint = longStrings
-    ? 'ws://fixture-server-with-a-deliberately-long-hostname.example.internal:51717/transcribe'
-    : externalMode
-      ? 'ws://external-fixture.example:51717/transcribe'
-      : 'ws://localhost:51717/transcribe';
-  let externalEnabled = $state(externalMode);
 </script>
 
 <div class="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[#08090a] text-zinc-100">
@@ -38,33 +28,11 @@
         <div class="space-y-7 pb-8">
           <SettingsSection
             title="Server &amp; diagnostics"
-            description="Management mode, endpoint, health, diagnostics, and recent logs."
+            description="Server health, diagnostics, lifecycle, and recent logs."
             variant="content"
           >
             <div data-server-diagnostics class="min-w-0 space-y-6">
-              <section data-server-management class="min-w-0 space-y-2" aria-labelledby="fixture-server-management-heading">
-                <div class="min-w-0 px-1">
-                  <h3 id="fixture-server-management-heading" class="text-sm font-semibold text-zinc-200">Management mode &amp; endpoint</h3>
-                  <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Choose Eve-managed processing or connect to an external endpoint.</p>
-                </div>
-                <div data-server-mode-surface class="min-w-0 overflow-hidden rounded-xl border border-white/10 bg-white/[0.025]">
-                  <SettingsRow label="Use external server" description="Connect to your own server and disable built-in server management">
-                    <Toggle enabled={externalEnabled} label="Use external server" onchange={(enabled) => externalEnabled = enabled} />
-                  </SettingsRow>
-                  <div class="overflow-hidden border-t border-white/[0.08]">
-                    {#if externalEnabled}
-                      <div data-external-server-panel class="min-w-0 p-4">
-                        <p class="text-sm text-zinc-200">Custom server endpoint</p>
-                        <p class="mt-1 text-xs leading-5 text-zinc-500 [overflow-wrap:anywhere]">Eve connects to <span class="font-mono">/transcribe</span> at the configured endpoint.</p>
-                        <label for="fixture-server-url" class="mt-3 block text-xs text-zinc-500">Endpoint</label>
-                        <input id="fixture-server-url" aria-label="External server endpoint" value={endpoint} readonly class="mt-1 min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100" />
-                      </div>
-                    {/if}
-                  </div>
-                </div>
-              </section>
-
-              <ServerView embedded externalMode={externalMode} />
+              <ServerView embedded />
             </div>
           </SettingsSection>
         </div>

--- a/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
+++ b/app/src/renderer/app/fixtures/SettingsSpeechFixture.svelte
@@ -8,14 +8,14 @@
   import Toggle from '../components/Toggle.svelte';
   import EveDropdown from '../components/EveDropdown.svelte';
 
-  type FixtureState = 'ready' | 'preparing' | 'error' | 'external';
+  type FixtureState = 'ready' | 'preparing' | 'error';
 
   const params = new URLSearchParams(globalThis.location.search);
   const fixtureState = (params.get('state') ?? 'ready') as FixtureState;
   const fixtureView = params.get('view') ?? 'all';
   let compatibilityOpen = $state(params.get('compatibility') === 'expanded');
   let selectedPreset = $state<SpeechModelPreset>(
-    fixtureState === 'ready' || fixtureState === 'external'
+    fixtureState === 'ready'
       ? SPEECH_MODEL_PRESETS[0]!
       : SPEECH_MODEL_PRESETS[1]!,
   );
@@ -152,7 +152,6 @@
                 availabilityKnown
                 engineStatus={engineStatus}
                 modelDownload={modelDownload}
-                externalMode={fixtureState === 'external'}
                 preparationFailed={fixtureState === 'error'}
                 onSelect={selectPreset}
               >

--- a/app/src/renderer/app/fixtures/home-fixture.ts
+++ b/app/src/renderer/app/fixtures/home-fixture.ts
@@ -51,7 +51,6 @@ serverStatusState.set({
   state,
   phase,
   announcement: `Fixture ${phase}`,
-  configuredExternalServer: false,
 });
 
 Object.assign(window, {

--- a/app/src/renderer/app/fixtures/settings-server-fixture.ts
+++ b/app/src/renderer/app/fixtures/settings-server-fixture.ts
@@ -8,7 +8,6 @@ import '../app.css';
 type FixtureState =
   | 'managed-ready'
   | 'managed-error'
-  | 'external-ready'
   | 'managed-long'
   | 'managed-short'
   | 'managed-empty'
@@ -17,7 +16,6 @@ type FixtureState =
 
 const params = new URLSearchParams(globalThis.location.search);
 const fixtureState = (params.get('state') ?? 'managed-ready') as FixtureState;
-const externalMode = fixtureState === 'external-ready';
 const longStrings = fixtureState === 'managed-long';
 const hasError = fixtureState === 'managed-error';
 const logError = fixtureState === 'managed-log-error';
@@ -43,8 +41,8 @@ const engineStatus = {
 
 const serverState: ServerStatePayload = {
   status: hasError ? 'error' : 'running',
-  managed: !externalMode,
-  pid: externalMode ? undefined : 4242,
+  managed: true,
+  pid: 4242,
   port: 51717,
   version: longStrings ? '0.8.0-fixture-build-with-a-long-version-label' : '0.8.0',
   uptime: 3725000,
@@ -77,19 +75,12 @@ const logs: ServerLogEntry[] = Array.from({ length: logCount }, (_, index) => ({
 
 const fixtureSettings = {
   ...DEFAULT_SETTINGS,
-  useExternalServer: externalMode,
-  serverUrl: longStrings
-    ? 'ws://fixture-server-with-a-deliberately-long-hostname.example.internal:51717/transcribe'
-    : externalMode
-      ? 'ws://external-fixture.example:51717/transcribe'
-      : DEFAULT_SETTINGS.serverUrl,
 };
 
 serverStatusState.set({
   state: serverState,
   phase: hasError ? 'error' : 'ready',
   announcement: '',
-  configuredExternalServer: externalMode,
 });
 
 const fixtureMain = {

--- a/app/src/renderer/app/server-settings-recovery.ts
+++ b/app/src/renderer/app/server-settings-recovery.ts
@@ -51,9 +51,8 @@ export function shouldRetryServerSettings(
 
 export function shouldClearServerSettings(
   state: SettingsRecoveryState | null | undefined,
-  externalMode: boolean,
 ): boolean {
-  return !externalMode && state !== null && state !== undefined && state.status !== 'running';
+  return state !== null && state !== undefined && state.status !== 'running';
 }
 
 /**
@@ -63,10 +62,9 @@ export function shouldClearServerSettings(
  */
 export function recoverInterruptedManagedPreparation(
   state: SettingsRecoveryState | null | undefined,
-  externalMode: boolean,
   lifecycle: EnginePreparationLifecycle,
 ): ManagedServerPreparationRecovery | null {
-  if (!shouldClearServerSettings(state, externalMode)) return null;
+  if (!shouldClearServerSettings(state)) return null;
 
   const interrupted = lifecycle.requested
     || lifecycle.active

--- a/app/src/renderer/app/server-settings-recovery.ts
+++ b/app/src/renderer/app/server-settings-recovery.ts
@@ -1,6 +1,6 @@
 import type { ServerStatePayload } from '../../shared/types';
 
-type SettingsRecoveryState = Pick<ServerStatePayload, 'status' | 'port' | 'wsUrl' | 'version' | 'engineStatus' | 'modelDownload'>;
+type SettingsRecoveryState = Pick<ServerStatePayload, 'status' | 'managed' | 'port' | 'wsUrl' | 'version' | 'engineStatus' | 'modelDownload'>;
 
 export interface EnginePreparationLifecycle {
   pending: Record<string, unknown>;
@@ -56,15 +56,15 @@ export function shouldClearServerSettings(
 }
 
 /**
- * Clear every renderer-only preparation flag when the managed server leaves
- * running state. Keeping a staged model after that transition would leave the
- * Settings surface stuck on Preparing with no server-side transaction alive.
+ * Clear renderer-only preparation flags when a managed server leaves running
+ * state. Unmanaged development outages clear fetched server data through
+ * shouldClearServerSettings, but keep staged settings available for recovery.
  */
 export function recoverInterruptedManagedPreparation(
   state: SettingsRecoveryState | null | undefined,
   lifecycle: EnginePreparationLifecycle,
 ): ManagedServerPreparationRecovery | null {
-  if (!shouldClearServerSettings(state)) return null;
+  if (!shouldClearServerSettings(state) || state?.managed !== true) return null;
 
   const interrupted = lifecycle.requested
     || lifecycle.active

--- a/app/src/renderer/app/server-status.ts
+++ b/app/src/renderer/app/server-status.ts
@@ -18,27 +18,15 @@ export interface SharedServerStatus {
   state: ServerStatePayload | null;
   phase: ServerStatusPhase;
   announcement: string;
-  configuredExternalServer: boolean | null;
 }
 
 const initialStatus: SharedServerStatus = {
   state: null,
   phase: 'connecting',
   announcement: 'Checking Eve speech readiness.',
-  configuredExternalServer: null,
 };
 
 export const serverStatusState = writable<SharedServerStatus>(initialStatus);
-
-export type ServerManagementMode = 'managed' | 'external' | 'unknown';
-
-export function getServerManagementMode(status: SharedServerStatus): ServerManagementMode {
-  if (status.configuredExternalServer === true || (status.state !== null && !status.state.managed)) {
-    return 'external';
-  }
-  if (status.state?.managed) return 'managed';
-  return 'unknown';
-}
 
 export function getServerStatusPhase(state: ServerStatePayload | null): ServerStatusPhase {
   if (!state) return 'unavailable';
@@ -114,21 +102,6 @@ function publish(state: ServerStatePayload | null): void {
   schedulePoll();
 }
 
-function setConfiguredExternalServer(configuredExternalServer: boolean): void {
-  current = { ...current, configuredExternalServer };
-  serverStatusState.set(current);
-}
-
-async function refreshConfiguredExternalServer(): Promise<void> {
-  const requestLifecycle = lifecycleGeneration;
-  try {
-    const settings = await window.murmurMain.getSettings();
-    if (requestLifecycle === lifecycleGeneration) setConfiguredExternalServer(settings.useExternalServer);
-  } catch {
-    // Keep management mode unknown when its settings cannot be read.
-  }
-}
-
 function clearPoll(): void {
   if (pollTimer !== null) {
     clearTimeout(pollTimer);
@@ -172,7 +145,6 @@ export function initializeServerStatus(): void {
     publish(state);
   });
   window.addEventListener('focus', reseedOnFocus);
-  void refreshConfiguredExternalServer();
   void refresh();
 }
 

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -184,7 +184,7 @@
     <div class="flex min-w-0 flex-col gap-3 rounded-2xl border border-white/[0.08] bg-white/[0.018] p-4 sm:flex-row sm:items-center sm:justify-between">
       <div class="min-w-0">
         <h2 id="home-privacy-heading" class="text-sm font-medium text-zinc-200">Private by default</h2>
-        <p class="mt-1 max-w-2xl text-xs leading-5 text-zinc-500">Eve processes speech locally through its managed service. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
+        <p class="mt-1 max-w-2xl text-xs leading-5 text-zinc-500">Packaged Eve uses its managed local service for speech. During development, Eve may use a separately started localhost service. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
         {#if shortcutsError}<p class="mt-2 text-xs text-zinc-500">Shortcut labels could not be read. Open Settings to review them.</p>{/if}
       </div>
       <span class="shrink-0 rounded-full border border-emerald-300/15 bg-emerald-300/[0.05] px-3 py-1.5 text-xs text-emerald-300">Local-first</span>

--- a/app/src/renderer/app/views/HomeView.svelte
+++ b/app/src/renderer/app/views/HomeView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { ServerStatusPhase } from '../server-status';
-  import { getServerManagementMode, retryManagedServer, serverStatusState } from '../server-status';
+  import { retryManagedServer, serverStatusState } from '../server-status';
   import PrimaryPage from '../components/PrimaryPage.svelte';
 
   interface Props {
@@ -32,7 +32,6 @@
   };
 
   let readiness = $derived(phaseCopy[snapshot.phase]);
-  let managementMode = $derived(getServerManagementMode(snapshot));
   let phaseAccent = $derived(
     snapshot.phase === 'ready'
       ? 'emerald'
@@ -97,9 +96,6 @@
               </span>
               {snapshot.phase === 'ready' ? 'Listening when you are' : readiness.title}
             </span>
-            {#if managementMode === 'external'}
-              <span class="rounded-full border border-white/10 px-3 py-1.5 text-xs text-zinc-400">External processing</span>
-            {/if}
           </div>
 
           <p class="mt-6 text-xs font-semibold uppercase tracking-[0.24em] text-zinc-500">Your words, ready to move</p>
@@ -137,9 +133,7 @@
         </div>
       </div>
 
-      {#if managementMode === 'external'}
-        <p class="relative mt-5 text-xs leading-5 text-zinc-500">External server — Eve cannot restart this endpoint.</p>
-      {:else if server?.managed && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
+      {#if server?.managed && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
         <button
           type="button"
           onclick={retry}
@@ -149,8 +143,6 @@
         >
           {retrying ? 'Retrying…' : 'Retry managed server'}
         </button>
-      {:else if managementMode === 'unknown' && (snapshot.phase === 'error' || snapshot.phase === 'unavailable')}
-        <p class="relative mt-5 text-xs leading-5 text-zinc-500">Management mode cannot be confirmed. Open Settings &gt; Server &amp; diagnostics.</p>
       {/if}
 
       {#if model && snapshot.phase === 'downloading'}
@@ -192,7 +184,7 @@
     <div class="flex min-w-0 flex-col gap-3 rounded-2xl border border-white/[0.08] bg-white/[0.018] p-4 sm:flex-row sm:items-center sm:justify-between">
       <div class="min-w-0">
         <h2 id="home-privacy-heading" class="text-sm font-medium text-zinc-200">Private by default</h2>
-        <p class="mt-1 max-w-2xl text-xs leading-5 text-zinc-500">By default, Eve processes speech locally. If you configure an external endpoint, audio is sent to that endpoint under your control. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
+        <p class="mt-1 max-w-2xl text-xs leading-5 text-zinc-500">Eve processes speech locally through its managed service. Eve keeps the Murmur legacy profile untouched and does not automatically import personal data.</p>
         {#if shortcutsError}<p class="mt-2 text-xs text-zinc-500">Shortcut labels could not be read. Open Settings to review them.</p>{/if}
       </div>
       <span class="shrink-0 rounded-full border border-emerald-300/15 bg-emerald-300/[0.05] px-3 py-1.5 text-xs text-emerald-300">Local-first</span>

--- a/app/src/renderer/app/views/ServerView.svelte
+++ b/app/src/renderer/app/views/ServerView.svelte
@@ -5,7 +5,7 @@
   import ModelProgressCard from '../components/ModelProgressCard.svelte';
   import type { ServerStatePayload, ServerLogEntry } from '$shared/types';
   import { shouldShowModelProgress } from '$shared/model-progress';
-  import { getServerManagementMode, serverStatusState } from '../server-status';
+  import { serverStatusState } from '../server-status';
   import {
     getServerLogBodySize,
     getServerLogCountLabel,
@@ -16,10 +16,9 @@
 
   interface Props {
     embedded?: boolean;
-    externalMode?: boolean;
   }
 
-  let { embedded = false, externalMode: externalModeProp }: Props = $props();
+  let { embedded = false }: Props = $props();
   const componentId = $props.id();
   const headingTag = $derived(embedded ? 'h3' : 'h2');
 
@@ -37,7 +36,6 @@
   let logsLoadState = $state<ServerLogLoadState>('loading');
   let showLogs = $state(false);
   let autoStart = $state(true);
-  let configuredExternalServer = $state(false);
   let isLoading = $state(false);
   let logsContainer: HTMLDivElement | null = $state(null);
   let logsCopied = $state(false);
@@ -50,9 +48,6 @@
   let removeLogListener: (() => void) | null = null;
   let reloadLogs: (() => Promise<void>) | null = null;
 
-  let externalMode = $derived(
-    externalModeProp ?? getServerManagementMode({ ...$serverStatusState, configuredExternalServer }) === 'external'
-  );
   const logOutputId = `server-log-output-${componentId}`;
   const privacyWarningId = `server-logs-privacy-${componentId}`;
   const diagnosticsStatusId = `server-diagnostics-status-${componentId}`;
@@ -102,19 +97,13 @@
   }
 
   let canStart = $derived(
-    !externalMode &&
     !isLoading &&
     (serverState.status === 'stopped' || serverState.status === 'idle' || serverState.status === 'error')
   );
   let canStop = $derived(
-    !externalMode &&
     !isLoading && serverState.managed && serverState.status === 'running'
   );
   let canRestart = $derived(
-    !externalMode &&
-    !isLoading && serverState.managed && serverState.status === 'running'
-  );
-  let canShutdownManaged = $derived(
     !isLoading && serverState.managed && serverState.status === 'running'
   );
 
@@ -253,7 +242,6 @@
       const settings = await window.murmurMain.getSettings();
       if (!active) return;
       autoStart = settings.serverAutoStart;
-      configuredExternalServer = settings.useExternalServer;
 
       if (!active || removeLogListener) return;
       removeLogListener = window.murmurMain.onServerLog((entry) => {
@@ -279,33 +267,6 @@
 </script>
 
 <div data-server-view class={embedded ? 'min-w-0 space-y-6' : 'h-full min-h-0 min-w-0 space-y-6 overflow-y-auto overscroll-contain p-4 pr-3'}>
-  {#if externalMode}
-    <div data-server-external-notice class="flex min-w-0 flex-col gap-3 rounded-xl border border-amber-800/70 bg-amber-950/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-      <div class="min-w-0">
-        <p class="text-sm text-amber-200">External server mode is enabled</p>
-        <p class="mt-1 text-xs leading-5 text-amber-300/80 [overflow-wrap:anywhere]">
-          Built-in server controls are disabled.
-          {#if embedded}
-            Configure the external endpoint in the Management mode &amp; endpoint section above.
-          {:else}
-            Configure the external endpoint in Settings &gt; Server &amp; diagnostics.
-          {/if}
-        </p>
-      </div>
-      {#if serverState.managed && serverState.status === 'running'}
-        <button
-          type="button"
-          onclick={handleStop}
-          disabled={!canShutdownManaged}
-          class="inline-flex min-h-9 shrink-0 items-center justify-center rounded-lg border border-red-800/70 bg-red-900/60 px-3 py-2 text-xs font-medium text-red-100 transition-colors
-            {canShutdownManaged ? 'cursor-pointer hover:bg-red-900' : 'cursor-not-allowed opacity-60'}"
-        >
-          Shut down built-in server
-        </button>
-      {/if}
-    </div>
-  {/if}
-
   <section data-server-section="diagnostics" class="min-w-0 space-y-2" aria-labelledby={headingId('diagnostics')}>
     <div class="min-w-0 px-1">
       <svelte:element this={headingTag} id={headingId('diagnostics')} class="text-sm font-semibold text-zinc-200">Diagnostics</svelte:element>
@@ -342,7 +303,6 @@
           enabled={autoStart}
           onchange={updateAutoStart}
           label="Auto-start server"
-          disabled={externalMode}
         />
       </SettingsRow>
     </div>
@@ -363,9 +323,6 @@
             <span class="relative h-3 w-3 rounded-full {statusDisplay.bgColor}"></span>
           </span>
           <span data-server-status class="min-w-0 text-lg font-medium {statusDisplay.color} [overflow-wrap:anywhere]">{statusDisplay.label}</span>
-          {#if !serverState.managed && serverState.status === 'running'}
-            <span class="shrink-0 rounded-full border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300">External</span>
-          {/if}
         </div>
 
         {#if serverState.status === 'running' && (serverState.pid !== undefined || serverState.port !== undefined || serverState.version !== undefined || serverState.uptime !== undefined)}
@@ -420,10 +377,6 @@
           {/if}
         </div>
       </div>
-
-      {#if externalMode}
-        <p data-server-action-restriction class="mt-3 border-t border-white/[0.08] pt-3 text-xs leading-5 text-zinc-500">Start, restart, and stop are unavailable while an external endpoint is active.</p>
-      {/if}
 
       {#if serverState.error}
         <div class="mt-4 rounded-lg border border-red-900/60 bg-red-950/30 p-3">

--- a/app/src/renderer/app/views/SettingsView.svelte
+++ b/app/src/renderer/app/views/SettingsView.svelte
@@ -11,7 +11,7 @@
   import ServerView from './ServerView.svelte';
   import SpeechModelChooser from '../components/SpeechModelChooser.svelte';
   import { SPEECH_MODEL_PRESETS, hasPendingCompatibilityChanges, presetMatchesReadyEngine, presetPatch, stagedPresetFromPending } from '../speech-model-presets';
-  import { getServerManagementMode, serverStatusState } from '../server-status';
+  import { serverStatusState } from '../server-status';
   import {
     recoverInterruptedManagedPreparation,
     serverSettingsStateKey,
@@ -23,10 +23,6 @@
   import { toast } from '$lib/toast.svelte';
   import { DEFAULT_SETTINGS, type Settings, type Hotkey, type EngineStatus, type ServerSetting, type ServerSettingOption } from '$shared/types';
   import { HOTWORDS_WARNING_THRESHOLD, formatHotwordsCsl, parseHotwordsCsl } from '$shared/hotwords';
-
-  const DEFAULT_SERVER_HOST = 'localhost';
-  const DEFAULT_SERVER_PORT = 51717;
-  const TRANSCRIBE_PATH = '/transcribe';
 
   const DICTATION_MODE_OPTIONS: EveDropdownOption[] = [
     { value: 'raw', label: 'Raw Dictation' },
@@ -84,9 +80,6 @@
   let settingsLoaded = $state(false);
   let appVersion = $state('unknown');
   let hotwordsFileMessage = $state('');
-  let externalServerHost = $state(DEFAULT_SERVER_HOST);
-  let externalServerPort = $state(String(DEFAULT_SERVER_PORT));
-  let externalServerError = $state('');
 
   let hotwordEntries = $derived(parseHotwordsCsl(settings.hotwordsCsl));
   let hotwordCount = $derived(hotwordEntries.length);
@@ -111,7 +104,6 @@
   let pendingEngine = $state<Record<string, unknown>>({});
   let sharedServerState = $derived($serverStatusState.state);
   let sharedEngineStatus = $derived(engineStatus ?? sharedServerState?.engineStatus ?? null);
-  let externalMode = $derived(settings.useExternalServer || getServerManagementMode($serverStatusState) === 'external');
 
   // Derive current values (server value overridden by pending)
   function getSettingValue<T>(key: string): T | undefined {
@@ -204,82 +196,10 @@
     ].join('\n');
   }
 
-  function parseServerUrl(url: string): { host: string; port: string } {
-    try {
-      const parsed = new URL(url);
-      return {
-        host: parsed.hostname || DEFAULT_SERVER_HOST,
-        port: parsed.port || String(DEFAULT_SERVER_PORT),
-      };
-    } catch {
-      return {
-        host: DEFAULT_SERVER_HOST,
-        port: String(DEFAULT_SERVER_PORT),
-      };
-    }
-  }
-
-  function parseHostPaste(input: string): { host: string; port?: string } {
-    const trimmed = input.trim();
-    if (!trimmed) {
-      return { host: '' };
-    }
-
-    try {
-      const withProtocol = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmed)
-        ? trimmed
-        : `ws://${trimmed}`;
-      const parsed = new URL(withProtocol);
-      return {
-        host: parsed.hostname,
-        port: parsed.port || undefined,
-      };
-    } catch {
-      const hostPortMatch = trimmed.match(/^([^/:\s]+):(\d{1,5})$/);
-      if (hostPortMatch) {
-        return {
-          host: hostPortMatch[1] ?? '',
-          port: hostPortMatch[2],
-        };
-      }
-      return { host: trimmed };
-    }
-  }
-
-  function syncExternalServerFields(url: string): void {
-    const parsed = parseServerUrl(url);
-    externalServerHost = parsed.host;
-    externalServerPort = parsed.port;
-  }
-
-  function buildExternalServerUrl(host: string, port: number): string {
-    return `ws://${host}:${port}${TRANSCRIBE_PATH}`;
-  }
-
-  function updateExternalServerUrl(): void {
-    const host = externalServerHost.trim();
-    const port = Number(externalServerPort);
-    const isValidPort = Number.isInteger(port) && port > 0 && port <= 65535;
-
-    if (!host) {
-      externalServerError = 'Host is required';
-      return;
-    }
-
-    if (!isValidPort) {
-      externalServerError = 'Port must be a number between 1 and 65535';
-      return;
-    }
-
-    externalServerError = '';
-    updateSetting('serverUrl', buildExternalServerUrl(host, port));
-  }
-
   async function loadCoreSettings() {
     try {
       const loadedSettings = await window.murmurMain.getSettings();
       settings = loadedSettings;
-      syncExternalServerFields(loadedSettings.serverUrl);
       settingsLoaded = true;
 
       const displayNames = await Promise.allSettled([
@@ -359,8 +279,8 @@
 
   $effect(() => {
     const state = sharedServerState;
-    if (shouldClearServerSettings(state, externalMode)) {
-      const recovery = recoverInterruptedManagedPreparation(state, externalMode, {
+    if (shouldClearServerSettings(state)) {
+      const recovery = recoverInterruptedManagedPreparation(state, {
         pending: pendingEngine,
         requested: enginePreparationRequested,
         active: enginePreparationActive,
@@ -413,13 +333,6 @@
     settings.hotwordsCsl = value;
     window.murmurMain.updateSetting('hotwordsCsl', value);
     hotwordsFileMessage = '';
-  }
-
-  function updateUseExternalServer(enabled: boolean) {
-    updateSetting('useExternalServer', enabled);
-    if (enabled) {
-      updateExternalServerUrl();
-    }
   }
 
   function openHotkeyCapture(target: 'quick' | 'long') {
@@ -483,7 +396,7 @@
   }
 
   function selectPreset(preset: typeof SPEECH_MODEL_PRESETS[number]): void {
-    if (externalMode || !isEngineAvailable(preset.engine)) return;
+    if (!isEngineAvailable(preset.engine)) return;
     pendingEngine = { ...pendingEngine, ...presetPatch(preset) };
     engineApplyError = '';
   }
@@ -870,7 +783,6 @@
           availabilityKnown={availableEngines.length > 0}
           engineStatus={sharedEngineStatus}
           modelDownload={sharedServerState?.modelDownload}
-          externalMode={externalMode}
           preparationFailed={preparationFailed}
           onSelect={selectPreset}
         >
@@ -880,7 +792,7 @@
                 {preparationFailed ? 'Preparation failed. Retry or revert your selected model.' : 'Selected model is pending preparation; the current engine remains active until the selected model is ready.'}
               </p>
             {/if}
-            {#if stagedPreset && !externalMode}
+            {#if stagedPreset}
               <div class="mt-3 flex flex-wrap items-center gap-2">
                 <button type="button" onclick={applyEngineSettings} disabled={engineApplying} class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed' : 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer'}">{engineApplying ? 'Preparing…' : preparationFailed ? 'Retry preparation' : 'Apply and prepare model'}</button>
                 <button type="button" onclick={revertEngineSettings} disabled={engineApplying || engineRevertDisabled} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying || engineRevertDisabled ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
@@ -926,13 +838,6 @@
             {/if}
           </div>
 
-          {#if externalMode}
-            <div data-compatibility-external class="mt-4 flex items-start gap-3 border-t border-white/[0.08] pt-4 text-xs leading-5 text-zinc-400">
-              <span class="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-amber-300"></span>
-              <p>Compatibility controls are read-only while an external server is active. Configure the external server through its own endpoint.</p>
-            </div>
-          {/if}
-
       {#if !serverConnected}
         <div class="mt-4 border-t border-white/[0.08] pt-4">
           <p class="text-xs leading-5 text-zinc-500">
@@ -940,7 +845,7 @@
           </p>
         </div>
       {:else if serverSettings}
-        <div id="compatibility-controls" hidden={!compatibilityControlsOpen} class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2 {externalMode ? 'opacity-60' : ''}">
+        <div id="compatibility-controls" hidden={!compatibilityControlsOpen} class="mt-4 divide-y divide-white/[0.08] border-t border-white/[0.08] pt-2">
         {#if serverSettings.whisper_model}
           <SettingsRow label={serverSettings.whisper_model.label} description="Raw Whisper compatibility model, including Medium and Tiny">
             <EveDropdown
@@ -948,7 +853,6 @@
               value={String(getSettingValue('whisper_model') ?? serverSettings.whisper_model.value)}
               options={toDropdownOptions(getOptions('whisper_model'))}
               onchange={(value) => updateEngineSetting('whisper_model', value)}
-              disabled={externalMode}
             />
           </SettingsRow>
         {/if}
@@ -959,7 +863,6 @@
               value={String(getSettingValue('whisper_compute_type') ?? serverSettings.whisper_compute_type.value)}
               options={toDropdownOptions(getWhisperComputeOptions())}
               onchange={(value) => updateEngineSetting('whisper_compute_type', value)}
-              disabled={externalMode}
             />
             {#each disabledOptionReasons(getWhisperComputeOptions()) as reason}
               <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
@@ -973,7 +876,6 @@
               aria-label={serverSettings.whisper_language.label}
               value={getSettingValue<string>('whisper_language') ?? String(serverSettings.whisper_language.value ?? '')}
               oninput={(e) => updateEngineSetting('whisper_language', e.currentTarget.value)}
-              disabled={externalMode}
               class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-28"
             />
           </SettingsRow>
@@ -985,7 +887,6 @@
               value={String(getSettingValue('whisper_device') ?? serverSettings.whisper_device.value)}
               options={toDropdownOptions(getOptions('whisper_device'))}
               onchange={(value) => updateEngineSetting('whisper_device', value)}
-              disabled={externalMode}
             />
             {#each disabledOptionReasons(getOptions('whisper_device')) as reason}
               <p data-setting-option-reason class="mt-1 text-xs leading-5 text-amber-300">{reason}</p>
@@ -998,7 +899,6 @@
               enabled={!!getSettingValue('unload_before_swap')}
               onchange={(v) => updateEngineSetting('unload_before_swap', v)}
               label="Unload before swap"
-              disabled={externalMode}
             />
           </SettingsRow>
         {/if}
@@ -1013,9 +913,9 @@
                   <button
                     type="button"
                     onclick={applyEngineSettings}
-                    disabled={engineApplying || externalMode}
+                    disabled={engineApplying}
                     class="min-h-9 rounded-lg px-3 py-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100
-                      {engineApplying || externalMode
+                      {engineApplying
                         ? 'bg-zinc-700 text-zinc-400 cursor-not-allowed'
                         : 'bg-zinc-100 text-zinc-950 hover:bg-white cursor-pointer'}"
                   >
@@ -1027,7 +927,7 @@
                       Apply compatibility changes
                     {/if}
                   </button>
-                  <button type="button" onclick={revertEngineSettings} disabled={engineApplying || engineRevertDisabled || externalMode} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying || engineRevertDisabled || externalMode ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
+                  <button type="button" onclick={revertEngineSettings} disabled={engineApplying || engineRevertDisabled} class="min-h-9 rounded-lg border border-zinc-700 px-3 py-2 text-xs text-zinc-300 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-zinc-100 {engineApplying || engineRevertDisabled ? 'cursor-not-allowed' : 'hover:bg-zinc-800 cursor-pointer'}">Revert</button>
                 </div>
               {/if}
             </div>
@@ -1085,97 +985,11 @@
 
     <SettingsSection
       title="Server &amp; diagnostics"
-      description="Management mode, endpoint, health, diagnostics, and recent logs."
+      description="Server health, diagnostics, lifecycle, and recent logs."
       variant="content"
     >
       <div data-server-diagnostics class="min-w-0 space-y-6">
-        <section data-server-management class="min-w-0 space-y-2" aria-labelledby="settings-server-management-heading">
-          <div class="min-w-0 px-1">
-            <h3 id="settings-server-management-heading" class="text-sm font-semibold text-zinc-200">Management mode &amp; endpoint</h3>
-            <p class="mt-1 max-w-prose text-xs leading-5 text-zinc-500">Choose Eve-managed processing or connect to an external endpoint.</p>
-          </div>
-
-          <div data-server-mode-surface class="min-w-0 overflow-hidden rounded-xl border border-white/10 bg-white/[0.025]">
-            <SettingsRow
-              label="Use external server"
-              description="Connect to your own server and disable built-in server management"
-            >
-              <Toggle
-                enabled={settings.useExternalServer}
-                onchange={updateUseExternalServer}
-                label="Use external server"
-              />
-            </SettingsRow>
-
-            <div class="overflow-hidden border-t border-white/[0.08]">
-              {#if settings.useExternalServer}
-                <div data-external-server-panel class="min-w-0 p-4">
-                  <p class="text-sm text-zinc-200">Custom server endpoint</p>
-                  <p class="mt-1 text-xs leading-5 text-zinc-500">
-                    Set the host and port for your transcription server. Eve connects to <span class="font-mono">/transcribe</span>.
-                  </p>
-
-                  {#if externalServerError}
-                    <p class="mt-3 text-xs leading-5 text-red-300 [overflow-wrap:anywhere]">{externalServerError}</p>
-                  {:else}
-                    <p class="mt-3 text-xs leading-5 text-zinc-500 [overflow-wrap:anywhere]">
-                      Using endpoint <span class="font-mono text-zinc-300">{settings.serverUrl}</span>
-                    </p>
-                  {/if}
-
-                  <div class="mt-4 grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
-                    <div class="min-w-0">
-                      <label for="external-server-host" class="mb-1 block text-xs text-zinc-500">Host</label>
-                      <input
-                        id="external-server-host"
-                        type="text"
-                        value={externalServerHost}
-                        onpaste={(e) => {
-                          const pasted = e.clipboardData?.getData('text') ?? '';
-                          if (!pasted) {
-                            return;
-                          }
-                          const parsed = parseHostPaste(pasted);
-                          if (parsed.host) {
-                            e.preventDefault();
-                            externalServerHost = parsed.host;
-                            if (parsed.port) {
-                              externalServerPort = parsed.port;
-                            }
-                            updateExternalServerUrl();
-                          }
-                        }}
-                        oninput={(e) => {
-                          externalServerHost = e.currentTarget.value;
-                          updateExternalServerUrl();
-                        }}
-                        class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
-                        placeholder="localhost"
-                      />
-                    </div>
-
-                    <div class="min-w-0">
-                      <label for="external-server-port" class="mb-1 block text-xs text-zinc-500">Port</label>
-                      <input
-                        id="external-server-port"
-                        type="text"
-                        value={externalServerPort}
-                        oninput={(e) => {
-                          externalServerPort = e.currentTarget.value;
-                          updateExternalServerUrl();
-                        }}
-                        class="min-h-9 w-full max-w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm font-mono text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-100"
-                        placeholder="51717"
-                      />
-                    </div>
-                  </div>
-                </div>
-              {/if}
-            </div>
-          </div>
-        </section>
-
-        <ServerView embedded externalMode={externalMode} />
+        <ServerView embedded />
       </div>
     </SettingsSection>
 

--- a/app/src/renderer/overlay/audio-capture.ts
+++ b/app/src/renderer/overlay/audio-capture.ts
@@ -124,9 +124,14 @@ registerProcessor('audio-processor', AudioProcessor);
       this.analyserNode.fftSize = 256;
       this.analyserNode.smoothingTimeConstant = 0.5;
 
-      this.workletNode = new AudioWorkletNode(audioContext, 'audio-processor');
-      this.workletNode.port.onmessage = (event) => {
-        if (!this.isCapturing) return;
+      const workletNode = new AudioWorkletNode(audioContext, 'audio-processor');
+      this.workletNode = workletNode;
+      workletNode.port.onmessage = (event) => {
+        if (
+          !this.isCapturing ||
+          generation !== this.startGeneration ||
+          this.workletNode !== workletNode
+        ) return;
         const { audioData } = event.data;
         if (audioData) {
           this.sendAudioToServer(audioData);
@@ -161,6 +166,7 @@ registerProcessor('audio-processor', AudioProcessor);
     }
 
     if (this.workletNode) {
+      this.workletNode.port.onmessage = null;
       this.workletNode.disconnect();
       this.workletNode = null;
     }

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -22,7 +22,7 @@ export interface ServerStatePayload {
   uptime?: number;
   error?: string;
   wsUrl?: string;
-  managed: boolean; // false in dev mode (externally running server)
+  managed: boolean; // false when Eve detected an already-running server
   engineStatus?: EngineStatus;
   diagnostics?: ServerDiagnostics;
   modelDownload?: ModelDownloadState;
@@ -287,7 +287,6 @@ export interface Settings {
   clipboardRestoreDelayMs: number;
   pasteMethod: 'sendinput' | 'vbscript';
   silenceTimeout: number;
-  serverUrl: string;
   // Post-processing
   appendPeriod: boolean;
   appendSpace: boolean;
@@ -299,7 +298,6 @@ export interface Settings {
   startMinimized: boolean;
   // Server management
   serverAutoStart: boolean; // Auto-start server in production mode
-  useExternalServer: boolean; // Bypass managed server and use custom serverUrl
   // Recognition vocabulary hints
   hotwordsEnabled: boolean;
   hotwordsCsl: string;
@@ -416,7 +414,6 @@ export const DEFAULT_SETTINGS: Settings = {
   clipboardRestoreDelayMs: 250,
   pasteMethod: 'sendinput',
   silenceTimeout: 15,
-  serverUrl: 'ws://localhost:51717/transcribe',
   // Post-processing
   appendPeriod: false,
   appendSpace: false,
@@ -428,7 +425,6 @@ export const DEFAULT_SETTINGS: Settings = {
   startMinimized: false,
   // Server management
   serverAutoStart: true,
-  useExternalServer: false,
   // Recognition vocabulary hints
   hotwordsEnabled: false,
   hotwordsCsl: '',

--- a/app/tests/audio-capture-cancellation.test.ts
+++ b/app/tests/audio-capture-cancellation.test.ts
@@ -123,4 +123,105 @@ describe('AudioCapture startup cancellation', () => {
       }
     }
   });
+
+  test('ignores frames from a previous worklet after restart', async () => {
+    const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+    const originalAudioContext = Object.getOwnPropertyDescriptor(globalThis, 'AudioContext');
+    const originalAudioWorkletNode = Object.getOwnPropertyDescriptor(globalThis, 'AudioWorkletNode');
+    const originalRequestAnimationFrame = Object.getOwnPropertyDescriptor(globalThis, 'requestAnimationFrame');
+    const originalCancelAnimationFrame = Object.getOwnPropertyDescriptor(globalThis, 'cancelAnimationFrame');
+    const firstStream = fakeStream();
+    const secondStream = fakeStream();
+    let getUserMediaCallCount = 0;
+    const getUserMedia = mock(() =>
+      Promise.resolve(++getUserMediaCallCount === 1 ? firstStream.stream : secondStream.stream)
+    );
+
+    class FakeAudioContext {
+      audioWorklet = { addModule: async () => undefined };
+
+      createMediaStreamSource() {
+        return { connect: () => undefined, disconnect: () => undefined };
+      }
+
+      createAnalyser() {
+        return {
+          fftSize: 0,
+          smoothingTimeConstant: 0,
+          frequencyBinCount: 128,
+          getByteTimeDomainData: () => undefined,
+          disconnect: () => undefined,
+        };
+      }
+
+      async close() {}
+    }
+
+    class FakeAudioWorkletNode {
+      static nodes: FakeAudioWorkletNode[] = [];
+      port = { onmessage: null as ((event: MessageEvent) => void) | null };
+
+      constructor() {
+        FakeAudioWorkletNode.nodes.push(this);
+      }
+
+      disconnect() {}
+    }
+
+    Object.defineProperties(globalThis, {
+      navigator: {
+        configurable: true,
+        value: { mediaDevices: { getUserMedia } },
+      },
+      AudioContext: { configurable: true, value: FakeAudioContext },
+      AudioWorkletNode: { configurable: true, value: FakeAudioWorkletNode },
+      requestAnimationFrame: { configurable: true, value: () => 1 },
+      cancelAnimationFrame: { configurable: true, value: () => undefined },
+    });
+
+    const capture = new AudioCapture();
+    const audioFrames: ArrayBuffer[] = [];
+
+    try {
+      await capture.start(
+        (frame) => audioFrames.push(frame),
+        () => undefined
+      );
+      const oldWorklet = FakeAudioWorkletNode.nodes[0];
+      expect(oldWorklet).toBeDefined();
+      const oldHandler = oldWorklet?.port.onmessage;
+      oldHandler?.({ data: { audioData: new Float32Array([0.25]) } } as MessageEvent);
+      expect(audioFrames).toHaveLength(1);
+
+      capture.stop();
+      expect(oldWorklet?.port.onmessage).toBeNull();
+
+      await capture.start(
+        (frame) => audioFrames.push(frame),
+        () => undefined
+      );
+      const currentWorklet = FakeAudioWorkletNode.nodes[1];
+      expect(currentWorklet).toBeDefined();
+
+      oldHandler?.({ data: { audioData: new Float32Array([0.75]) } } as MessageEvent);
+      expect(audioFrames).toHaveLength(1);
+
+      currentWorklet?.port.onmessage?.({
+        data: { audioData: new Float32Array([0.5]) },
+      } as MessageEvent);
+      expect(audioFrames).toHaveLength(2);
+    } finally {
+      capture.stop();
+      for (const [name, descriptor] of [
+        ['navigator', originalNavigator],
+        ['AudioContext', originalAudioContext],
+        ['AudioWorkletNode', originalAudioWorkletNode],
+        ['requestAnimationFrame', originalRequestAnimationFrame],
+        ['cancelAnimationFrame', originalCancelAnimationFrame],
+      ] as const) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else delete (globalThis as Record<string, unknown>)[name];
+      }
+    }
+  });
 });

--- a/app/tests/clipboard.test.ts
+++ b/app/tests/clipboard.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 let clipboardText = '';
+let clipboardWrites: string[] = [];
 const execFile = mock((
   command: string,
   args: string[],
@@ -20,6 +21,7 @@ mock.module('electron', () => ({
     readText: () => clipboardText,
     writeText: (text: string) => {
       clipboardText = text;
+      clipboardWrites.push(text);
     },
   },
 }));
@@ -33,6 +35,7 @@ const { buildSendInputScriptContent, getForegroundWindowHandle, pasteText, simul
 describe('pasteText', () => {
   beforeEach(() => {
     clipboardText = 'previous';
+    clipboardWrites = [];
     execFile.mockClear();
   });
 
@@ -55,6 +58,42 @@ describe('pasteText', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 800));
     expect(clipboardText).toBe('previous');
+  });
+
+  test('does not restore over a user clipboard change', async () => {
+    await pasteText('new text', {
+      restoreClipboard: true,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 12345,
+    });
+
+    clipboardText = 'user text';
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    expect(clipboardText).toBe('user text');
+  });
+
+  test('does not let an older paste restore over a newer paste', async () => {
+    const firstPaste = pasteText('new text', {
+      restoreClipboard: true,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 12345,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const secondPaste = pasteText('new text', {
+      restoreClipboard: true,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 12345,
+    });
+
+    await Promise.all([firstPaste, secondPaste]);
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    expect(clipboardText).toBe('new text');
+    expect(clipboardWrites).not.toContain('previous');
   });
 
   test('does not fall back to untargeted VBScript when targeted SendInput fails', async () => {

--- a/app/tests/clipboard.test.ts
+++ b/app/tests/clipboard.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 let clipboardText = '';
+let clipboardFormats: string[] = [];
 let clipboardWrites: string[] = [];
 const execFile = mock((
   command: string,
@@ -19,8 +20,10 @@ mock.module('electron', () => ({
   },
   clipboard: {
     readText: () => clipboardText,
+    availableFormats: () => [...clipboardFormats],
     writeText: (text: string) => {
       clipboardText = text;
+      clipboardFormats = ['text/plain'];
       clipboardWrites.push(text);
     },
   },
@@ -35,6 +38,7 @@ const { buildSendInputScriptContent, getForegroundWindowHandle, pasteText, simul
 describe('pasteText', () => {
   beforeEach(() => {
     clipboardText = 'previous';
+    clipboardFormats = ['text/plain'];
     clipboardWrites = [];
     execFile.mockClear();
   });
@@ -72,6 +76,21 @@ describe('pasteText', () => {
     await new Promise((resolve) => setTimeout(resolve, 800));
 
     expect(clipboardText).toBe('user text');
+  });
+
+  test('does not restore over rich clipboard content with the same text', async () => {
+    await pasteText('new text', {
+      restoreClipboard: true,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 12345,
+    });
+
+    clipboardFormats = ['text/plain', 'text/html'];
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    expect(clipboardText).toBe('new text');
+    expect(clipboardFormats).toEqual(['text/plain', 'text/html']);
   });
 
   test('does not let an older paste restore over a newer paste', async () => {

--- a/app/tests/clipboard.test.ts
+++ b/app/tests/clipboard.test.ts
@@ -111,8 +111,8 @@ describe('pasteText', () => {
     await Promise.all([firstPaste, secondPaste]);
     await new Promise((resolve) => setTimeout(resolve, 800));
 
-    expect(clipboardText).toBe('new text');
-    expect(clipboardWrites).not.toContain('previous');
+    expect(clipboardText).toBe('previous');
+    expect(clipboardWrites).toContain('previous');
   });
 
   test('does not paste a superseded operation', async () => {
@@ -136,6 +136,67 @@ describe('pasteText', () => {
     expect(execFile.mock.calls[0]?.[1]).toContain('22222');
     expect(execFile.mock.calls[0]?.[1]).not.toContain('11111');
     expect(clipboardWrites).toEqual(['first text', 'second text']);
+  });
+
+  test('serializes an in-flight paste and restores the original sequence baseline', async () => {
+    let finishFirstSimulation: ((error?: Error | null, stdout?: string) => void) | undefined;
+    execFile.mockImplementationOnce((_command, _args, options, callback) => {
+      finishFirstSimulation = typeof options === 'function' ? options : callback;
+      return { kill: mock(() => {}) };
+    });
+
+    const firstPaste = pasteText('first text', {
+      restoreClipboard: true,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 11111,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 140));
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(execFile.mock.calls[0]?.[1]).toContain('11111');
+    const secondPaste = pasteText('second text', {
+      restoreClipboard: true,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 22222,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(clipboardText).toBe('first text');
+    expect(execFile).toHaveBeenCalledTimes(1);
+
+    finishFirstSimulation?.(null, '');
+    await Promise.all([firstPaste, secondPaste]);
+
+    expect(execFile).toHaveBeenCalledTimes(2);
+    expect(execFile.mock.calls[1]?.[1]).toContain('22222');
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    expect(clipboardText).toBe('previous');
+  });
+
+  test('keeps the original baseline when a newer paste starts during settling', async () => {
+    const firstPaste = pasteText('first text', {
+      restoreClipboard: true,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 11111,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const secondPaste = pasteText('second text', {
+      restoreClipboard: true,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 22222,
+    });
+
+    await Promise.all([firstPaste, secondPaste]);
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(execFile.mock.calls[0]?.[1]).toContain('22222');
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    expect(clipboardText).toBe('previous');
   });
 
   test('does not fall back to untargeted VBScript when targeted SendInput fails', async () => {

--- a/app/tests/clipboard.test.ts
+++ b/app/tests/clipboard.test.ts
@@ -115,6 +115,29 @@ describe('pasteText', () => {
     expect(clipboardWrites).not.toContain('previous');
   });
 
+  test('does not paste a superseded operation', async () => {
+    const firstPaste = pasteText('first text', {
+      restoreClipboard: false,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 11111,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const secondPaste = pasteText('second text', {
+      restoreClipboard: false,
+      restoreDelayMs: 1,
+      method: 'sendinput',
+      targetWindowHandle: 22222,
+    });
+
+    await Promise.all([firstPaste, secondPaste]);
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(execFile.mock.calls[0]?.[1]).toContain('22222');
+    expect(execFile.mock.calls[0]?.[1]).not.toContain('11111');
+    expect(clipboardWrites).toEqual(['first text', 'second text']);
+  });
+
   test('does not fall back to untargeted VBScript when targeted SendInput fails', async () => {
     execFile.mockImplementationOnce((_command: string, _args: string[], _options: unknown, callback: (error?: Error | null) => void) => {
       callback(new Error('target activation failed'));

--- a/app/tests/diagnostics-report.test.ts
+++ b/app/tests/diagnostics-report.test.ts
@@ -113,7 +113,7 @@ VC++ runtime installed: yes
       history: sensitiveValues[2],
     });
 
-    expect(output).toContain('Server mode: external');
+    expect(output).toContain('Server mode: detected');
     expect(output).toContain('Model: custom/local model');
     expect(output).toContain('- cuda_unavailable: CUDA is unavailable; Eve may use CPU mode.');
     expect(output).toContain('- unknown_warning: Additional details omitted for privacy.');
@@ -153,7 +153,7 @@ VC++ runtime installed: yes
     expect(output).not.toContain('ETA:');
   });
 
-  test('does not copy regex-valid secrets from an external server', () => {
+  test('does not copy regex-valid secrets from a detected server', () => {
     const secret = 'top-secret-token';
     const output = report({
       status: 'running',

--- a/app/tests/fixtures/settings-server-electron.cjs
+++ b/app/tests/fixtures/settings-server-electron.cjs
@@ -12,7 +12,6 @@ const userData = path.resolve(tempRoot, `eve-settings-server-${process.pid}`);
 const cases = [
   ['managed-ready', false, 'managed-ready.png'],
   ['managed-error', false, 'managed-error.png'],
-  ['external-ready', false, 'external-ready.png'],
   ['managed-ready', true, 'logs-expanded.png'],
   ['managed-long', false, 'long-strings.png'],
   ['managed-short', true, null],
@@ -92,8 +91,6 @@ async function measure(window, state, logsExpanded, zoom) {
       headingIdsUnique: headingIds.every(Boolean) && new Set(headingIds).size === headingIds.length,
       headingLevels: [...document.querySelectorAll('h1, h2, h3')].map((heading) => Number(heading.tagName.slice(1))),
       serverSubsectionCount: serverView?.querySelectorAll('[data-server-section]').length ?? 0,
-      external: !!document.querySelector('[data-server-external-notice]'),
-      restriction: !!document.querySelector('[data-server-action-restriction]'),
       status: document.querySelector('[data-server-status]')?.textContent?.trim() ?? '',
       healthButtonsDisabled: [...document.querySelectorAll('[data-server-health-surface] button')].map((button) => button.disabled),
       autoStartDisabled: document.querySelector('[data-server-management-surface] [role="switch"]')?.disabled ?? false,

--- a/app/tests/fixtures/settings-speech-electron.cjs
+++ b/app/tests/fixtures/settings-speech-electron.cjs
@@ -14,7 +14,6 @@ const electronScreenshots = [
   ['speech', 'ready', false, 'speech-ready.png'],
   ['speech', 'preparing', false, 'speech-preparing.png'],
   ['speech', 'error', false, 'speech-error.png'],
-  ['speech', 'external', false, null],
   ['speech', 'ready', true, 'compatibility-expanded.png'],
 ];
 
@@ -68,7 +67,6 @@ async function measure(window, view, state, compatibility, zoom) {
       optionContained: !!ownerRect && optionRects.every((option) => option && option.left >= ownerRect.left && option.right <= ownerRect.right),
       focus: focusStyle ? { focusWithin: !!focusLabel?.matches(':focus-within'), outlineWidth: focusStyle.outlineWidth, boxShadow: focusStyle.boxShadow } : null,
       document: { scrollWidth: document.documentElement.scrollWidth, clientWidth: document.documentElement.clientWidth },
-      external: !!document.querySelector('[data-speech-model-external]'),
       compatibilityExpanded: compatibilityButton?.getAttribute('aria-expanded') === 'true' && !!compatibilityControls,
       compatibilityAssociation: !!compatibilityButton && compatibilityButton.getAttribute('aria-controls') === compatibilityControls?.id,
     };

--- a/app/tests/gate5-accessibility.test.ts
+++ b/app/tests/gate5-accessibility.test.ts
@@ -52,6 +52,14 @@ describe('Gate 5 accessibility contracts', () => {
     expect(hotkeyModal).toContain('aria-modal="true"');
   });
 
+  test('ignores stale hotkey capture callbacks across cancel and reopen', () => {
+    expect(hotkeyModal).toContain('let captureGeneration = 0;');
+    expect(hotkeyModal).toContain('const generation = ++captureGeneration;');
+    expect(hotkeyModal).toContain('if (generation !== captureGeneration) return;');
+    expect(hotkeyModal).toContain('if (generation === captureGeneration)');
+    expect(hotkeyModal).toContain('captureGeneration += 1;');
+  });
+
   test('keeps the overlay click-through, non-focusable, and noninteractive', () => {
     expect(overlayWindow).toContain('focusable: false');
     expect(overlayWindow).toContain('overlay.setIgnoreMouseEvents(true)');

--- a/app/tests/gate5-information-architecture.test.ts
+++ b/app/tests/gate5-information-architecture.test.ts
@@ -33,7 +33,7 @@ describe('Gate 5 information architecture', () => {
   test('embeds every existing server surface under Settings Server & diagnostics', () => {
     expect(settingsView).toContain("import ServerView");
     expect(settingsView).toContain('title="Server &amp; diagnostics"');
-    expect(settingsView).toContain('<ServerView embedded externalMode={externalMode} />');
+    expect(settingsView).toContain('<ServerView embedded />');
 
     for (const operation of [
       'startServer',

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -4,7 +4,6 @@ import { get } from 'svelte/store';
 import {
   disposeServerStatus,
   getDownloadMilestone,
-  getServerManagementMode,
   getServerStatusPhase,
   initializeServerStatus,
   refresh,
@@ -203,10 +202,8 @@ describe('Home and shared server status', () => {
     expect(mount).not.toContain('updateServerSettings');
     expect(mount).not.toContain('prepare');
     expect(homeView).toContain('onclick={retry}');
-    expect(homeView).toContain('External server — Eve cannot restart this endpoint.');
-    expect(homeView).toContain('Management mode cannot be confirmed. Open Settings &gt; Server &amp; diagnostics.');
-    expect(statusController).toContain('const settings = await window.murmurMain.getSettings();');
-    expect(statusController).toContain('setConfiguredExternalServer(settings.useExternalServer);');
+    expect(homeView).not.toContain('External server');
+    expect(statusController).not.toContain('useExternalServer');
     expect(homeView).toContain('if (retrying) return;');
     expect(homeView).toContain('disabled={retrying}');
     expect(statusController).toContain('if (!initialized || !current.state?.managed || retryInFlight) return false;');
@@ -234,16 +231,15 @@ describe('Home and shared server status', () => {
     expect(serverView).toContain('if (!active) return;');
     expect(banner).toContain('Open Settings &gt; Server &amp; diagnostics for details.');
     expect(banner).not.toContain('Open Server and use Restart');
-    expect(homeView).toContain('By default, Eve processes speech locally.');
-    expect(homeView).toContain('audio is sent to that endpoint under your control.');
+    expect(homeView).toContain('Eve processes speech locally through its managed service.');
   });
 
-  test('shares external management truth and retains a forced-colors focus fallback', () => {
-    expect(getServerManagementMode({ state: null, phase: 'unavailable', announcement: '', configuredExternalServer: null })).toBe('unknown');
-    expect(getServerManagementMode({ state: null, phase: 'unavailable', announcement: '', configuredExternalServer: true })).toBe('external');
-    expect(getServerManagementMode({ state: { status: 'running', managed: true }, phase: 'stale', announcement: '', configuredExternalServer: false })).toBe('managed');
+  test('keeps detected development servers separate from managed retry actions', () => {
+    expect(getServerStatusPhase({ status: 'running', managed: false, engineStatus: { current: 'whisper', status: 'ready' } })).toBe('ready');
+    expect(statusController).toContain('!current.state?.managed');
+    expect(homeView).not.toContain('getServerManagementMode');
     expect(homeView).toContain('focus-visible:outline-hidden');
-    expect(banner).toContain('getServerManagementMode($serverStatusState)');
+    expect(banner).not.toContain('getServerManagementMode');
   });
 
   test('uses the expressive Home composition and tolerates sparse runtime metadata', () => {

--- a/app/tests/home-shared-status.test.ts
+++ b/app/tests/home-shared-status.test.ts
@@ -231,7 +231,8 @@ describe('Home and shared server status', () => {
     expect(serverView).toContain('if (!active) return;');
     expect(banner).toContain('Open Settings &gt; Server &amp; diagnostics for details.');
     expect(banner).not.toContain('Open Server and use Restart');
-    expect(homeView).toContain('Eve processes speech locally through its managed service.');
+    expect(homeView).toContain('Packaged Eve uses its managed local service for speech.');
+    expect(homeView).toContain('During development, Eve may use a separately started localhost service.');
   });
 
   test('keeps detected development servers separate from managed retry actions', () => {

--- a/app/tests/hotkey-capture-lifecycle.test.ts
+++ b/app/tests/hotkey-capture-lifecycle.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+type KeyboardEvent = {
+  keycode: number;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  metaKey: boolean;
+};
+
+type KeyboardListener = (event: KeyboardEvent) => void;
+
+const listeners = new Set<KeyboardListener>();
+const uIOhook = {
+  on: mock((_event: string, listener: KeyboardListener) => {
+    listeners.add(listener);
+  }),
+  off: mock((_event: string, listener: KeyboardListener) => {
+    listeners.delete(listener);
+  }),
+  start: mock(() => undefined),
+  stop: mock(() => undefined),
+};
+
+mock.module('electron', () => ({
+  app: {
+    on: mock(() => undefined),
+  },
+}));
+
+mock.module('uiohook-napi', () => ({
+  uIOhook,
+  UiohookKey: {
+    Ctrl: 29,
+    CtrlRight: 3613,
+    Alt: 56,
+    AltRight: 3640,
+    Shift: 42,
+    ShiftRight: 54,
+    Meta: 3675,
+    MetaRight: 3676,
+    F17: 100,
+  },
+}));
+
+mock.module('../src/main/services/settings.js', () => ({
+  getSetting: () => ({
+    keycode: 3675,
+    ctrlKey: true,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+  }),
+}));
+
+const { cancelHotkeyCapture, startHotkeyCapture } = await import('../src/main/services/hotkey.js');
+
+const keyEvent = (keycode: number): KeyboardEvent => ({
+  keycode,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  metaKey: false,
+});
+
+describe('hotkey capture lifecycle', () => {
+  test('cancellation settles the pending invocation and detaches its listener', async () => {
+    const pending = startHotkeyCapture();
+
+    cancelHotkeyCapture();
+
+    await expect(pending).rejects.toMatchObject({
+      message: 'Hotkey capture cancelled',
+    });
+    expect(listeners.size).toBe(0);
+  });
+
+  test('replacement settles the old invocation and ignores its stale callback', async () => {
+    const first = startHotkeyCapture();
+    const staleListener = [...listeners][0];
+    expect(staleListener).toBeDefined();
+
+    const second = startHotkeyCapture();
+    const currentListener = [...listeners][0];
+    expect(currentListener).toBeDefined();
+    expect(currentListener).not.toBe(staleListener);
+
+    await expect(first).rejects.toMatchObject({
+      message: 'Hotkey capture replaced',
+    });
+
+    staleListener?.(keyEvent(100));
+    expect(listeners).toContain(currentListener);
+
+    currentListener?.(keyEvent(100));
+    await expect(second).resolves.toMatchObject({
+      hotkey: {
+        keycode: 100,
+      },
+    });
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/app/tests/pipeline.test.ts
+++ b/app/tests/pipeline.test.ts
@@ -22,7 +22,6 @@ const settings: Settings = {
   clipboardRestoreDelayMs: 250,
   pasteMethod: 'sendinput',
   silenceTimeout: 15,
-  serverUrl: 'ws://localhost:51717/transcribe',
   appendPeriod: false,
   appendSpace: false,
   dictationMode: 'clean_prompt',
@@ -30,7 +29,6 @@ const settings: Settings = {
   launchOnBoot: false,
   startMinimized: false,
   serverAutoStart: true,
-  useExternalServer: false,
   hotwordsEnabled: false,
   hotwordsCsl: '',
 };

--- a/app/tests/server-api-url.test.ts
+++ b/app/tests/server-api-url.test.ts
@@ -6,11 +6,12 @@ describe('server API endpoint selection', () => {
   const dynamic = 'ws://localhost:51490/transcribe';
 
   test('uses the manager-reported dynamic endpoint for managed running servers', () => {
-    expect(resolveServerApiUrl(configured, { status: 'running', wsUrl: dynamic }, false)).toBe(dynamic);
-    expect(resolveServerApiUrl(configured, { status: 'starting' }, false)).toBe(configured);
+    expect(resolveServerApiUrl(configured, { status: 'running', wsUrl: dynamic })).toBe(dynamic);
+    expect(resolveServerApiUrl(configured, { status: 'starting' })).toBe(configured);
   });
 
-  test('preserves the configured endpoint for external-server mode', () => {
-    expect(resolveServerApiUrl(configured, { status: 'running', wsUrl: dynamic }, true)).toBe(configured);
+  test('falls back to localhost until the manager reports a running server', () => {
+    expect(resolveServerApiUrl(configured, null)).toBe(configured);
+    expect(resolveServerApiUrl(configured, { status: 'stopped', wsUrl: dynamic })).toBe(configured);
   });
 });

--- a/app/tests/server-api-url.test.ts
+++ b/app/tests/server-api-url.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { resolveServerApiUrl } from '../src/main/services/server-api-url';
 
 describe('server API endpoint selection', () => {
@@ -10,8 +11,15 @@ describe('server API endpoint selection', () => {
     expect(resolveServerApiUrl(configured, { status: 'starting' })).toBe(configured);
   });
 
-  test('falls back to localhost until the manager reports a running server', () => {
+  test('requires a discovered endpoint in packaged mode while preserving the development fallback', () => {
     expect(resolveServerApiUrl(configured, null)).toBe(configured);
-    expect(resolveServerApiUrl(configured, { status: 'stopped', wsUrl: dynamic })).toBe(configured);
+    expect(resolveServerApiUrl(undefined, null)).toBeUndefined();
+    expect(resolveServerApiUrl(undefined, { status: 'stopped', wsUrl: dynamic })).toBeUndefined();
+  });
+
+  test('fails closed before packaged API settings calls can use localhost', () => {
+    const source = readFileSync(new URL('../src/main/ipc/handlers.ts', import.meta.url), 'utf8');
+    expect(source).toContain('const configuredUrl = app.isPackaged ? undefined : LOCAL_SERVER_URL;');
+    expect(source).toContain("throw new Error('Managed server URL unavailable');");
   });
 });

--- a/app/tests/server-settings-recovery.test.ts
+++ b/app/tests/server-settings-recovery.test.ts
@@ -31,10 +31,9 @@ describe('Settings server-state recovery', () => {
     const loading = { ...ready, engineStatus: { current: 'whisper', status: 'loading' as const } };
     expect(serverSettingsStateKey(loading)).not.toBe(readyKey);
     expect(shouldRetryServerSettings(loading, false, false, readyKey)).toBeTrue();
-    expect(shouldClearServerSettings(null, false)).toBeFalse();
-    expect(shouldClearServerSettings(starting, false)).toBeTrue();
-    expect(shouldClearServerSettings(starting, true)).toBeFalse();
-    expect(shouldClearServerSettings(ready, false)).toBeFalse();
+    expect(shouldClearServerSettings(null)).toBeFalse();
+    expect(shouldClearServerSettings(starting)).toBeTrue();
+    expect(shouldClearServerSettings(ready)).toBeFalse();
   });
 
   test('retries when the live endpoint changes even if its port is reused', () => {
@@ -42,7 +41,7 @@ describe('Settings server-state recovery', () => {
     expect(serverSettingsStateKey(samePortDifferentEndpoint)).not.toBe(serverSettingsStateKey(ready));
   });
 
-  test('clears an interrupted managed preparation and preserves external-server state', () => {
+  test('clears an interrupted managed preparation after the server stops', () => {
     const lifecycle = {
       pending: { engine: 'nemotron', nemotron_model: 'nvidia/canary-qwen-2.5b' },
       requested: true,
@@ -51,7 +50,7 @@ describe('Settings server-state recovery', () => {
       applying: true,
     };
 
-    expect(recoverInterruptedManagedPreparation(starting, false, lifecycle)).toEqual({
+    expect(recoverInterruptedManagedPreparation(starting, lifecycle)).toEqual({
       pending: {},
       requested: false,
       active: false,
@@ -59,7 +58,6 @@ describe('Settings server-state recovery', () => {
       applying: false,
       message: 'The managed speech server stopped while model settings were being prepared. Restart it, then select and apply the model again.',
     });
-    expect(recoverInterruptedManagedPreparation(starting, true, lifecycle)).toBeNull();
-    expect(recoverInterruptedManagedPreparation(ready, false, lifecycle)).toBeNull();
+    expect(recoverInterruptedManagedPreparation(ready, lifecycle)).toBeNull();
   });
 });

--- a/app/tests/server-settings-recovery.test.ts
+++ b/app/tests/server-settings-recovery.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/renderer/app/server-settings-recovery';
 
 const starting = { status: 'starting' as const, managed: true };
+const unmanagedStarting = { status: 'starting' as const, managed: false };
 const ready = {
   status: 'running' as const,
   managed: true,
@@ -59,5 +60,18 @@ describe('Settings server-state recovery', () => {
       message: 'The managed speech server stopped while model settings were being prepared. Restart it, then select and apply the model again.',
     });
     expect(recoverInterruptedManagedPreparation(ready, lifecycle)).toBeNull();
+  });
+
+  test('preserves staged preparation during an unmanaged development outage', () => {
+    const lifecycle = {
+      pending: { engine: 'whisper' },
+      requested: true,
+      active: true,
+      observed: true,
+      applying: true,
+    };
+
+    expect(shouldClearServerSettings(unmanagedStarting)).toBeTrue();
+    expect(recoverInterruptedManagedPreparation(unmanagedStarting, lifecycle)).toBeNull();
   });
 });

--- a/app/tests/server-startup.test.ts
+++ b/app/tests/server-startup.test.ts
@@ -69,6 +69,28 @@ describe('packaged server startup timing', () => {
     );
   });
 
+  test('keeps packaged recording on discovered managed readiness', () => {
+    const source = readFileSync(
+      new URL('../src/main/index.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(source).toContain('if (app.isPackaged && !discoveredServerUrl)');
+    expect(source).toContain('serverState?.engineStatus?.status !== \'ready\'');
+    expect(source).toContain('const serverUrl = discoveredServerUrl ?? LOCAL_SERVER_URL;');
+    expect(source).not.toContain('useExternalServer');
+  });
+
+  test('ignores legacy external endpoint keys in public settings', () => {
+    const source = readFileSync(
+      new URL('../src/main/services/settings.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(source).not.toContain('serverUrl: store.get');
+    expect(source).not.toContain('useExternalServer: store.get');
+  });
+
   test('keeps one definitive PATH when merging packaged server environment', () => {
     const childEnvironment = buildChildEnvironment(
       {

--- a/app/tests/settings-server-cohesion.test.ts
+++ b/app/tests/settings-server-cohesion.test.ts
@@ -16,7 +16,7 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
   test('uses one cohesive Server & diagnostics section without nested SettingsSection composition', () => {
     expect(settingsView).toContain('title="Server &amp; diagnostics"');
     expect(settingsView).toContain('data-server-diagnostics');
-    expect(settingsView).toContain('<ServerView embedded externalMode={externalMode} />');
+    expect(settingsView).toContain('<ServerView embedded />');
     expect(settingsView).not.toContain('<SettingsSection title="Server">');
     expect(serverView).not.toContain('<SettingsSection');
     expect(serverView).not.toContain('title="Settings"');
@@ -24,20 +24,15 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(serverView).toContain('aria-labelledby={headingId(');
   });
 
-  test('keeps management mode, endpoint, auto-start, health, and truthful external restrictions together', () => {
-    expect(settingsView).toContain('data-server-management');
-    expect(settingsView).toContain('data-server-mode-surface');
-    expect(settingsView).toContain('label="Use external server"');
-    expect(settingsView).toContain('data-external-server-panel');
-    expect(serverFixture).toContain('{#if externalEnabled}');
+  test('keeps managed lifecycle, health, diagnostics, and logs together', () => {
+    expect(settingsView).not.toContain('data-server-mode-surface');
+    expect(settingsView).not.toContain('Use external server');
+    expect(settingsView).not.toContain('data-external-server-panel');
+    expect(serverFixture).not.toContain('external');
     expect(serverView).toContain('data-server-section="management"');
     expect(serverView).toContain('label="Auto-start server"');
-    expect(serverView).toContain('disabled={externalMode}');
-    expect(serverView).toContain('data-server-action-restriction');
-    expect(serverView.match(/!externalMode &&/g)?.length).toBe(3);
-    expect(serverView).toContain('getServerManagementMode');
-    expect(serverView).toContain('Management mode &amp; endpoint section above.');
-    expect(serverView).toContain('Settings &gt; Server &amp; diagnostics.');
+    expect(serverView).not.toContain('externalMode');
+    expect(serverView).not.toContain('data-server-action-restriction');
     expect(serverView).toContain('window.murmurMain.startServer()');
     expect(serverView).toContain('window.murmurMain.stopServer()');
     expect(serverView).toContain('window.murmurMain.restartServer()');
@@ -89,7 +84,6 @@ describe('Phase 3 Server and diagnostics cohesion contracts', () => {
     expect(primaryPage).toContain('data-scroll-owner={scrollOwner}');
     expect(primaryPage).toContain('overflow-x-hidden overflow-y-auto overscroll-contain');
     expect(settingsView).toContain('min-h-9 w-full max-w-full rounded-lg border border-zinc-700');
-    expect(settingsView).toContain('[overflow-wrap:anywhere]');
     expect(serverView).toContain('[overflow-wrap:anywhere]');
     expect(serverView).toContain('serverState.version !== undefined');
     expect(serverView).toContain('serverState.uptime !== undefined');

--- a/app/tests/settings-server-rendered.test.mjs
+++ b/app/tests/settings-server-rendered.test.mjs
@@ -143,7 +143,7 @@ describe('rendered Phase 3 Server and diagnostics fixture', () => {
     expect(measurements.length).toBe(48);
     for (const measurement of measurements) {
       expect(measurement.owner.overflowY).toBe('auto');
-      expect(measurement.owner.scrollHeight).toBeGreaterThan(measurement.owner.clientHeight);
+      expect(measurement.owner.scrollHeight).toBeGreaterThanOrEqual(measurement.owner.clientHeight);
       expect(measurement.owner.scrollWidth).toBeLessThanOrEqual(measurement.owner.clientWidth);
       expect(measurement.document.scrollWidth).toBeLessThanOrEqual(measurement.document.clientWidth);
       expect(measurement.scrollersOutsideLogs).toBe(1);

--- a/app/tests/settings-server-rendered.test.mjs
+++ b/app/tests/settings-server-rendered.test.mjs
@@ -140,7 +140,7 @@ const { measurements } = result;
 
 describe('rendered Phase 3 Server and diagnostics fixture', () => {
   test('keeps one page scroll owner and no horizontal overflow at narrow/high zoom states', () => {
-    expect(measurements.length).toBe(54);
+    expect(measurements.length).toBe(48);
     for (const measurement of measurements) {
       expect(measurement.owner.overflowY).toBe('auto');
       expect(measurement.owner.scrollHeight).toBeGreaterThan(measurement.owner.clientHeight);
@@ -155,22 +155,9 @@ describe('rendered Phase 3 Server and diagnostics fixture', () => {
     const ready = measurements.find((measurement) => measurement.state === 'managed-ready' && measurement.zoom === 1 && measurement.viewport.width === 960);
     const error = measurements.find((measurement) => measurement.state === 'managed-error' && measurement.zoom === 1 && measurement.viewport.width === 960);
     expect(ready.status).toBe('Running');
-    expect(ready.external).toBeFalse();
-    expect(ready.restriction).toBeFalse();
     expect(ready.healthButtonsDisabled.every((disabled) => disabled === false)).toBeTrue();
     expect(error.status).toBe('Error');
-    expect(error.external).toBeFalse();
     expect(error.healthButtonsDisabled.every((disabled) => disabled === false)).toBeTrue();
-  });
-
-  test('renders external restrictions without hiding factual health, diagnostics, or logs', () => {
-    const external = measurements.find((measurement) => measurement.state === 'external-ready' && measurement.zoom === 1 && measurement.viewport.width === 960);
-    expect(external.external).toBeTrue();
-    expect(external.restriction).toBeTrue();
-    expect(external.healthButtonsDisabled.every((disabled) => disabled === true)).toBeTrue();
-    expect(external.autoStartDisabled).toBeTrue();
-    expect(external.status).toBe('Running');
-    expect(external.privacyWarning).toBeTrue();
   });
 
   test('keeps collapsed and expanded logs associated, private-data warning visible, and output bounded', () => {
@@ -238,7 +225,7 @@ describe('rendered Phase 3 Server and diagnostics fixture', () => {
   });
 
   test('cleans the isolated Electron userData directory and writes deterministic screenshots', () => {
-    expect(result.screenshots).toHaveLength(5);
+    expect(result.screenshots).toHaveLength(4);
     for (const screenshot of result.screenshots) {
       expect(existsSync(screenshot)).toBeTrue();
     }

--- a/app/tests/settings-speech-cohesion.test.ts
+++ b/app/tests/settings-speech-cohesion.test.ts
@@ -35,7 +35,7 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(chooser).not.toContain('rounded-xl border p-3 transition-colors');
   });
 
-  test('distinguishes current, selected, available, preparing, error, and external states', () => {
+  test('distinguishes current, selected, available, preparing, and error states', () => {
     expect(chooser).toContain("if (isError(preset)) return isSelected(preset) ? 'Selected · Error' : 'Error'");
     expect(chooser).toContain("if (isPreparing(preset)) return 'Preparing'");
     expect(chooser).toContain("if (isCurrent(preset)) return 'Current'");
@@ -43,7 +43,6 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(chooser).toContain("'Selected'");
     expect(chooser).toContain("return 'Available'");
     expect(chooser).toContain("return 'Unavailable'");
-    expect(chooser).toContain('data-speech-model-external');
     expect(chooser).toContain('preparationFailed: boolean');
     expect(settingsView).toContain('preparationFailed={preparationFailed}');
   });
@@ -55,7 +54,7 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(settingsView).toContain('>Revert</button>');
     expect(settingsView).toContain('current engine remains active until the selected model is ready');
     expect(settingsView).toContain('selectPreset');
-    expect(settingsView).toContain('if (externalMode || !isEngineAvailable(preset.engine)) return;');
+    expect(settingsView).toContain('if (!isEngineAvailable(preset.engine)) return;');
     expect(settingsView).not.toContain('async function pollEngineStatus');
     expect(settingsView).toContain('void loadServerSettings()');
   });
@@ -67,7 +66,7 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(settingsView).toContain('id="compatibility-controls"');
     expect(settingsView).toContain('hidden={!compatibilityControlsOpen}');
     expect(settingsView).toContain('hasPendingCompatibilityChanges(pendingEngine, stagedPreset)');
-    expect(chooser).toContain('externalMode || unavailable(preset)');
+    expect(chooser).toContain('const disabled = unavailable(preset)');
     expect(settingsView).toContain("'whisper_compute_type'");
     expect(settingsView).toContain("'whisper_language'");
     expect(settingsView).not.toContain("'nemotron_device'");
@@ -76,7 +75,7 @@ describe('Phase 2 General and Speech cohesion contracts', () => {
     expect(settingsView).toContain('data-compatibility-footer');
     expect(settingsView).toContain('Apply compatibility changes');
     expect(settingsView).toContain('data-engine-status');
-    expect(settingsView).toContain('disabled={externalMode}');
+    expect(settingsView).not.toContain('disabled={externalMode}');
     expect(settingsView).not.toContain('engineAdvancedOpen');
     expect(settingsView).not.toContain('engine-advanced-options');
   });

--- a/app/tests/settings-speech-rendered.test.mjs
+++ b/app/tests/settings-speech-rendered.test.mjs
@@ -101,7 +101,7 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
   });
 
   test('keeps the General and Speech fixture inside one page scroll owner at all zooms', () => {
-    expect(measurements.length).toBe(36);
+    expect(measurements.length).toBe(30);
     for (const measurement of measurements) {
       expect(measurement.owner.overflowY).toBe('auto');
       expect(measurement.owner.overflowX).toBe('hidden');
@@ -132,12 +132,7 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
     expect(error.states.some((label) => label.includes('Selected') && label.includes('Error'))).toBeTrue();
   });
 
-  test('preserves external restrictions and the compatibility disclosure association', () => {
-    const external = measurements.find((measurement) => measurement.view === 'speech' && measurement.state === 'external' && measurement.zoom === 1);
-    expect(external.external).toBeTrue();
-    expect(external.optionCount).toBe(0);
-    expect(external.focus.focusWithin).toBeFalse();
-
+  test('keeps the compatibility disclosure association', () => {
     const expanded = measurements.find((measurement) => measurement.compatibility);
     expect(expanded.compatibilityExpanded).toBeTrue();
     expect(expanded.compatibilityAssociation).toBeTrue();
@@ -160,7 +155,7 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
   });
 
   test('writes deterministic isolated screenshots and cleans Electron userData', () => {
-    expect(result.screenshots).toHaveLength(5);
+    expect(result.screenshots).toHaveLength(4);
     for (const screenshot of result.screenshots) {
       expect(existsSync(screenshot)).toBeTrue();
     }

--- a/app/tests/settings-speech-rendered.test.mjs
+++ b/app/tests/settings-speech-rendered.test.mjs
@@ -155,7 +155,7 @@ describe('rendered Phase 2 Settings/Speech fixture', () => {
   });
 
   test('writes deterministic isolated screenshots and cleans Electron userData', () => {
-    expect(result.screenshots).toHaveLength(4);
+    expect(result.screenshots).toHaveLength(5);
     for (const screenshot of result.screenshots) {
       expect(existsSync(screenshot)).toBeTrue();
     }

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -24,10 +24,13 @@ uv run pytest
 uv run python -m src.main
 ```
 
-Use `uv sync --extra release --frozen` when preparing the shipped Whisper-only
-closure. The experimental `nemotron` extra remains available for deferred
-repair work, but is not shipped or user-selectable in this alpha. Development
-commands must use the current clone, never a copied user environment.
+Use `uv sync --python 3.11 --no-dev --extra release --frozen` when preparing the
+shipped Whisper-only closure. Pinning the sync interpreter keeps compiled
+packages compatible with the relocatable runtime, and `--no-dev` keeps the
+default development group out of the shipped environment. The experimental
+`nemotron` extra remains available for deferred repair work, but is not shipped
+or user-selectable in this alpha. Development commands must use the current
+clone, never a copied user environment.
 
 ## Windows package preparation
 
@@ -35,16 +38,18 @@ The supported installer is `nsis-web`. Before a release-authorized package attem
 
 ```powershell
 Set-Location server
-uv sync --extra release --frozen
+uv sync --python 3.11 --no-dev --extra release --frozen
 ../scripts/prepare-python-runtime.ps1 -ServerDir .
 
 Set-Location ../app
 bun run package:win
 ```
 
-`prepare-python-runtime.ps1` copies and verifies the standalone `.runtime` CPython
-root. Do not substitute a virtual-environment launcher, move caches, or modify the
-frozen app identity, NSIS GUID, profiles, install chain, or historical release assets.
+`prepare-python-runtime.ps1` checks that the synced `.venv` and managed runtime
+use the same Python ABI before copying and verifying the standalone `.runtime`
+CPython root. Do not substitute a virtual-environment launcher, move caches, or
+modify the frozen app identity, NSIS GUID, profiles, install chain, or historical
+release assets.
 The package script uses `--publish never`; package, tag, upload, draft, and public
 release actions each require their applicable authorization and release plan.
 

--- a/docs/installer-dependencies.md
+++ b/docs/installer-dependencies.md
@@ -139,7 +139,7 @@ These warnings are actionable and include guidance or links where possible.
 
 | Build Config | PyTorch? | cuBLAS/cuDNN available? | Whisper GPU? | Nemotron |
 |-------------|----------|------------------------|-------------|----------|
-| `uv sync --extra release` | Yes (cu124) | Yes, via packaged torch/lib/ | Yes (if the driver supports it) | Deferred |
+| `uv sync --python 3.11 --no-dev --extra release --frozen` | Yes (cu124) | Yes, via packaged torch/lib/ | Yes (if the driver supports it) | Deferred |
 | `uv sync --extra all` | Yes (cu124) | Yes, via packaged torch/lib/ | Yes (if the driver supports it) | Experimental only |
 | `uv sync --extra nemotron` | Yes (cu124) | Yes, via packaged torch/lib/ | N/A (not installed) | Deferred repair |
 | `uv sync --extra whisper` | **No** | **No** | CPU only | N/A |
@@ -158,7 +158,7 @@ CUDA runtime. No separate CUDA Toolkit or user-installed NeMo stack is required.
 
 ### 5.1 Release Workflow Installs the Whisper Closure (Resolved)
 
-The release workflow now runs `uv sync --extra release`, so the packaged venv contains Faster-Whisper and locked CUDA PyTorch without NeMo or torchaudio. This provides the CUDA DLLs needed for the shipped Whisper engine while keeping Nemotron deferred and unavailable in the alpha.
+The release workflow now runs `uv sync --python 3.11 --no-dev --extra release --frozen`, so the packaged venv contains Faster-Whisper and locked CUDA PyTorch without NeMo, torchaudio, or the default development group. This provides the CUDA DLLs needed for the shipped Whisper engine while keeping Nemotron deferred and unavailable in the alpha.
 
 ### 5.2 NSIS 2GB Installer Size Limit (Resolved via nsis-web)
 
@@ -260,7 +260,7 @@ https://aka.ms/vs/17/release/vc_redist.x64.exe
 
 ### Completed in the current release pipeline
 
-1. Release workflow installs the shipped Whisper closure with `uv sync --extra release`
+1. Release workflow installs the shipped Whisper closure with `uv sync --python 3.11 --no-dev --extra release --frozen`
 2. nsis-web packaging avoids the 2GB limit and ships payload artifacts with releases
 3. Runtime diagnostics warn about missing VC++ Redistributable, CUDA DLLs, or outdated drivers
 4. First-run model download UX includes status messaging and retry guidance

--- a/docs/releases/eve-v0.8.0-release-notes.md
+++ b/docs/releases/eve-v0.8.0-release-notes.md
@@ -21,8 +21,8 @@ created by these notes.
 
 ## Compatibility and privacy
 
-- Eve processes audio locally by default. If a user configures an external endpoint, audio
-  is sent to that endpoint under the user's control.
+- Eve processes audio through its bundled local service. Packaged Eve does not expose a
+  configurable external-server endpoint.
 - Eve does not automatically read, import, merge, prompt for, or delete legacy Murmur
   personal data. `%APPDATA%\murmur` remains untouched; `%APPDATA%\Eve` is the active
   profile.

--- a/docs/windows-local-cuda-dictation.md
+++ b/docs/windows-local-cuda-dictation.md
@@ -149,7 +149,6 @@ Set `%APPDATA%\murmur\settings.json` to:
   "launchOnBoot": true,
   "startMinimized": true,
   "serverAutoStart": true,
-  "useExternalServer": false,
   "hotwordsEnabled": false,
   "hotwordsCsl": ""
 }
@@ -177,7 +176,6 @@ $appSettings = "$env:APPDATA\murmur\settings.json"
   "clipboardRestoreDelayMs": 250,
   "pasteMethod": "sendinput",
   "silenceTimeout": 15,
-  "serverUrl": "ws://localhost:51717/transcribe",
   "appendPeriod": false,
   "appendSpace": true,
   "dictationMode": "clean_prompt",
@@ -185,7 +183,6 @@ $appSettings = "$env:APPDATA\murmur\settings.json"
   "launchOnBoot": true,
   "startMinimized": true,
   "serverAutoStart": true,
-  "useExternalServer": false,
   "hotwordsEnabled": false,
   "hotwordsCsl": "",
   "__internal__": {
@@ -197,7 +194,7 @@ $appSettings = "$env:APPDATA\murmur\settings.json"
 '@ | Set-Content -LiteralPath $appSettings -Encoding UTF8
 ```
 
-`serverUrl` may remain at `51717`; the bundled server manager can allocate a dynamic port and writes the actual active port to `%APPDATA%\murmur\server.pid`.
+The bundled server manager can allocate a dynamic port and writes the active port to `%APPDATA%\murmur\server.pid`; packaged recording uses that discovered endpoint. Development falls back to `ws://localhost:51717/transcribe` when no local server has been detected.
 
 ## Server virtual environment
 

--- a/scripts/prepare-python-runtime.ps1
+++ b/scripts/prepare-python-runtime.ps1
@@ -53,6 +53,19 @@ function Assert-SelfContainedRuntime {
     }
 }
 
+function Get-PythonAbi {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PythonPath
+    )
+
+    $pythonAbi = (& $PythonPath -I -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")').Trim()
+    if ($LASTEXITCODE -ne 0 -or $pythonAbi -notmatch '^\d+$') {
+        throw "Could not determine the Python ABI for $PythonPath."
+    }
+    return $pythonAbi
+}
+
 uv python install $PythonVersion
 $previousVirtualEnv = $env:VIRTUAL_ENV
 try {
@@ -83,9 +96,15 @@ if ((Test-PathWithin -Path $pythonPath -Root $serverPath) -or
 }
 
 $runtimeSource = Split-Path -Parent $pythonPath
-$pythonAbi = (& $pythonPath -I -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")').Trim()
-if ($LASTEXITCODE -ne 0 -or -not $pythonAbi) {
-    throw "Could not determine the managed Python ABI version."
+$pythonAbi = Get-PythonAbi -PythonPath $pythonPath
+
+$venvPython = Join-Path $serverPath ".venv\Scripts\python.exe"
+if (-not (Test-Path -LiteralPath $venvPython -PathType Leaf)) {
+    throw "Release virtual environment is missing its Python executable: $venvPython"
+}
+$venvAbi = Get-PythonAbi -PythonPath $venvPython
+if ($venvAbi -ne $pythonAbi) {
+    throw "Release .venv/runtime Python ABI mismatch: .venv=$venvAbi runtime=$pythonAbi"
 }
 
 foreach ($required in @("python.exe", "python$pythonAbi.dll", "Lib", "DLLs")) {

--- a/server/src/audio/buffer.py
+++ b/server/src/audio/buffer.py
@@ -68,6 +68,33 @@ class AudioBuffer:
             return np.array([], dtype=np.float32)
         return samples.astype(np.float32) / 32768.0
 
+    def get_audio_tail_float32(self, max_samples: int) -> NDArray[np.float32]:
+        """Get a bounded tail of accumulated audio as float32 samples.
+
+        Only chunks needed for the requested tail are copied and converted;
+        earlier retained audio is not materialized.
+        """
+        if max_samples <= 0 or not self._chunks:
+            return np.array([], dtype=np.float32)
+
+        remaining = min(max_samples, self._total_samples)
+        tail_chunks: list[NDArray[np.float32]] = []
+        for chunk in reversed(self._chunks):
+            if remaining <= 0:
+                break
+            if len(chunk) == 0:
+                continue
+            tail = chunk[-remaining:]
+            tail_chunks.append(tail.astype(np.float32) / 32768.0)
+            remaining -= len(tail)
+
+        if not tail_chunks:
+            return np.array([], dtype=np.float32)
+        tail_chunks.reverse()
+        if len(tail_chunks) == 1:
+            return tail_chunks[0]
+        return np.concatenate(tail_chunks)
+
     def clear(self) -> None:
         """Clear all accumulated audio."""
         self._chunks.clear()

--- a/server/src/transcription/processor.py
+++ b/server/src/transcription/processor.py
@@ -109,20 +109,18 @@ class TranscriptionProcessor:
 
         start_time = time.perf_counter()
         audio_duration = self._context.audio_buffer.duration_seconds
+        loop = asyncio.get_running_loop()
+        if audio_duration >= self._long_dictation_threshold_s:
+            return await self._transcribe_long_partial_window(
+                audio_duration=audio_duration,
+                start_time=start_time,
+                loop=loop,
+            )
 
         audio = self._context.audio_buffer.get_audio_float32()
 
         if len(audio) == 0:
             return None
-
-        loop = asyncio.get_running_loop()
-        if audio_duration >= self._long_dictation_threshold_s:
-            return await self._transcribe_long_partial_window(
-                audio,
-                audio_duration=audio_duration,
-                start_time=start_time,
-                loop=loop,
-            )
 
         if self._allow_overlapping_inference:
             executor = await get_executor(self._transcription_max_workers)
@@ -210,12 +208,11 @@ class TranscriptionProcessor:
 
     async def _transcribe_long_partial_window(
         self,
-        audio,
         *,
         audio_duration: float,
         start_time: float,
         loop: asyncio.AbstractEventLoop,
-    ) -> TranscriptionResult:
+    ) -> TranscriptionResult | None:
         """Use a bounded tail window for speech timing after long mode starts.
 
         We intentionally suppress live text for long recordings. Re-emitting a
@@ -223,8 +220,13 @@ class TranscriptionProcessor:
         long-context drift that chunked final mode is designed to avoid.
         """
         max_samples = max(1, int(self._long_dictation_chunk_s * AUDIO_SAMPLE_RATE))
-        window_start_sample = max(0, len(audio) - max_samples)
-        window_audio = audio[window_start_sample:]
+        window_audio = self._context.audio_buffer.get_audio_tail_float32(max_samples)
+        if len(window_audio) == 0:
+            return None
+        window_start_sample = max(
+            0,
+            self._context.audio_buffer.sample_count - len(window_audio),
+        )
         result = await self._run_transcribe(
             window_audio,
             loop=loop,

--- a/server/tests/test_long_dictation.py
+++ b/server/tests/test_long_dictation.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from audio.buffer import AudioBuffer
 import transcription.processor as processor_module
 from transcription.errors import VramExhaustedError
 from transcription.long_dictation import plan_chunks, stitch_text
@@ -41,6 +42,7 @@ class _FakeAudioBuffer:
 class _RecordingSession:
     def __init__(self) -> None:
         self.calls: list[tuple[int, TranscribeOptions | None]] = []
+        self.audio_inputs: list[np.ndarray] = []
 
     def transcribe(
         self,
@@ -50,6 +52,7 @@ class _RecordingSession:
         options: TranscribeOptions | None = None,
     ) -> TranscribeResult:
         self.calls.append((len(audio), options))
+        self.audio_inputs.append(np.array(audio, copy=True))
         return TranscribeResult(
             text=f"chunk {len(self.calls)}",
             confidence=0.8,
@@ -175,15 +178,28 @@ async def test_long_partial_uses_tail_window_for_speech_timing_only(
 ) -> None:
     session = _RecordingSession()
     manager = _RecordingManager(session)
-    audio = np.zeros(int(40 * 16000), dtype=np.float32)
+    first_chunk = np.full(3 * 16000, 100, dtype=np.int16)
+    last_chunk = np.linspace(-1000, 1000, 16000, dtype=np.int16)
+    audio_buffer = AudioBuffer()
+    audio_buffer.append(0, first_chunk)
+    audio_buffer.append(1, last_chunk)
+
+    def _fail_full_conversion() -> np.ndarray:
+        raise AssertionError("long partials must not convert the full audio buffer")
+
+    monkeypatch.setattr(audio_buffer, "get_audio_float32", _fail_full_conversion)
     context = SimpleNamespace(
         session_id="long-partial",
-        audio_buffer=_FakeAudioBuffer(audio),
+        audio_buffer=audio_buffer,
         hotwords=None,
         last_partial_text="previous visible text",
     )
 
-    monkeypatch.setattr(processor_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(
+        processor_module,
+        "get_settings",
+        lambda: _settings(long_dictation_threshold_s=3.0, long_dictation_chunk_s=2.0),
+    )
     monkeypatch.setattr(processor_module, "get_engine_manager", lambda: manager)
 
     processor = processor_module.TranscriptionProcessor(context)
@@ -193,10 +209,14 @@ async def test_long_partial_uses_tail_window_for_speech_timing_only(
     assert result.text == ""
     assert result.is_empty is True
     assert len(session.calls) == 1
-    assert session.calls[0][0] == int(25 * 16000)
+    assert session.calls[0][0] == 2 * 16000
     assert session.calls[0][1] is not None
     assert session.calls[0][1].condition_on_previous_text is False
-    assert result.last_speech_end == pytest.approx(40.0)
+    expected_tail = (
+        np.concatenate((first_chunk[-16000:], last_chunk)).astype(np.float32) / 32768.0
+    )
+    np.testing.assert_array_equal(session.audio_inputs[0], expected_tail)
+    assert result.last_speech_end == pytest.approx(4.0)
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -142,6 +142,29 @@ def test_release_verification_targets_eve_with_legacy_payload_name() -> None:
     assert '"murmur-$ExpectedVersion-x64.nsis.7z"' in contents
 
 
+def test_release_sync_pins_python_excludes_dev_and_checks_runtime_abi() -> None:
+    release_sync = "uv sync --python 3.11 --no-dev --extra release --frozen"
+    for relative_path in (
+        "AGENTS.md",
+        "README.md",
+        "docs/development/building.md",
+        "docs/installer-dependencies.md",
+    ):
+        assert release_sync in (ROOT / relative_path).read_text(encoding="utf-8")
+
+    runtime_script = (ROOT / "scripts" / "prepare-python-runtime.ps1").read_text(
+        encoding="utf-8"
+    )
+    assert 'Join-Path $serverPath ".venv\\Scripts\\python.exe"' in runtime_script
+    assert "$venvAbi = Get-PythonAbi -PythonPath $venvPython" in runtime_script
+    assert "Release .venv/runtime Python ABI mismatch" in runtime_script
+    mismatch_index = runtime_script.index("Release .venv/runtime Python ABI mismatch")
+    replace_index = runtime_script.index(
+        'Remove-Item -LiteralPath $runtimePath -Recurse -Force'
+    )
+    assert mismatch_index < replace_index
+
+
 def test_release_extra_is_whisper_torch_only_and_all_keeps_nemotron() -> None:
     project = _load_server_pyproject()["project"]
     extras = project["optional-dependencies"]


### PR DESCRIPTION
## Summary

This bounded stabilization integrates the seven accepted fixes on canonical `2d03ad4`:

- settle hotkey capture cancellation/replacement and detach stale listeners;
- ignore stale AudioWorklet frames and dispose pending capture acquisitions;
- protect clipboard restoration ownership and keep targeted paste failures fail-closed;
- pin the release Python ABI and omit development-only dependencies from the packaged runtime path;
- bound recurring long-dictation partial PCM windows;
- remove current-product external-server controls and claims while preserving the development localhost path;
- fail closed before packaged API calls until a managed local endpoint is discovered.

The full-session PCM retention concern remains intentionally tracked in [#69](https://github.com/burntcookiedough/eve-windows-dictation/issues/69); the long-dictation change bounds the working partial window without changing final-session storage semantics.

## Focused validation

- `bun test tests/hotkey-capture-lifecycle.test.ts tests/audio-capture-cancellation.test.ts tests/clipboard.test.ts` — 14 passed.
- `bun test tests/diagnostics-report.test.ts tests/gate5-information-architecture.test.ts tests/home-shared-status.test.ts tests/pipeline.test.ts tests/server-api-url.test.ts tests/server-settings-recovery.test.ts tests/server-startup.test.ts tests/settings-server-cohesion.test.ts tests/settings-speech-cohesion.test.ts` — 38 passed; `home-shared-status.test.ts` is unavailable in this clean worktree because `app/node_modules` is intentionally absent.
- `PYTHONPATH=server/src python -m pytest tests/test_long_dictation.py tests/test_buffer.py tests/test_release_config.py tests/test_docs_consistency.py -q` — 37 passed.
- `git diff --check` — passed; tracked tree clean before push.

Packaging, manual smoke, full-session validation, and release/signing/publication remain pending. No build, package, runtime preparation, tag, merge, or release was performed for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Packaged builds now use only the bundled local speech service; configurable external endpoints have been removed.
  * Development setups may connect to a separately started localhost speech service.
  * Server settings and diagnostics now distinguish managed and detected services more clearly.
* **Bug Fixes**
  * Improved hotkey capture, audio-session, and clipboard handling to prevent stale activity.
  * Reduced memory use during long partial transcriptions by processing only recent audio.
* **Documentation**
  * Clarified privacy, networking, and release setup requirements, including Python 3.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->