### PR TITLE
Prepare Eve v0.8.2-alpha.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eve for Windows
 
-<p><img src="https://img.shields.io/badge/v0.8.2-alpha.1-orange?style=flat-square" alt="v0.8.2-alpha.1"> <strong>Source status: v0.8.2-alpha.1 pre-alpha · unreleased</strong></p>
+<p><img src="https://img.shields.io/badge/v0.8.2-alpha.2-orange?style=flat-square" alt="v0.8.2-alpha.2"> <strong>Source status: v0.8.2-alpha.1 pre-alpha · unreleased</strong></p>
 
 ## Local-first dictation that stays in your flow
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eve for Windows
 
-<p><img src="https://img.shields.io/badge/v0.8.2-alpha.2-orange?style=flat-square" alt="v0.8.2-alpha.2"> <strong>Source status: v0.8.2-alpha.1 pre-alpha · unreleased</strong></p>
+<p><img src="https://img.shields.io/badge/v0.8.2-alpha.2-orange?style=flat-square" alt="v0.8.2-alpha.2"> <strong>Source status: v0.8.2-alpha.2 stabilization alpha · prerelease</strong></p>
 
 ## Local-first dictation that stays in your flow
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.8.2-alpha.1",
+  "version": "0.8.2-alpha.2",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$ExpectedVersion = "0.8.2-alpha.1",
+    [string]$ExpectedVersion = "0.8.2-alpha.2",
     [string]$InstallerDir = "E:\EveRelease\release-prep\full-nsis-web\nsis-web",
     [string]$InstallDir = "E:\EveRelease\release-prep\smoke-install\Eve",
     [string]$BaseBranch = "trunk",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.8.2-alpha.1"
+version = "0.8.2-alpha.2"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.8.2-alpha.1"
+SERVER_VERSION = "0.8.2-alpha.2"

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "murmur"
-version = "0.8.2-alpha.1"
+version = "0.8.2-alpha.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- prepare Eve v0.8.2-alpha.2 version metadata from merged commit bfd3cbf455eb06e865bdca3e9a39345af90affcb
- update only the six fields owned by `scripts/version.py`

## Validation
- `python scripts/version.py check --tag v0.8.2-alpha.2`
- six-file allowlist and field-only diff proof
- `git diff --check`

This is a mechanical preparation PR. No build, package, tag, release, or publication was performed.