### PR TITLE
Bound Eve/Murmur responsiveness paths

### DIFF
--- a/app/src/main/services/server-log-transport.ts
+++ b/app/src/main/services/server-log-transport.ts
@@ -1,0 +1,84 @@
+import { StringDecoder } from 'node:string_decoder';
+
+/**
+ * Frames text from a child-process stream without assuming data events align
+ * with log boundaries. Newlines and bare carriage returns both terminate an
+ * entry so progress updates do not remain embedded in a later log line.
+ */
+export class ServerLogFramer {
+  private readonly decoder = new StringDecoder('utf8');
+  private pending = '';
+
+  push(chunk: Uint8Array | string): string[] {
+    const text = typeof chunk === 'string' ? chunk : this.decoder.write(chunk);
+    return this.consume(text);
+  }
+
+  flush(): string[] {
+    const frames = this.consume(this.decoder.end());
+    if (this.pending.trim()) {
+      frames.push(this.pending);
+    }
+    this.pending = '';
+    return frames;
+  }
+
+  private consume(text: string): string[] {
+    if (text.length === 0) return [];
+
+    this.pending += text;
+    const frames: string[] = [];
+    let frameStart = 0;
+
+    for (let index = 0; index < this.pending.length; index += 1) {
+      const code = this.pending.charCodeAt(index);
+      if (code !== 10 && code !== 13) continue;
+
+      const frame = this.pending.slice(frameStart, index);
+      if (frame.trim()) frames.push(frame);
+      frameStart = index + 1;
+    }
+
+    if (frameStart > 0) {
+      this.pending = this.pending.slice(frameStart);
+    }
+
+    return frames;
+  }
+}
+
+/**
+ * FIFO delivery queue that retains the newest entries when a producer is
+ * faster than its consumer. The bounded size keeps renderer IPC backpressure
+ * from growing without limit while preserving recent diagnostics.
+ */
+export class BoundedLogDeliveryQueue<T> {
+  private readonly entries: T[] = [];
+
+  constructor(private readonly capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity < 1) {
+      throw new RangeError('Log delivery queue capacity must be a positive integer');
+    }
+  }
+
+  get size(): number {
+    return this.entries.length;
+  }
+
+  enqueue(entry: T): void {
+    this.entries.push(entry);
+    const overflow = this.entries.length - this.capacity;
+    if (overflow > 0) {
+      this.entries.splice(0, overflow);
+    }
+  }
+
+  drain(maxEntries: number): T[] {
+    if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) return [];
+    return this.entries.splice(0, maxEntries);
+  }
+
+  clear(): void {
+    this.entries.length = 0;
+  }
+}

--- a/app/src/main/services/server-log-transport.ts
+++ b/app/src/main/services/server-log-transport.ts
@@ -1,9 +1,28 @@
 import { StringDecoder } from 'node:string_decoder';
+import { Buffer } from 'node:buffer';
+
+export const MAX_PENDING_FRAME_BYTES = 64 * 1024;
+
+function takeUtf8Prefix(value: string, maxBytes: number): [string, string] {
+  let byteLength = 0;
+  let end = 0;
+
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, 'utf8');
+    if (byteLength + characterBytes > maxBytes) break;
+    byteLength += characterBytes;
+    end += character.length;
+  }
+
+  return [value.slice(0, end), value.slice(end)];
+}
 
 /**
  * Frames text from a child-process stream without assuming data events align
  * with log boundaries. Newlines and bare carriage returns both terminate an
  * entry so progress updates do not remain embedded in a later log line.
+ * Unterminated output is emitted in bounded UTF-8 chunks to prevent a noisy
+ * child process from retaining an unbounded pending frame.
  */
 export class ServerLogFramer {
   private readonly decoder = new StringDecoder('utf8');
@@ -41,6 +60,13 @@ export class ServerLogFramer {
 
     if (frameStart > 0) {
       this.pending = this.pending.slice(frameStart);
+    }
+
+    while (Buffer.byteLength(this.pending, 'utf8') > MAX_PENDING_FRAME_BYTES) {
+      const [frame, remainder] = takeUtf8Prefix(this.pending, MAX_PENDING_FRAME_BYTES);
+      if (!frame) break;
+      if (frame.trim()) frames.push(frame);
+      this.pending = remainder;
     }
 
     return frames;

--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -32,6 +32,7 @@ const log = createLogger('ServerManager');
 
 const MAX_LOG_ENTRIES = 500;
 const HEALTH_POLL_INTERVAL_MS = 3000;
+const HEALTH_REQUEST_TIMEOUT_MS = 2000;
 const STOP_TIMEOUT_MS = 10000;
 const execFileAsync = promisify(execFile);
 
@@ -95,15 +96,16 @@ export class ServerManager {
   /**
    * Check server health by hitting the /health endpoint.
    */
-  private async getHealthState(port: number): Promise<HealthState> {
+  private async getHealthState(
+    port: number,
+    timeoutMs = HEALTH_REQUEST_TIMEOUT_MS,
+  ): Promise<HealthState> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 2000);
-
       const response = await fetch(`http://localhost:${port}/health`, {
         signal: controller.signal,
       });
-      clearTimeout(timeout);
 
       if (!response.ok) {
         return { healthy: false };
@@ -112,6 +114,8 @@ export class ServerManager {
       return parseHealthyResponse(await response.json());
     } catch {
       return { healthy: false };
+    } finally {
+      clearTimeout(timeout);
     }
   }
 
@@ -640,15 +644,35 @@ export class ServerManager {
    * Wait for health check to pass.
    */
   private async waitForHealth(port: number, timeoutMs: number): Promise<HealthState | null> {
-    const startTime = Date.now();
-    while (Date.now() - startTime < timeoutMs) {
-      const health = await this.getHealthState(port);
-      if (health.healthy) {
-        return health;
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) return null;
+
+      let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const health = await Promise.race([
+          this.getHealthState(port, Math.min(HEALTH_REQUEST_TIMEOUT_MS, remainingMs)),
+          new Promise<null>((resolve) => {
+            deadlineTimer = setTimeout(() => resolve(null), remainingMs);
+          }),
+        ]);
+        if (health?.healthy) {
+          return health;
+        }
+      } finally {
+        if (deadlineTimer !== undefined) {
+          clearTimeout(deadlineTimer);
+        }
       }
-      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      const remainingAfterCheckMs = deadline - Date.now();
+      if (remainingAfterCheckMs <= 0) return null;
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, Math.min(500, remainingAfterCheckMs));
+      });
     }
-    return null;
   }
 
   /**

--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -27,10 +27,13 @@ import {
   waitForPidFile,
 } from './server-startup.js';
 import { buildChildEnvironment } from './server-environment.js';
+import { BoundedLogDeliveryQueue, ServerLogFramer } from './server-log-transport.js';
 
 const log = createLogger('ServerManager');
 
 const MAX_LOG_ENTRIES = 500;
+const SERVER_LOG_DELIVERY_INTERVAL_MS = 50;
+const SERVER_LOG_DELIVERY_BATCH_SIZE = 50;
 const HEALTH_POLL_INTERVAL_MS = 3000;
 const HEALTH_REQUEST_TIMEOUT_MS = 2000;
 const STOP_TIMEOUT_MS = 10000;
@@ -41,6 +44,8 @@ export class ServerManager {
   private childProcess: ChildProcess | null = null;
   private pidFile: ServerPidFile | null = null;
   private logs: ServerLogEntry[] = [];
+  private readonly pendingLogDelivery = new BoundedLogDeliveryQueue<ServerLogEntry>(MAX_LOG_ENTRIES);
+  private logDeliveryTimer: ReturnType<typeof setTimeout> | null = null;
   private healthPollInterval: ReturnType<typeof setInterval> | null = null;
   private mainWindow: BrowserWindow | null = null;
   private managed = false; // Whether we spawned the server (production) vs detected it (dev)
@@ -256,6 +261,42 @@ export class ServerManager {
     this.broadcastLog(entry);
   }
 
+  private clearPendingLogDelivery(): void {
+    if (this.logDeliveryTimer !== null) {
+      clearTimeout(this.logDeliveryTimer);
+      this.logDeliveryTimer = null;
+    }
+    this.pendingLogDelivery.clear();
+  }
+
+  private scheduleLogDelivery(): void {
+    if (this.logDeliveryTimer !== null) return;
+
+    this.logDeliveryTimer = setTimeout(() => {
+      this.logDeliveryTimer = null;
+      this.flushLogDelivery();
+    }, SERVER_LOG_DELIVERY_INTERVAL_MS);
+  }
+
+  private flushLogDelivery(): void {
+    if (!this.mainWindow || this.mainWindow.isDestroyed()) {
+      this.pendingLogDelivery.clear();
+      return;
+    }
+
+    for (const entry of this.pendingLogDelivery.drain(SERVER_LOG_DELIVERY_BATCH_SIZE)) {
+      if (!this.mainWindow || this.mainWindow.isDestroyed()) {
+        this.pendingLogDelivery.clear();
+        return;
+      }
+      this.mainWindow.webContents.send(IPC_CHANNELS.SERVER_LOG, entry);
+    }
+
+    if (this.pendingLogDelivery.size > 0) {
+      this.scheduleLogDelivery();
+    }
+  }
+
   /**
    * Update status and broadcast to renderer.
    */
@@ -279,7 +320,8 @@ export class ServerManager {
    */
   private broadcastLog(entry: ServerLogEntry): void {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
-    this.mainWindow.webContents.send(IPC_CHANNELS.SERVER_LOG, entry);
+    this.pendingLogDelivery.enqueue(entry);
+    this.scheduleLogDelivery();
   }
 
   /**
@@ -530,6 +572,7 @@ export class ServerManager {
     this.setDiagnostics(undefined);
     this.setModelDownload(undefined);
     this.setEngineStatus(undefined);
+    this.clearPendingLogDelivery();
     this.logs = []; // Clear logs for new session
 
     try {
@@ -551,20 +594,33 @@ export class ServerManager {
         env: childEnv,
       });
 
+      const stdoutFramer = new ServerLogFramer();
+      const stderrFramer = new ServerLogFramer();
+      const emitFramedLogs = (framer: ServerLogFramer, level: 'stdout' | 'stderr') => {
+        for (const line of framer.flush()) {
+          this.addLog(level, line);
+        }
+      };
+
       // Capture stdout
       this.childProcess.stdout?.on('data', (data: Buffer) => {
-        const lines = data.toString().split('\n').filter((l) => l.trim());
-        for (const line of lines) {
+        for (const line of stdoutFramer.push(data)) {
           this.addLog('stdout', line);
         }
       });
+      this.childProcess.stdout?.once('end', () => emitFramedLogs(stdoutFramer, 'stdout'));
 
       // Capture stderr
       this.childProcess.stderr?.on('data', (data: Buffer) => {
-        const lines = data.toString().split('\n').filter((l) => l.trim());
-        for (const line of lines) {
+        for (const line of stderrFramer.push(data)) {
           this.addLog('stderr', line);
         }
+      });
+      this.childProcess.stderr?.once('end', () => emitFramedLogs(stderrFramer, 'stderr'));
+
+      this.childProcess.once('close', () => {
+        emitFramedLogs(stdoutFramer, 'stdout');
+        emitFramedLogs(stderrFramer, 'stderr');
       });
 
       // Handle process exit
@@ -803,5 +859,7 @@ export class ServerManager {
       log.info('Cleaning up server on app quit');
       await this.stop();
     }
+
+    this.clearPendingLogDelivery();
   }
 }

--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -35,7 +35,9 @@ const MAX_LOG_ENTRIES = 500;
 const SERVER_LOG_DELIVERY_INTERVAL_MS = 50;
 const SERVER_LOG_DELIVERY_BATCH_SIZE = 50;
 const HEALTH_POLL_INTERVAL_MS = 3000;
-const HEALTH_REQUEST_TIMEOUT_MS = 2000;
+// Server-side GPU probes may consume their full two-second timeout. Keep
+// enough response overhead here while still finishing before the next poll.
+const HEALTH_REQUEST_TIMEOUT_MS = 2500;
 const STOP_TIMEOUT_MS = 10000;
 const execFileAsync = promisify(execFile);
 

--- a/app/src/main/services/server-settings.ts
+++ b/app/src/main/services/server-settings.ts
@@ -2,7 +2,8 @@ import type { ServerSettingsResponse, EngineStatus, AvailableEngine } from '../.
 import { createLogger } from '../lib/logger.js';
 
 const log = createLogger('ServerSettings');
-const SERVER_SETTINGS_REQUEST_TIMEOUT_MS = 2000;
+// Engine status can include a server-side GPU probe with a two-second ceiling.
+const SERVER_SETTINGS_REQUEST_TIMEOUT_MS = 3000;
 
 /**
  * Derive the server base URL from a WebSocket endpoint.

--- a/app/src/main/services/server-settings.ts
+++ b/app/src/main/services/server-settings.ts
@@ -2,6 +2,7 @@ import type { ServerSettingsResponse, EngineStatus, AvailableEngine } from '../.
 import { createLogger } from '../lib/logger.js';
 
 const log = createLogger('ServerSettings');
+const SERVER_SETTINGS_REQUEST_TIMEOUT_MS = 2000;
 
 /**
  * Derive the server base URL from a WebSocket endpoint.
@@ -20,20 +21,27 @@ async function fetchJson<T>(path: string, options: RequestInit | undefined, serv
   const url = `${base}${path}`;
   log.debug('Fetching', { url, method: options?.method ?? 'GET' });
 
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options?.headers,
-    },
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SERVER_SETTINGS_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...options?.headers,
+      },
+      signal: controller.signal,
+    });
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    throw new Error(`Server returned ${response.status}: ${body}`);
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Server returned ${response.status}: ${body}`);
+    }
+
+    return (await response.json()) as T;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  return response.json() as Promise<T>;
 }
 
 export async function getServerSettings(serverUrl: string): Promise<ServerSettingsResponse> {

--- a/app/tests/clipboard.test.ts
+++ b/app/tests/clipboard.test.ts
@@ -13,6 +13,9 @@ const execFile = mock((
   done?.(null, '12345');
   return { kill: mock(() => {}) };
 });
+const spawn = mock(() => {
+  throw new Error('spawn is not used by clipboard tests');
+});
 
 mock.module('electron', () => ({
   app: {
@@ -31,6 +34,7 @@ mock.module('electron', () => ({
 
 mock.module('child_process', () => ({
   execFile,
+  spawn,
 }));
 
 const { buildSendInputScriptContent, getForegroundWindowHandle, pasteText, simulatePaste } = await import('../src/main/services/clipboard.js');

--- a/app/tests/request-deadlines.test.ts
+++ b/app/tests/request-deadlines.test.ts
@@ -32,6 +32,45 @@ function restoreGlobalProperty(
 }
 
 describe('Electron request deadlines', () => {
+  test('keeps client deadlines beyond the server probe ceiling', async () => {
+    const manager = asPrivateManager(new ServerManager());
+    const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+    const originalSetTimeout = Object.getOwnPropertyDescriptor(globalThis, 'setTimeout');
+    const scheduledDelays: number[] = [];
+
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: () => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ status: 'healthy' }),
+      } as Response),
+    });
+    Object.defineProperty(globalThis, 'setTimeout', {
+      configurable: true,
+      writable: true,
+      value: ((_handler: unknown, delay?: number) => {
+        scheduledDelays.push(delay ?? 0);
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+    });
+
+    try {
+      expect(await manager.getHealthState(51717)).toEqual({ healthy: true });
+      await getServerSettings('ws://localhost:51717/transcribe');
+
+      expect(scheduledDelays).toHaveLength(2);
+      const [healthDeadline, settingsDeadline] = scheduledDelays;
+      const serverProbeCeilingMs = 2000;
+      expect(healthDeadline).toBeGreaterThan(serverProbeCeilingMs);
+      expect(healthDeadline).toBeLessThan(3000);
+      expect(settingsDeadline).toBeGreaterThan(serverProbeCeilingMs);
+    } finally {
+      restoreGlobalProperty('fetch', originalFetch);
+      restoreGlobalProperty('setTimeout', originalSetTimeout);
+    }
+  });
+
   test('aborts a health request when response body consumption stalls', async () => {
     const manager = asPrivateManager(new ServerManager());
     const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');

--- a/app/tests/request-deadlines.test.ts
+++ b/app/tests/request-deadlines.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { HealthState } from '../src/main/services/server-health';
+
+mock.module('electron', () => ({
+  app: {
+    getPath: () => process.cwd(),
+  },
+  BrowserWindow: class {},
+}));
+
+const { ServerManager } = await import('../src/main/services/server-manager');
+const { getServerSettings } = await import('../src/main/services/server-settings');
+
+type PrivateServerManager = {
+  getHealthState: (port: number, timeoutMs?: number) => Promise<HealthState>;
+  waitForHealth: (port: number, timeoutMs: number) => Promise<HealthState | null>;
+};
+
+function asPrivateManager(manager: InstanceType<typeof ServerManager>): PrivateServerManager {
+  return manager as unknown as PrivateServerManager;
+}
+
+function restoreGlobalProperty(
+  name: 'fetch' | 'setTimeout',
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    delete (globalThis as Record<string, unknown>)[name];
+  }
+}
+
+describe('Electron request deadlines', () => {
+  test('aborts a health request when response body consumption stalls', async () => {
+    const manager = asPrivateManager(new ServerManager());
+    const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+    let signal: AbortSignal | undefined;
+
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: (_input: RequestInfo | URL, init?: RequestInit) => {
+        signal = init?.signal;
+        return Promise.resolve({
+          ok: true,
+          json: () => new Promise<never>((_resolve, reject) => {
+            signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+          }),
+        } as Response);
+      },
+    });
+
+    try {
+      const outcome = await Promise.race([
+        manager.getHealthState(51717, 20).then((health) => ({ kind: 'settled' as const, health })),
+        new Promise<{ kind: 'test-timeout' }>((resolve) => {
+          setTimeout(() => resolve({ kind: 'test-timeout' }), 250);
+        }),
+      ]);
+
+      expect(outcome.kind).toBe('settled');
+      if (outcome.kind === 'settled') {
+        expect(outcome.health).toEqual({ healthy: false });
+      }
+      expect(signal?.aborted).toBeTrue();
+    } finally {
+      restoreGlobalProperty('fetch', originalFetch);
+    }
+  });
+
+  test('keeps the health readiness wait inside its outer deadline', async () => {
+    const manager = asPrivateManager(new ServerManager());
+    const originalGetHealthState = manager.getHealthState;
+    manager.getHealthState = () => new Promise<HealthState>(() => {});
+
+    try {
+      const outcome = await Promise.race([
+        manager.waitForHealth(51717, 20).then((health) => ({ kind: 'settled' as const, health })),
+        new Promise<{ kind: 'test-timeout' }>((resolve) => {
+          setTimeout(() => resolve({ kind: 'test-timeout' }), 250);
+        }),
+      ]);
+
+      expect(outcome.kind).toBe('settled');
+      if (outcome.kind === 'settled') {
+        expect(outcome.health).toBeNull();
+      }
+    } finally {
+      manager.getHealthState = originalGetHealthState;
+    }
+  });
+
+  test('passes an abort signal and rejects when a settings request times out', async () => {
+    const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+    const originalSetTimeout = Object.getOwnPropertyDescriptor(globalThis, 'setTimeout');
+    let signal: AbortSignal | undefined;
+    let fireTimeout: (() => void) | undefined;
+
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: (_input: RequestInfo | URL, init?: RequestInit) => {
+        signal = init?.signal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+            { once: true },
+          );
+        });
+      },
+    });
+    Object.defineProperty(globalThis, 'setTimeout', {
+      configurable: true,
+      writable: true,
+      value: ((handler: unknown, _delay?: number, ...args: unknown[]) => {
+        if (typeof handler === 'function') {
+          fireTimeout = () => (handler as (...callbackArgs: unknown[]) => void)(...args);
+        }
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+    });
+
+    try {
+      const request = getServerSettings('ws://localhost:51717/transcribe');
+      await Promise.resolve();
+      fireTimeout?.();
+
+      await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+      expect(signal?.aborted).toBeTrue();
+    } finally {
+      restoreGlobalProperty('fetch', originalFetch);
+      restoreGlobalProperty('setTimeout', originalSetTimeout);
+    }
+  });
+});

--- a/app/tests/server-log.test.ts
+++ b/app/tests/server-log.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../src/renderer/app/server-log.js';
 import {
   BoundedLogDeliveryQueue,
+  MAX_PENDING_FRAME_BYTES,
   ServerLogFramer,
 } from '../src/main/services/server-log-transport.js';
 
@@ -97,6 +98,19 @@ describe('Server log state and sizing contracts', () => {
     ]);
     expect(framer.push(Buffer.from('entry\r\nlast'))).toEqual(['next entry']);
     expect(framer.flush()).toEqual(['last']);
+  });
+
+  test('bounds delimiter-free UTF-8 output without losing code points', () => {
+    const framer = new ServerLogFramer();
+    const payload = '🙂'.repeat(Math.ceil(MAX_PENDING_FRAME_BYTES / 4) + 7);
+
+    const firstFrames = framer.push(payload);
+    const finalFrames = framer.flush();
+    const frames = [...firstFrames, ...finalFrames];
+
+    expect(frames.length).toBeGreaterThan(1);
+    expect(frames.every((frame) => Buffer.byteLength(frame, 'utf8') <= MAX_PENDING_FRAME_BYTES)).toBeTrue();
+    expect(frames.join('')).toBe(payload);
   });
 
   test('bounds high-rate delivery queue while retaining the newest diagnostics', () => {

--- a/app/tests/server-log.test.ts
+++ b/app/tests/server-log.test.ts
@@ -7,6 +7,10 @@ import {
   SHORT_SERVER_LOG_ENTRY_LIMIT,
   SERVER_LOG_LOAD_ERROR,
 } from '../src/renderer/app/server-log.js';
+import {
+  BoundedLogDeliveryQueue,
+  ServerLogFramer,
+} from '../src/main/services/server-log-transport.js';
 
 function source(path: string): string {
   return readFileSync(new URL(path, import.meta.url), 'utf8');
@@ -81,5 +85,28 @@ describe('Server log state and sizing contracts', () => {
     expect(fixture).toContain('if (logLoading) return new Promise<ServerLogEntry[]>(() => {})');
     expect(fixture).toContain("if (logError) throw new Error('fixture log retrieval failed')");
     expect(fixture).toContain('Array.from({ length: logCount }');
+  });
+
+  test('frames fragmented UTF-8 output and bare carriage-return progress updates', () => {
+    const framer = new ServerLogFramer();
+
+    expect(framer.push(Buffer.from('ready: 50'))).toEqual([]);
+    expect(framer.push(Buffer.from('%\rready: 100%\nnext '))).toEqual([
+      'ready: 50%',
+      'ready: 100%',
+    ]);
+    expect(framer.push(Buffer.from('entry\r\nlast'))).toEqual(['next entry']);
+    expect(framer.flush()).toEqual(['last']);
+  });
+
+  test('bounds high-rate delivery queue while retaining the newest diagnostics', () => {
+    const queue = new BoundedLogDeliveryQueue<number>(3);
+
+    for (let entry = 1; entry <= 6; entry += 1) queue.enqueue(entry);
+
+    expect(queue.size).toBe(3);
+    expect(queue.drain(2)).toEqual([4, 5]);
+    expect(queue.drain(2)).toEqual([6]);
+    expect(queue.size).toBe(0);
   });
 });

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -128,26 +128,35 @@ def create_app() -> FastAPI:
     async def health_check() -> dict:
         manager = get_session_manager()
         engine_mgr = get_engine_manager()
-        status = engine_mgr.get_status()
         settings = get_settings()
+        diagnostics_payload, status, model_download = await asyncio.gather(
+            asyncio.to_thread(collect_diagnostics, settings),
+            asyncio.to_thread(engine_mgr.get_status),
+            asyncio.to_thread(get_model_download_state),
+        )
         return {
             "status": "healthy",
             "version": SERVER_VERSION,
             "active_sessions": manager.active_count,
             "max_sessions": manager.max_sessions,
             "engine": serialize_engine_status(status),
-            "diagnostics": collect_diagnostics(settings),
-            "model_download": get_model_download_state(),
+            "diagnostics": diagnostics_payload,
+            "model_download": model_download,
         }
 
     @app.get("/diagnostics")
     async def diagnostics() -> dict:
         settings = get_settings()
         engine_mgr = get_engine_manager()
+        diagnostics_payload, status, model_download = await asyncio.gather(
+            asyncio.to_thread(collect_diagnostics, settings),
+            asyncio.to_thread(engine_mgr.get_status),
+            asyncio.to_thread(get_model_download_state),
+        )
         return {
-            **collect_diagnostics(settings),
-            "engine": serialize_engine_status(engine_mgr.get_status()),
-            "model_download": get_model_download_state(),
+            **diagnostics_payload,
+            "engine": serialize_engine_status(status),
+            "model_download": model_download,
         }
 
     @app.get("/settings")

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -163,7 +163,7 @@ def create_app() -> FastAPI:
     async def get_server_settings() -> dict:
         settings = get_settings()
         engine_mgr = get_engine_manager()
-        status = engine_mgr.get_status()
+        status = await asyncio.to_thread(engine_mgr.get_status)
         available = [e["id"] for e in discover_engines() if e["available"]]
 
         return {
@@ -227,7 +227,7 @@ def create_app() -> FastAPI:
                     detail="Could not save settings. Please try again.",
                 ) from None
 
-        status = engine_mgr.get_status()
+        status = await asyncio.to_thread(engine_mgr.get_status)
         session_mgr = get_session_manager()
 
         response: dict[str, Any] = {
@@ -248,7 +248,7 @@ def create_app() -> FastAPI:
     async def get_available_engines() -> dict:
         engines = discover_engines()
         engine_mgr = get_engine_manager()
-        status = engine_mgr.get_status()
+        status = await asyncio.to_thread(engine_mgr.get_status)
         return {
             "engines": engines,
             "current": status.current,
@@ -257,7 +257,7 @@ def create_app() -> FastAPI:
     @app.get("/engine/status")
     async def get_engine_status() -> dict:
         engine_mgr = get_engine_manager()
-        status = engine_mgr.get_status()
+        status = await asyncio.to_thread(engine_mgr.get_status)
         return serialize_engine_status(status)
 
     @app.websocket("/transcribe")

--- a/server/src/diagnostics.py
+++ b/server/src/diagnostics.py
@@ -24,6 +24,7 @@ _NVIDIA_SMI_TIMEOUT_S = 2.0
 _last_diagnostics: dict[str, Any] | None = None
 _last_collected_at: float | None = None
 _last_signature: tuple[str, str, str] | None = None
+_diagnostics_cache_lock = threading.Lock()
 _diagnostics_refresh_lock = threading.Lock()
 
 
@@ -299,22 +300,85 @@ def build_warnings(
     return warnings
 
 
+def _get_cached_diagnostics(
+    signature: tuple[str, str, str],
+    *,
+    fresh_only: bool,
+) -> dict[str, Any] | None:
+    with _diagnostics_cache_lock:
+        if (
+            _last_diagnostics is None
+            or _last_collected_at is None
+            or _last_signature != signature
+        ):
+            return None
+        if fresh_only and time.time() - _last_collected_at >= _DIAGNOSTICS_CACHE_TTL_S:
+            return None
+        return _last_diagnostics
+
+
+def _diagnostics_refreshing_payload(settings: Settings) -> dict[str, Any]:
+    detail = "Runtime diagnostics refresh is in progress."
+    payload = DiagnosticsPayload(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        cuda=CudaDiagnostics(
+            available=False,
+            device=_get_engine_device(settings),
+            reason=detail,
+        ),
+        cuda_dlls=CudaDllDiagnostics(available=False, detail=detail),
+        nvidia_driver=NvidiaDriverDiagnostics(
+            available=False,
+            version=None,
+            minimum_version=MIN_NVIDIA_DRIVER_VERSION,
+            meets_minimum=None,
+        ),
+        vc_redist=VcRedistDiagnostics(
+            required=sys.platform == "win32",
+            installed=None,
+            missing=None,
+            url=VC_REDIST_URL if sys.platform == "win32" else None,
+        ),
+        warnings=[
+            DiagnosticWarning(
+                code="diagnostics_refreshing",
+                message=detail,
+                action="Retry shortly.",
+                severity="warning",
+            )
+        ],
+    )
+    return {
+        "generated_at": payload.generated_at,
+        "cuda": asdict(payload.cuda),
+        "cuda_dlls": asdict(payload.cuda_dlls),
+        "nvidia_driver": asdict(payload.nvidia_driver),
+        "vc_redist": asdict(payload.vc_redist),
+        "warnings": [asdict(warning) for warning in payload.warnings],
+    }
+
+
 def collect_diagnostics(settings: Settings, *, force: bool = False) -> dict[str, Any]:
     global _last_diagnostics, _last_collected_at, _last_signature
 
     signature = (settings.engine, settings.whisper_device, settings.nemotron_device)
 
-    with _diagnostics_refresh_lock:
-        now = time.time()
-        if (
-            not force
-            and _last_diagnostics is not None
-            and _last_collected_at is not None
-            and _last_signature == signature
-            and now - _last_collected_at < _DIAGNOSTICS_CACHE_TTL_S
-        ):
-            return _last_diagnostics
+    if not force:
+        cached = _get_cached_diagnostics(signature, fresh_only=True)
+        if cached is not None:
+            return cached
 
+    if not _diagnostics_refresh_lock.acquire(blocking=False):
+        cached = _get_cached_diagnostics(signature, fresh_only=False)
+        return cached if cached is not None else _diagnostics_refreshing_payload(settings)
+
+    try:
+        if not force:
+            cached = _get_cached_diagnostics(signature, fresh_only=True)
+            if cached is not None:
+                return cached
+
+        now = time.time()
         device = _get_engine_device(settings)
         cuda = check_cuda_capability(device)
         cuda_dlls = check_ctranslate2_cuda_dlls()
@@ -346,8 +410,11 @@ def collect_diagnostics(settings: Settings, *, force: bool = False) -> dict[str,
             "warnings": [asdict(warning) for warning in payload.warnings],
         }
 
-        _last_diagnostics = serialized
-        _last_collected_at = now
-        _last_signature = signature
+        with _diagnostics_cache_lock:
+            _last_diagnostics = serialized
+            _last_collected_at = now
+            _last_signature = signature
 
         return serialized
+    finally:
+        _diagnostics_refresh_lock.release()

--- a/server/src/diagnostics.py
+++ b/server/src/diagnostics.py
@@ -6,6 +6,7 @@ import ctypes
 import importlib
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -23,6 +24,7 @@ _NVIDIA_SMI_TIMEOUT_S = 2.0
 _last_diagnostics: dict[str, Any] | None = None
 _last_collected_at: float | None = None
 _last_signature: tuple[str, str, str] | None = None
+_diagnostics_refresh_lock = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -301,50 +303,51 @@ def collect_diagnostics(settings: Settings, *, force: bool = False) -> dict[str,
     global _last_diagnostics, _last_collected_at, _last_signature
 
     signature = (settings.engine, settings.whisper_device, settings.nemotron_device)
-    now = time.time()
 
-    if (
-        not force
-        and _last_diagnostics is not None
-        and _last_collected_at is not None
-        and _last_signature == signature
-        and now - _last_collected_at < _DIAGNOSTICS_CACHE_TTL_S
-    ):
-        return _last_diagnostics
+    with _diagnostics_refresh_lock:
+        now = time.time()
+        if (
+            not force
+            and _last_diagnostics is not None
+            and _last_collected_at is not None
+            and _last_signature == signature
+            and now - _last_collected_at < _DIAGNOSTICS_CACHE_TTL_S
+        ):
+            return _last_diagnostics
 
-    device = _get_engine_device(settings)
-    cuda = check_cuda_capability(device)
-    cuda_dlls = check_ctranslate2_cuda_dlls()
-    driver = check_nvidia_driver()
-    vc_redist = check_vc_redist()
-    warnings = build_warnings(
-        device=device,
-        cuda=cuda,
-        cuda_dlls=cuda_dlls,
-        driver=driver,
-        vc_redist=vc_redist,
-    )
+        device = _get_engine_device(settings)
+        cuda = check_cuda_capability(device)
+        cuda_dlls = check_ctranslate2_cuda_dlls()
+        driver = check_nvidia_driver()
+        vc_redist = check_vc_redist()
+        warnings = build_warnings(
+            device=device,
+            cuda=cuda,
+            cuda_dlls=cuda_dlls,
+            driver=driver,
+            vc_redist=vc_redist,
+        )
 
-    payload = DiagnosticsPayload(
-        generated_at=datetime.now(timezone.utc).isoformat(),
-        cuda=cuda,
-        cuda_dlls=cuda_dlls,
-        nvidia_driver=driver,
-        vc_redist=vc_redist,
-        warnings=warnings,
-    )
+        payload = DiagnosticsPayload(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            cuda=cuda,
+            cuda_dlls=cuda_dlls,
+            nvidia_driver=driver,
+            vc_redist=vc_redist,
+            warnings=warnings,
+        )
 
-    serialized = {
-        "generated_at": payload.generated_at,
-        "cuda": asdict(payload.cuda),
-        "cuda_dlls": asdict(payload.cuda_dlls),
-        "nvidia_driver": asdict(payload.nvidia_driver),
-        "vc_redist": asdict(payload.vc_redist),
-        "warnings": [asdict(warning) for warning in payload.warnings],
-    }
+        serialized = {
+            "generated_at": payload.generated_at,
+            "cuda": asdict(payload.cuda),
+            "cuda_dlls": asdict(payload.cuda_dlls),
+            "nvidia_driver": asdict(payload.nvidia_driver),
+            "vc_redist": asdict(payload.vc_redist),
+            "warnings": [asdict(warning) for warning in payload.warnings],
+        }
 
-    _last_diagnostics = serialized
-    _last_collected_at = now
-    _last_signature = signature
+        _last_diagnostics = serialized
+        _last_collected_at = now
+        _last_signature = signature
 
-    return serialized
+        return serialized

--- a/server/src/diagnostics.py
+++ b/server/src/diagnostics.py
@@ -19,6 +19,7 @@ NVIDIA_DRIVER_URL = "https://www.nvidia.com/Download/index.aspx"
 VC_REDIST_URL = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
 
 _DIAGNOSTICS_CACHE_TTL_S = 30.0
+_NVIDIA_SMI_TIMEOUT_S = 2.0
 _last_diagnostics: dict[str, Any] | None = None
 _last_collected_at: float | None = None
 _last_signature: tuple[str, str, str] | None = None
@@ -93,10 +94,11 @@ def _run_nvidia_smi() -> str | None:
             check=True,
             capture_output=True,
             text=True,
+            timeout=_NVIDIA_SMI_TIMEOUT_S,
         )
     except FileNotFoundError:
         return None
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
 
     output = completed.stdout.strip()

--- a/server/src/transcription/engines/whisper.py
+++ b/server/src/transcription/engines/whisper.py
@@ -54,6 +54,7 @@ _WHISPER_MODEL_ALLOW_PATTERNS = (
     "tokenizer.json",
     "vocabulary.*",
 )
+_NVIDIA_SMI_TIMEOUT_S = 2.0
 
 
 @dataclass(frozen=True)
@@ -155,8 +156,13 @@ def _get_vram_used_gb() -> float | None:
             check=True,
             capture_output=True,
             text=True,
+            timeout=_NVIDIA_SMI_TIMEOUT_S,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ):
         return None
     first = completed.stdout.strip().splitlines()[0] if completed.stdout.strip() else ""
     try:

--- a/server/src/transcription/factory.py
+++ b/server/src/transcription/factory.py
@@ -249,9 +249,10 @@ class EngineManager:
             capabilities.total_vram_gb,
         )
 
-        self._gpu_name = capabilities.name
-        self._gpu_vram_gb = capabilities.total_vram_gb
-        self._estimated_max_duration_s = estimated_max_duration_s
+        with self._lock:
+            self._gpu_name = capabilities.name
+            self._gpu_vram_gb = capabilities.total_vram_gb
+            self._estimated_max_duration_s = estimated_max_duration_s
 
         if capabilities.total_vram_gb is not None:
             logger.info(
@@ -292,30 +293,50 @@ class EngineManager:
         )
 
     def get_status(self) -> EngineStatus:
-        info = self.engine_info if self._engine else None
-        if self._pending_status:
+        with self._lock:
+            engine = self._engine
+            current = self._settings.engine
+            pending_status = self._pending_status
+            pending_engine_id = self._pending_engine_id
+            pending_message = self._pending_message
+            swap_error = self._swap_error
+            recovery_required = self._recovery_required
+            gpu_name = self._gpu_name
+            gpu_vram_gb = self._gpu_vram_gb
+            estimated_max_duration_s = self._estimated_max_duration_s
+
+        info = None
+        if engine is not None:
+            info = replace(
+                engine.engine_info,
+                gpu_name=gpu_name,
+                gpu_vram_gb=gpu_vram_gb,
+                estimated_max_duration_s=estimated_max_duration_s,
+            )
+
+        if pending_status:
             status_value = "loading"
-        elif self._engine:
+        elif engine is not None:
             status_value = "ready"
-        elif self._swap_error:
+        elif swap_error:
             status_value = "error"
         else:
             status_value = "loading"
 
         status = EngineStatus(
-            current=self._settings.engine,
+            current=current,
             status=status_value,
             info=info,
         )
-        if self._pending_status:
+        if pending_status:
             status.pending = {
-                "engine": self._pending_engine_id,
-                "status": self._pending_status,
-                "message": self._pending_message,
+                "engine": pending_engine_id,
+                "status": pending_status,
+                "message": pending_message,
             }
-        if self._swap_error:
-            status.message = self._swap_error
-        if self._recovery_required:
+        if swap_error:
+            status.message = swap_error
+        if recovery_required:
             status.recovery = {
                 "action": "restart_server",
                 "message": ENGINE_RECOVERY_REQUIRED_MESSAGE,
@@ -375,22 +396,24 @@ class EngineManager:
                 if self._shutting_down:
                     return
 
-            self._swap_error = None
+            with self._lock:
+                self._swap_error = None
             available = _get_available_engine_ids()
             self._prepare_engine_selection(new_settings, available)
 
-            self._pending_engine_id = new_settings.engine
-            self._pending_status = "loading"
-            self._pending_message = f"Loading {new_settings.engine} engine..."
+            with self._lock:
+                self._pending_engine_id = new_settings.engine
+                self._pending_status = "loading"
+                self._pending_message = f"Loading {new_settings.engine} engine..."
 
             unload_first = getattr(new_settings, "unload_before_swap", False)
             loop = asyncio.get_running_loop()
 
             old_engine: TranscriptionEngine | None = None
             should_unload_old = False
-            if unload_first and self._engine is not None:
+            if unload_first:
                 with self._lock:
-                    if not self._active_sessions:
+                    if self._engine is not None and not self._active_sessions:
                         old_engine = self._engine
                         self._engine = None
                         should_unload_old = True
@@ -433,7 +456,8 @@ class EngineManager:
             except Exception as create_error:
                 restore_error = await restore_previous_engine()
                 if restore_error is not None:
-                    self._recovery_required = True
+                    with self._lock:
+                        self._recovery_required = True
                     raise EngineRecoveryRequiredError(
                         "Candidate engine creation and previous-engine recovery both failed"
                     ) from create_error
@@ -464,7 +488,8 @@ class EngineManager:
                     logger.error("Failed to discard unactivated engine: %s", shutdown_error)
                 restore_error = await restore_previous_engine()
                 if restore_error is not None:
-                    self._recovery_required = True
+                    with self._lock:
+                        self._recovery_required = True
                     raise EngineRecoveryRequiredError(
                         "Candidate engine activation and previous-engine recovery both failed"
                     ) from activation_error
@@ -473,9 +498,10 @@ class EngineManager:
             if discard_new_engine:
                 logger.info("Discarding engine that finished loading during shutdown")
                 await loop.run_in_executor(None, new_engine.shutdown)
-                self._pending_status = None
-                self._pending_engine_id = None
-                self._pending_message = None
+                with self._lock:
+                    self._pending_status = None
+                    self._pending_engine_id = None
+                    self._pending_message = None
                 return
 
             self._update_runtime_metadata(new_settings)
@@ -484,19 +510,21 @@ class EngineManager:
                 await loop.run_in_executor(None, old_engine.shutdown)
                 _force_free_vram()
 
-            self._pending_status = None
-            self._pending_engine_id = None
-            self._pending_message = None
-            self._swap_error = None
-            self._recovery_required = False
+            with self._lock:
+                self._pending_status = None
+                self._pending_engine_id = None
+                self._pending_message = None
+                self._swap_error = None
+                self._recovery_required = False
             logger.info("Engine swap complete: now using %s", new_settings.engine)
 
         except Exception as e:
             logger.error("Engine swap failed: %s", e)
-            self._swap_error = safe_engine_preparation_message(e)
-            self._pending_status = None
-            self._pending_engine_id = None
-            self._pending_message = None
+            with self._lock:
+                self._swap_error = safe_engine_preparation_message(e)
+                self._pending_status = None
+                self._pending_engine_id = None
+                self._pending_message = None
             raise
 
     def shutdown(self) -> None:

--- a/server/src/websocket/handler.py
+++ b/server/src/websocket/handler.py
@@ -50,7 +50,7 @@ async def websocket_handler(websocket: WebSocket) -> None:
         logger.info("[%s] WebSocket connected", context.session_id)
 
         try:
-            engine_status = get_engine_manager().get_status()
+            engine_status = await asyncio.to_thread(get_engine_manager().get_status)
         except Exception as e:
             logger.exception("[%s] Engine manager unavailable: %s", context.session_id, e)
             await sender.send_error(ErrorCode.INTERNAL, "Engine manager unavailable")
@@ -191,7 +191,8 @@ async def _wait_for_start(
     # Send ready with engine info
     try:
         engine_mgr = get_engine_manager()
-        engine_info_dict = asdict(engine_mgr.engine_info)
+        engine_info = await asyncio.to_thread(lambda: engine_mgr.engine_info)
+        engine_info_dict = asdict(engine_info)
     except Exception:
         engine_info_dict = None
     await sender.send_ready(engine_info=engine_info_dict)

--- a/server/tests/test_diagnostics.py
+++ b/server/tests/test_diagnostics.py
@@ -123,23 +123,25 @@ def test_collect_diagnostics_payload_shape(monkeypatch) -> None:
     assert isinstance(payload["warnings"], list)
 
 
-def test_collect_diagnostics_serializes_concurrent_cache_refreshes(monkeypatch) -> None:
+def test_collect_diagnostics_does_not_wait_behind_concurrent_cache_refresh(monkeypatch) -> None:
     probe_started = threading.Event()
     release_probe = threading.Event()
-    second_started = threading.Event()
+    contenders_finished = threading.Event()
     probe_calls = 0
-    results: list[dict] = []
+    results: dict[str, dict] = {}
+    stall_probe = False
 
     monkeypatch.setattr(diagnostics, "_last_diagnostics", None)
     monkeypatch.setattr(diagnostics, "_last_collected_at", None)
     monkeypatch.setattr(diagnostics, "_last_signature", None)
 
     def check_cuda(device: str) -> CudaDiagnostics:
-        nonlocal probe_calls
+        nonlocal probe_calls, stall_probe
         probe_calls += 1
-        probe_started.set()
-        if not release_probe.wait(timeout=2):
-            raise AssertionError("diagnostics probe was not released")
+        if stall_probe:
+            probe_started.set()
+            if not release_probe.wait(timeout=2):
+                raise AssertionError("diagnostics probe was not released")
         return CudaDiagnostics(
             available=True,
             device=device,
@@ -176,25 +178,39 @@ def test_collect_diagnostics_serializes_concurrent_cache_refreshes(monkeypatch) 
     )
 
     settings = Settings()
+    cached = diagnostics.collect_diagnostics(settings, force=True)
+    stall_probe = True
     first = threading.Thread(
-        target=lambda: results.append(diagnostics.collect_diagnostics(settings))
+        target=lambda: results.__setitem__(
+            "first", diagnostics.collect_diagnostics(settings, force=True)
+        )
     )
 
-    def collect_second() -> None:
-        second_started.set()
-        results.append(diagnostics.collect_diagnostics(settings))
+    def collect_contenders() -> None:
+        results["compatible"] = diagnostics.collect_diagnostics(
+            settings, force=True
+        )
+        incompatible_settings = Settings(whisper_device="cpu")
+        results["incompatible"] = diagnostics.collect_diagnostics(
+            incompatible_settings, force=True
+        )
+        contenders_finished.set()
 
-    second = threading.Thread(target=collect_second)
+    contenders = threading.Thread(target=collect_contenders)
     first.start()
     assert probe_started.wait(timeout=1)
-    second.start()
-    assert second_started.wait(timeout=1)
+    contenders.start()
+    contenders_finished_before_release = contenders_finished.wait(timeout=1)
     release_probe.set()
     first.join(timeout=2)
-    second.join(timeout=2)
+    contenders.join(timeout=2)
 
+    assert contenders_finished_before_release
     assert not first.is_alive()
-    assert not second.is_alive()
-    assert probe_calls == 1
-    assert len(results) == 2
-    assert results[0] is results[1]
+    assert not contenders.is_alive()
+    assert probe_calls == 2
+    assert len(results) == 3
+    assert results["compatible"] is cached
+    assert results["incompatible"]["warnings"][0]["code"] == "diagnostics_refreshing"
+    assert results["incompatible"]["warnings"][0]["severity"] == "warning"
+    assert diagnostics.collect_diagnostics(settings) is results["first"]

--- a/server/tests/test_diagnostics.py
+++ b/server/tests/test_diagnostics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import subprocess
 import sys
+import threading
 
 from config import Settings
 import diagnostics
@@ -120,3 +121,80 @@ def test_collect_diagnostics_payload_shape(monkeypatch) -> None:
     assert "nvidia_driver" in payload
     assert "vc_redist" in payload
     assert isinstance(payload["warnings"], list)
+
+
+def test_collect_diagnostics_serializes_concurrent_cache_refreshes(monkeypatch) -> None:
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    second_started = threading.Event()
+    probe_calls = 0
+    results: list[dict] = []
+
+    monkeypatch.setattr(diagnostics, "_last_diagnostics", None)
+    monkeypatch.setattr(diagnostics, "_last_collected_at", None)
+    monkeypatch.setattr(diagnostics, "_last_signature", None)
+
+    def check_cuda(device: str) -> CudaDiagnostics:
+        nonlocal probe_calls
+        probe_calls += 1
+        probe_started.set()
+        if not release_probe.wait(timeout=2):
+            raise AssertionError("diagnostics probe was not released")
+        return CudaDiagnostics(
+            available=True,
+            device=device,
+            reason=None,
+            name="GPU",
+            compute_capability="8.6",
+        )
+
+    monkeypatch.setattr(diagnostics, "check_cuda_capability", check_cuda)
+    monkeypatch.setattr(
+        diagnostics,
+        "check_ctranslate2_cuda_dlls",
+        lambda: CudaDllDiagnostics(available=True, detail=None),
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "check_nvidia_driver",
+        lambda: NvidiaDriverDiagnostics(
+            available=True,
+            version="551.86",
+            minimum_version="525.0",
+            meets_minimum=True,
+        ),
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "check_vc_redist",
+        lambda: VcRedistDiagnostics(
+            required=False,
+            installed=None,
+            missing=None,
+            url=None,
+        ),
+    )
+
+    settings = Settings()
+    first = threading.Thread(
+        target=lambda: results.append(diagnostics.collect_diagnostics(settings))
+    )
+
+    def collect_second() -> None:
+        second_started.set()
+        results.append(diagnostics.collect_diagnostics(settings))
+
+    second = threading.Thread(target=collect_second)
+    first.start()
+    assert probe_started.wait(timeout=1)
+    second.start()
+    assert second_started.wait(timeout=1)
+    release_probe.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert probe_calls == 1
+    assert len(results) == 2
+    assert results[0] is results[1]

--- a/server/tests/test_diagnostics.py
+++ b/server/tests/test_diagnostics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+import subprocess
 import sys
 
 from config import Settings
@@ -17,6 +19,22 @@ from diagnostics import (
 
 def test_parse_driver_version_handles_patch() -> None:
     assert diagnostics._parse_driver_version("551.86") == (551, 86, 0)
+
+
+def test_run_nvidia_smi_timeout_returns_unavailable(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def raise_timeout(*args, **kwargs):
+        calls.update(kwargs)
+        raise subprocess.TimeoutExpired(args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(diagnostics.subprocess, "run", raise_timeout)
+
+    assert diagnostics._run_nvidia_smi() is None
+    timeout = calls.get("timeout")
+    assert isinstance(timeout, (int, float))
+    assert math.isfinite(timeout)
+    assert timeout > 0
 
 
 def test_check_vc_redist_reports_missing_dlls(monkeypatch) -> None:

--- a/server/tests/test_model_download.py
+++ b/server/tests/test_model_download.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import threading
+import time
 from types import SimpleNamespace
 
 from config import Settings
 import app as app_module
 from fastapi import FastAPI
+import pytest
 from transcription import model_download
 
 
@@ -250,6 +253,56 @@ def test_health_liveness_is_separate_from_engine_readiness(monkeypatch) -> None:
     assert payload["status"] == "healthy"
     assert payload["engine"]["status"] == "loading"
     assert payload["engine"]["pending"]["status"] == "loading"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/health", "/diagnostics"])
+async def test_diagnostic_endpoints_keep_event_loop_responsive(path, monkeypatch) -> None:
+    settings = Settings()
+    release = threading.Event()
+    released = threading.Event()
+
+    def slow_diagnostics(_settings):
+        release.wait()
+        return {"warnings": []}
+
+    class SlowEngineManager:
+        def get_status(self) -> _DummyEngineStatus:
+            release.wait()
+            return _DummyEngineStatus()
+
+    def slow_model_download_state():
+        release.wait()
+        return {"status": "ready"}
+
+    monkeypatch.setattr(app_module, "get_session_manager", lambda: _DummySessionManager())
+    monkeypatch.setattr(app_module, "get_engine_manager", lambda: SlowEngineManager())
+    monkeypatch.setattr(app_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(app_module, "collect_diagnostics", slow_diagnostics)
+    monkeypatch.setattr(app_module, "get_model_download_state", slow_model_download_state)
+
+    endpoint = _get_route_endpoint(app_module.create_app(), path, "GET")
+    def release_probes() -> None:
+        released.set()
+        release.set()
+
+    release_timer = threading.Timer(0.5, release_probes)
+    release_timer.daemon = True
+    release_timer.start()
+    tick = asyncio.create_task(asyncio.sleep(0.05))
+    request = asyncio.create_task(endpoint())
+
+    await tick
+    responsive = not released.is_set()
+    release.set()
+    try:
+        payload = await request
+    finally:
+        release_timer.cancel()
+
+    assert responsive
+    assert payload["engine"]["status"] == "ready"
+    assert payload["model_download"]["status"] == "ready"
 
 
 def test_byte_progress_reports_percentage_speed_and_eta(monkeypatch) -> None:

--- a/server/tests/test_model_download.py
+++ b/server/tests/test_model_download.py
@@ -6,16 +6,25 @@ import asyncio
 import importlib
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 from config import Settings
 import app as app_module
-from fastapi import FastAPI
+import diagnostics
+from diagnostics import (
+    CudaDiagnostics,
+    CudaDllDiagnostics,
+    NvidiaDriverDiagnostics,
+    VcRedistDiagnostics,
+)
+from fastapi import FastAPI, WebSocketDisconnect
 import pytest
 from session.context import SessionContext
 from transcription.base import EngineInfo
 from transcription import model_download
-from websocket.handler import _wait_for_start
+import websocket.handler as websocket_handler_module
+from websocket.handler import _wait_for_start, websocket_handler
 
 
 class _DummyEngineStatus:
@@ -421,6 +430,169 @@ async def test_websocket_engine_probes_keep_event_loop_responsive(monkeypatch) -
     assert result is True
     assert sender.engine_info is not None
     assert sender.engine_info["id"] == "whisper"
+
+
+def test_stalled_diagnostics_refresh_does_not_starve_websocket_admission(
+    monkeypatch,
+) -> None:
+    settings = Settings()
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    websocket_receive_reached = asyncio.Event()
+
+    def stalled_cuda_probe(device: str) -> CudaDiagnostics:
+        probe_started.set()
+        release_probe.wait()
+        return CudaDiagnostics(
+            available=False,
+            device=device,
+            reason="test probe released",
+        )
+
+    monkeypatch.setattr(diagnostics, "_last_diagnostics", None)
+    monkeypatch.setattr(diagnostics, "_last_collected_at", None)
+    monkeypatch.setattr(diagnostics, "_last_signature", None)
+    monkeypatch.setattr(diagnostics, "check_cuda_capability", stalled_cuda_probe)
+    monkeypatch.setattr(
+        diagnostics,
+        "check_ctranslate2_cuda_dlls",
+        lambda: CudaDllDiagnostics(available=False, detail="unavailable"),
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "check_nvidia_driver",
+        lambda: NvidiaDriverDiagnostics(
+            available=False,
+            minimum_version="525.0",
+        ),
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "check_vc_redist",
+        lambda: VcRedistDiagnostics(
+            required=False,
+            installed=None,
+            missing=None,
+            url=None,
+        ),
+    )
+
+    class AdmissionSessionManager:
+        active_count = 0
+        max_sessions = 1
+
+        def create_session(self) -> SessionContext:
+            return SessionContext()
+
+        def remove_session(self, _session_id: str) -> None:
+            return
+
+    class AdmissionWebSocket:
+        async def accept(self) -> None:
+            return
+
+        async def receive(self) -> dict:
+            websocket_receive_reached.set()
+            raise WebSocketDisconnect()
+
+        async def close(self) -> None:
+            return
+
+    session_manager = AdmissionSessionManager()
+    engine_manager = _DummyEngineManager()
+    monkeypatch.setattr(app_module, "get_session_manager", lambda: session_manager)
+    monkeypatch.setattr(app_module, "get_engine_manager", lambda: engine_manager)
+    monkeypatch.setattr(app_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(app_module, "get_model_download_state", lambda: None)
+    monkeypatch.setattr(
+        websocket_handler_module,
+        "get_session_manager",
+        lambda: session_manager,
+    )
+    monkeypatch.setattr(
+        websocket_handler_module,
+        "get_engine_manager",
+        lambda: engine_manager,
+    )
+    monkeypatch.setattr(websocket_handler_module, "get_settings", lambda: settings)
+
+    app = app_module.create_app()
+    health_endpoint = _get_route_endpoint(app, "/health", "GET")
+    diagnostics_endpoint = _get_route_endpoint(app, "/diagnostics", "GET")
+
+    async def scenario() -> None:
+        first_request = asyncio.create_task(health_endpoint())
+        contending_requests: list[tuple[str, asyncio.Task[dict]]] = []
+        admission_task: asyncio.Task[None] | None = None
+        try:
+            for _ in range(200):
+                if probe_started.is_set():
+                    break
+                await asyncio.sleep(0.005)
+            assert probe_started.is_set()
+
+            await asyncio.sleep(0.05)
+            contending_requests.append(
+                ("diagnostics", asyncio.create_task(diagnostics_endpoint()))
+            )
+            await asyncio.sleep(0.05)
+            contending_requests.extend(
+                [
+                    ("health", asyncio.create_task(health_endpoint())),
+                    ("diagnostics", asyncio.create_task(diagnostics_endpoint())),
+                    ("health", asyncio.create_task(health_endpoint())),
+                ]
+            )
+            admission_task = asyncio.create_task(
+                websocket_handler(AdmissionWebSocket())
+            )
+
+            tasks = [task for _, task in contending_requests]
+            tasks.append(admission_task)
+            await asyncio.wait(tasks, timeout=0.5)
+            callers_completed = all(
+                task.done() for _, task in contending_requests
+            )
+            websocket_admitted = websocket_receive_reached.is_set()
+            completed_payloads = [
+                (path, task.result())
+                for path, task in contending_requests
+                if task.done() and not task.cancelled() and task.exception() is None
+            ]
+        finally:
+            release_probe.set()
+            cleanup_tasks = [first_request]
+            cleanup_tasks.extend(task for _, task in contending_requests)
+            if admission_task is not None:
+                cleanup_tasks.append(admission_task)
+            await asyncio.wait_for(
+                asyncio.gather(*cleanup_tasks, return_exceptions=True),
+                timeout=3,
+            )
+
+        assert callers_completed
+        assert websocket_admitted
+        assert len(completed_payloads) == len(contending_requests)
+        required_keys = {
+            "generated_at",
+            "cuda",
+            "cuda_dlls",
+            "nvidia_driver",
+            "vc_redist",
+            "warnings",
+        }
+        for path, payload in completed_payloads:
+            diagnostic_payload = payload["diagnostics"] if path == "health" else payload
+            assert required_keys <= diagnostic_payload.keys()
+            assert any(
+                warning["code"] == "diagnostics_refreshing"
+                for warning in diagnostic_payload["warnings"]
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        with asyncio.Runner() as runner:
+            runner.get_loop().set_default_executor(executor)
+            runner.run(scenario())
 
 
 def test_byte_progress_reports_percentage_speed_and_eta(monkeypatch) -> None:

--- a/server/tests/test_model_download.py
+++ b/server/tests/test_model_download.py
@@ -12,7 +12,10 @@ from config import Settings
 import app as app_module
 from fastapi import FastAPI
 import pytest
+from session.context import SessionContext
+from transcription.base import EngineInfo
 from transcription import model_download
+from websocket.handler import _wait_for_start
 
 
 class _DummyEngineStatus:
@@ -303,6 +306,121 @@ async def test_diagnostic_endpoints_keep_event_loop_responsive(path, monkeypatch
     assert responsive
     assert payload["engine"]["status"] == "ready"
     assert payload["model_download"]["status"] == "ready"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/settings", "/engines", "/engine/status"])
+async def test_status_endpoints_keep_event_loop_responsive(path, monkeypatch) -> None:
+    settings = Settings()
+    release = threading.Event()
+    released = threading.Event()
+
+    class SlowEngineManager:
+        def get_status(self) -> _DummyEngineStatus:
+            release.wait()
+            return _DummyEngineStatus()
+
+    monkeypatch.setattr(app_module, "get_engine_manager", lambda: SlowEngineManager())
+    monkeypatch.setattr(app_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        app_module,
+        "discover_engines",
+        lambda: [{"id": "whisper", "available": True}],
+    )
+    monkeypatch.setattr(
+        app_module,
+        "get_settings_with_metadata",
+        lambda _settings: {"engine": {"value": "whisper"}},
+    )
+
+    endpoint = _get_route_endpoint(app_module.create_app(), path, "GET")
+
+    def release_status() -> None:
+        released.set()
+        release.set()
+
+    release_timer = threading.Timer(0.5, release_status)
+    release_timer.daemon = True
+    release_timer.start()
+    tick = asyncio.create_task(asyncio.sleep(0.05))
+    request = asyncio.create_task(endpoint())
+
+    await tick
+    responsive = not released.is_set()
+    release.set()
+    try:
+        payload = await request
+    finally:
+        release_timer.cancel()
+
+    assert responsive
+    if path == "/settings":
+        assert payload["engine_status"]["status"] == "ready"
+    elif path == "/engines":
+        assert payload["current"] == "whisper"
+    else:
+        assert payload["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_websocket_engine_probes_keep_event_loop_responsive(monkeypatch) -> None:
+    release = threading.Event()
+    released = threading.Event()
+
+    class SlowEngineManager:
+        @property
+        def engine_info(self) -> EngineInfo:
+            release.wait()
+            return EngineInfo(
+                id="whisper",
+                name="Faster-Whisper",
+                model="tiny",
+                supports_hotwords=True,
+            )
+
+    class FakeWebSocket:
+        async def receive(self) -> dict[str, str]:
+            return {
+                "text": '{"frame":"control","type":"start","silence_timeout":5.0}',
+            }
+
+    class FakeSender:
+        engine_info: dict | None = None
+
+        async def send_ready(self, *, engine_info: dict | None = None) -> None:
+            self.engine_info = engine_info
+
+    monkeypatch.setattr(
+        "websocket.handler.get_engine_manager",
+        lambda: SlowEngineManager(),
+    )
+
+    def release_probe() -> None:
+        released.set()
+        release.set()
+
+    release_timer = threading.Timer(0.5, release_probe)
+    release_timer.daemon = True
+    release_timer.start()
+    tick = asyncio.create_task(asyncio.sleep(0.05))
+    context = SessionContext()
+    sender = FakeSender()
+    request = asyncio.create_task(
+        _wait_for_start(FakeWebSocket(), sender, context, timeout=1.0)
+    )
+
+    await tick
+    responsive = not released.is_set()
+    release.set()
+    try:
+        result = await request
+    finally:
+        release_timer.cancel()
+
+    assert responsive
+    assert result is True
+    assert sender.engine_info is not None
+    assert sender.engine_info["id"] == "whisper"
 
 
 def test_byte_progress_reports_percentage_speed_and_eta(monkeypatch) -> None:

--- a/server/tests/test_review_fixes.py
+++ b/server/tests/test_review_fixes.py
@@ -1,6 +1,7 @@
 """Tests for code review fixes (findings 1, 3, 4, 5, 6)."""
 
 import asyncio
+import threading
 from types import SimpleNamespace
 
 import numpy as np
@@ -108,6 +109,53 @@ async def test_swap_engine_serialized(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Should be sequential: start-1, end-1, start-2, end-2
     assert call_log == ["start-1", "end-1", "start-2", "end-2"]
+
+
+def test_get_status_snapshots_transition_before_slow_engine_info() -> None:
+    class BlockingInfoEngine(_DummyEngine):
+        def __init__(self, engine_id: str) -> None:
+            super().__init__(engine_id)
+            self.info_started = threading.Event()
+            self.allow_info = threading.Event()
+
+        @property
+        def engine_info(self) -> EngineInfo:
+            self.info_started.set()
+            if not self.allow_info.wait(timeout=2):
+                raise AssertionError("engine info probe was not released")
+            return super().engine_info
+
+    manager = factory_module.EngineManager(Settings(engine="whisper"))
+    old_engine = BlockingInfoEngine("whisper")
+    manager._engine = old_engine
+    status_result: list[factory_module.EngineStatus] = []
+
+    worker = threading.Thread(target=lambda: status_result.append(manager.get_status()))
+    worker.start()
+    assert old_engine.info_started.wait(timeout=1)
+
+    lock_acquired = manager._lock.acquire(timeout=1)
+    try:
+        assert lock_acquired
+        manager._engine = _DummyEngine("nemotron")
+        manager._settings = Settings(engine="nemotron")
+        manager._pending_engine_id = "nemotron"
+        manager._pending_status = "loading"
+        manager._pending_message = "Loading nemotron engine..."
+    finally:
+        if lock_acquired:
+            manager._lock.release()
+
+    old_engine.allow_info.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert len(status_result) == 1
+    status = status_result[0]
+    assert status.current == "whisper"
+    assert status.status == "ready"
+    assert status.info is not None
+    assert status.info.id == "whisper"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bound Electron health/readiness and server-settings requests, including response-body consumption.
- Keep Murmur diagnostics and engine status probes off the asyncio event loop and snapshot transition state safely.
- Frame fragmented server output and bound renderer log delivery while preserving recent diagnostics.

## Validation
- `bun test tests/request-deadlines.test.ts tests/server-health.test.ts tests/server-log.test.ts tests/server-startup.test.ts` — 30 passed, 113 assertions.
- `PYTHONPATH=src python -m pytest -q tests/test_review_fixes.py tests/test_diagnostics.py tests/test_model_download.py` — 44 passed.
- Backend hardening available subset — 13 passed; optional-engine tests were not runnable because `faster_whisper` and `soundfile` are not installed in the existing environment.

No dependency installation, build, launch, packaging, or runtime mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup and health checks with reliable timeouts, preventing stalled requests.
  * NVIDIA GPU memory checks now fail gracefully when unavailable or timed out.
  * Improved engine status accuracy during transitions and recovery.
  * Clipboard operations now use a more reliable system interaction.

* **Improvements**
  * Server logs now handle fragmented output smoothly and deliver recent entries efficiently.
  * Health, diagnostics, engine status, settings, and WebSocket checks remain responsive during slow operations.
  * Diagnostic results refresh safely during concurrent requests without blocking other checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->