### PR TITLE
fix: recover server UI after transient health failure

### DIFF
--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -133,19 +133,25 @@ export class ServerManager {
     this.stopHealthPolling();
     this.healthPollInterval = setInterval(async () => {
       const health = await this.getHealthState(port);
-      if (!health.healthy && this.status === 'running') {
-        log.warn('Server health check failed');
-        this.setDiagnostics(undefined);
-        this.setModelDownload(undefined);
-        this.setEngineStatus(undefined);
-        this.updateStatus('error', 'Health check failed');
+      if (!health.healthy) {
+        if (this.status === 'running') {
+          log.warn('Server health check failed');
+          this.setDiagnostics(undefined);
+          this.setModelDownload(undefined);
+          this.setEngineStatus(undefined);
+          this.updateStatus('error', 'Health check failed');
+        }
         return;
       }
 
+      const recovered = this.status === 'error';
+      if (recovered) {
+        this.status = 'running';
+      }
       const diagnosticsChanged = this.setDiagnostics(health.diagnostics);
       const downloadChanged = this.setModelDownload(health.modelDownload);
       const engineChanged = this.setEngineStatus(health.engineStatus);
-      let shouldBroadcast = diagnosticsChanged || downloadChanged || engineChanged;
+      let shouldBroadcast = recovered || diagnosticsChanged || downloadChanged || engineChanged;
 
       if (health.version && health.version !== this.serverVersion) {
         this.serverVersion = health.version;

--- a/app/src/main/services/server-manager.ts
+++ b/app/src/main/services/server-manager.ts
@@ -49,6 +49,7 @@ export class ServerManager {
   private readonly pendingLogDelivery = new BoundedLogDeliveryQueue<ServerLogEntry>(MAX_LOG_ENTRIES);
   private logDeliveryTimer: ReturnType<typeof setTimeout> | null = null;
   private healthPollInterval: ReturnType<typeof setInterval> | null = null;
+  private healthPollGeneration = 0;
   private mainWindow: BrowserWindow | null = null;
   private managed = false; // Whether we spawned the server (production) vs detected it (dev)
   private startedAt: number | null = null;
@@ -131,8 +132,10 @@ export class ServerManager {
    */
   private startHealthPolling(port: number): void {
     this.stopHealthPolling();
+    const generation = this.healthPollGeneration;
     this.healthPollInterval = setInterval(async () => {
       const health = await this.getHealthState(port);
+      if (generation !== this.healthPollGeneration) return;
       if (!health.healthy) {
         if (this.status === 'running') {
           log.warn('Server health check failed');
@@ -247,6 +250,7 @@ export class ServerManager {
    * Stop health polling.
    */
   private stopHealthPolling(): void {
+    this.healthPollGeneration += 1;
     if (this.healthPollInterval) {
       clearInterval(this.healthPollInterval);
       this.healthPollInterval = null;

--- a/app/tests/request-deadlines.test.ts
+++ b/app/tests/request-deadlines.test.ts
@@ -14,6 +14,7 @@ const { getServerSettings } = await import('../src/main/services/server-settings
 type PrivateServerManager = {
   getHealthState: (port: number, timeoutMs?: number) => Promise<HealthState>;
   getState: InstanceType<typeof ServerManager>['getState'];
+  setMainWindow: InstanceType<typeof ServerManager>['setMainWindow'];
   startHealthPolling: (port: number) => void;
   stopHealthPolling: () => void;
   updateStatus: (status: 'running') => void;
@@ -67,6 +68,78 @@ describe('Electron request deadlines', () => {
       expect(manager.getState()).toMatchObject({
         status: 'running',
         engineStatus: { current: 'whisper', status: 'ready' },
+      });
+    } finally {
+      manager.stopHealthPolling();
+      manager.getHealthState = originalGetHealthState;
+      restoreGlobalProperty('setInterval', originalSetInterval);
+    }
+  });
+
+  test('ignores a late healthy response after health polling stops', async () => {
+    const manager = asPrivateManager(new ServerManager());
+    const originalSetInterval = Object.getOwnPropertyDescriptor(globalThis, 'setInterval');
+    const originalGetHealthState = manager.getHealthState;
+    let poll: (() => Promise<void>) | undefined;
+    let resolveHealth: ((health: HealthState) => void) | undefined;
+    const deferredHealth = new Promise<HealthState>((resolve) => {
+      resolveHealth = resolve;
+    });
+    let healthRequestCount = 0;
+    const publishedStates: unknown[] = [];
+
+    Object.defineProperty(globalThis, 'setInterval', {
+      configurable: true,
+      writable: true,
+      value: ((handler: unknown) => {
+        poll = handler as () => Promise<void>;
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval,
+    });
+    manager.getHealthState = async () => {
+      healthRequestCount += 1;
+      return healthRequestCount === 1 ? { healthy: false } : deferredHealth;
+    };
+    manager.setMainWindow({
+      isDestroyed: () => false,
+      webContents: {
+        send: (_channel: string, state: unknown) => publishedStates.push(state),
+      },
+    } as unknown as Parameters<InstanceType<typeof ServerManager>['setMainWindow']>[0]);
+
+    try {
+      manager.updateStatus('running');
+      manager.startHealthPolling(51717);
+
+      await poll?.();
+      expect(manager.getState().status).toBe('error');
+      publishedStates.length = 0;
+
+      const latePoll = poll?.();
+      manager.stopHealthPolling();
+      resolveHealth?.({
+        healthy: true,
+        version: 'late-version',
+        diagnostics: {
+          generated_at: 'late-response',
+          cuda: { available: true, device: 'cuda' },
+          cuda_dlls: { available: true },
+          nvidia_driver: { available: true },
+          vc_redist: { required: false },
+          warnings: [],
+        },
+        engineStatus: { current: 'whisper', status: 'ready' },
+      });
+      await latePoll;
+
+      expect({ state: manager.getState(), publishedStates }).toMatchObject({
+        state: {
+          status: 'error',
+          version: undefined,
+          diagnostics: undefined,
+          engineStatus: undefined,
+        },
+        publishedStates: [],
       });
     } finally {
       manager.stopHealthPolling();

--- a/app/tests/request-deadlines.test.ts
+++ b/app/tests/request-deadlines.test.ts
@@ -13,6 +13,10 @@ const { getServerSettings } = await import('../src/main/services/server-settings
 
 type PrivateServerManager = {
   getHealthState: (port: number, timeoutMs?: number) => Promise<HealthState>;
+  getState: InstanceType<typeof ServerManager>['getState'];
+  startHealthPolling: (port: number) => void;
+  stopHealthPolling: () => void;
+  updateStatus: (status: 'running') => void;
   waitForHealth: (port: number, timeoutMs: number) => Promise<HealthState | null>;
 };
 
@@ -21,7 +25,7 @@ function asPrivateManager(manager: InstanceType<typeof ServerManager>): PrivateS
 }
 
 function restoreGlobalProperty(
-  name: 'fetch' | 'setTimeout',
+  name: 'fetch' | 'setInterval' | 'setTimeout',
   descriptor: PropertyDescriptor | undefined,
 ): void {
   if (descriptor) {
@@ -32,6 +36,45 @@ function restoreGlobalProperty(
 }
 
 describe('Electron request deadlines', () => {
+  test('restores running state after a transient health-check failure', async () => {
+    const manager = asPrivateManager(new ServerManager());
+    const originalSetInterval = Object.getOwnPropertyDescriptor(globalThis, 'setInterval');
+    const originalGetHealthState = manager.getHealthState;
+    let poll: (() => Promise<void>) | undefined;
+    const healthStates: HealthState[] = [
+      { healthy: false },
+      { healthy: true, engineStatus: { current: 'whisper', status: 'ready' } },
+    ];
+
+    Object.defineProperty(globalThis, 'setInterval', {
+      configurable: true,
+      writable: true,
+      value: ((handler: unknown) => {
+        poll = handler as () => Promise<void>;
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval,
+    });
+    manager.getHealthState = async () => healthStates.shift() ?? { healthy: true };
+
+    try {
+      manager.updateStatus('running');
+      manager.startHealthPolling(51717);
+
+      await poll?.();
+      expect(manager.getState().status).toBe('error');
+
+      await poll?.();
+      expect(manager.getState()).toMatchObject({
+        status: 'running',
+        engineStatus: { current: 'whisper', status: 'ready' },
+      });
+    } finally {
+      manager.stopHealthPolling();
+      manager.getHealthState = originalGetHealthState;
+      restoreGlobalProperty('setInterval', originalSetInterval);
+    }
+  });
+
   test('keeps client deadlines beyond the server probe ceiling', async () => {
     const manager = asPrivateManager(new ServerManager());
     const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');


### PR DESCRIPTION
## Summary
- Restore the server UI to `running` when the active health poll recovers after a transient failure.
- Broadcast the recovered snapshot so Home readiness, accessibility announcements, and Settings lifecycle controls match the healthy server.

## Defect
A single failed health poll left the manager in `error` indefinitely. Later healthy polls restored engine readiness but Home still reported setup trouble, while Settings hid Stop/Restart and offered Start against an already healthy server.

## Validation
- `Set-Location app; bun test tests/request-deadlines.test.ts` — 5 passed, 0 failed
- `Set-Location app; bun run build:main` — passed
- `git diff --check 3f6f11fea1f56bad5bca562759afc0fc986af54e..HEAD` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server health monitoring so transient failures correctly show an error state.
  * Restored servers now reliably return to a running state when health checks recover.
  * Recovery status updates are broadcast even when other server details remain unchanged.
  * Prevented delayed health responses from updating server status after monitoring has stopped or restarted.

* **Tests**
  * Added coverage confirming stale health responses are ignored after polling stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->