### PR TITLE
fix: stop repeated settings recovery

### DIFF
--- a/app/src/renderer/app/server-settings-recovery.ts
+++ b/app/src/renderer/app/server-settings-recovery.ts
@@ -72,12 +72,14 @@ export function recoverInterruptedManagedPreparation(
     || lifecycle.applying
     || Object.keys(lifecycle.pending).length > 0;
 
+  if (!interrupted) return null;
+
   return {
     pending: {},
     requested: false,
     active: false,
     observed: false,
     applying: false,
-    message: interrupted ? MANAGED_SERVER_PREPARATION_INTERRUPTED : '',
+    message: MANAGED_SERVER_PREPARATION_INTERRUPTED,
   };
 }

--- a/app/tests/server-settings-recovery.test.ts
+++ b/app/tests/server-settings-recovery.test.ts
@@ -62,6 +62,16 @@ describe('Settings server-state recovery', () => {
     expect(recoverInterruptedManagedPreparation(ready, lifecycle)).toBeNull();
   });
 
+  test('does not emit another recovery after an interrupted preparation is already clear', () => {
+    expect(recoverInterruptedManagedPreparation(starting, {
+      pending: {},
+      requested: false,
+      active: false,
+      observed: false,
+      applying: false,
+    })).toBeNull();
+  });
+
   test('preserves staged preparation during an unmanaged development outage', () => {
     const lifecycle = {
       pending: { engine: 'whisper' },


### PR DESCRIPTION
## Summary
- make managed preparation recovery idempotent after a model/server failure
- prevent the always-mounted Settings effect from self-invalidating and starving renderer navigation
- add a regression test for the already-cleared lifecycle

## Validation
- 249 unit/source tests passed
- 19 rendered Electron fixture tests passed sequentially
- TypeScript main and renderer checks passed
- production build passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate recovery notifications when no interrupted server preparation remains.
  - Recovery messages continue to appear when an interrupted preparation is detected, with its state cleared appropriately.

- **Tests**
  - Added coverage to verify that already-cleared preparation states do not trigger another recovery result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->