### PR TITLE
chore: prepare v0.8.2-alpha.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Models are downloaded from their public Hugging Face repositories the first time
 | **Small — Lightweight** | A smaller download for constrained hardware | [faster-whisper-small](https://huggingface.co/Systran/faster-whisper-small) |
 | **Medium / Tiny — Advanced** | Raw engine choices for users who want to tune the trade-off | [faster-whisper-medium](https://huggingface.co/Systran/faster-whisper-medium) / [faster-whisper-tiny](https://huggingface.co/Systran/faster-whisper-tiny) |
 
-The v0.8.2-alpha.1 alpha ships Faster-Whisper as its sole selectable engine. Nemotron
+The v0.8.2-alpha.3 alpha ships Faster-Whisper as its sole selectable engine. Nemotron
 remains in the source tree and optional `nemotron` dependency for deferred
 repair work; it is not shipped or user-selectable in this alpha.
 
@@ -64,7 +64,7 @@ The [v0.7.0 release record](https://github.com/burntcookiedough/eve-windows-dict
 | `murmur-0.7.0-x64.nsis.7z` | 2,033,658,084 | `9f3137a096ac2183828e393a41b19e23a0b7387c2f44d40f6285d059ae2ae619` |
 | `latest.yml` | 558 | `fd23678bbed97980152fe9495c27f39081e61c1207f76f0eb614afac9d5c6221` |
 
-The current source tree also contains **Eve v0.8.2-alpha.1 pre-alpha work**. It is unreleased source work, not a published version or downloadable artifact; use the [development setup](#development) below to run it locally.
+The current source tree also contains **Eve v0.8.2-alpha.3 pre-alpha work**. It is unreleased source work, not a published version or downloadable artifact; use the [development setup](#development) below to run it locally.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eve for Windows
 
-<p><img src="https://img.shields.io/badge/v0.8.2-alpha.2-orange?style=flat-square" alt="v0.8.2-alpha.2"> <strong>Source status: v0.8.2-alpha.2 stabilization alpha · prerelease</strong></p>
+<p><img src="https://img.shields.io/badge/v0.8.2-alpha.3-orange?style=flat-square" alt="v0.8.2-alpha.3"> <strong>Source status: v0.8.2-alpha.3 stabilization alpha · prerelease</strong></p>
 
 ## Local-first dictation that stays in your flow
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.8.2-alpha.2",
+  "version": "0.8.2-alpha.3",
   "description": "Desktop voice transcription app",
   "repository": {
     "type": "git",

--- a/scripts/release-verify.ps1
+++ b/scripts/release-verify.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$ExpectedVersion = "0.8.2-alpha.2",
+    [string]$ExpectedVersion = "0.8.2-alpha.3",
     [string]$InstallerDir = "E:\EveRelease\release-prep\full-nsis-web\nsis-web",
     [string]$InstallDir = "E:\EveRelease\release-prep\smoke-install\Eve",
     [string]$BaseBranch = "trunk",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "murmur"
-version = "0.8.2-alpha.2"
+version = "0.8.2-alpha.3"
 description = "WebSocket-based live voice transcription server"
 requires-python = ">=3.11"
 dependencies = [

--- a/server/src/version.py
+++ b/server/src/version.py
@@ -1,3 +1,3 @@
 """Version constants for the Murmur server."""
 
-SERVER_VERSION = "0.8.2-alpha.2"
+SERVER_VERSION = "0.8.2-alpha.3"

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "murmur"
-version = "0.8.2-alpha.2"
+version = "0.8.2-alpha.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- synchronize Eve application and server versions to 0.8.2-alpha.3
- update release verification defaults and visible source-status metadata
- preserve dependencies, identity, installer, runtime, profiles, protocols, and cache behavior

## Validation
- version check for v0.8.2-alpha.3 passed
- 249 app unit/source tests passed; 19 rendered Electron fixture tests passed (Home fixture rerun sequentially after an initial local fixture-start race)
- History/Insights aggregate check passed
- both TypeScript projects passed
- production source build passed
- 227 server tests passed
- uv lock check passed
- app/bun.lock unchanged
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application and server prerelease version to **0.8.2-alpha.3**.
  - Synchronized the documented version and release verification settings with the new prerelease version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->