### PR TITLE
fix: preserve prerelease promotion state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ on:
         required: true
         default: false
         type: boolean
+      publish_prerelease:
+        description: Publish a hyphenated semantic-version tag as a prerelease, never latest
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -65,10 +70,13 @@ jobs:
           EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}
           ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
           ACCEPTED_NAME_RISK: ${{ inputs.accepted_name_risk }}
+          PUBLISH_PRERELEASE: ${{ inputs.publish_prerelease }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_RELEASE_ID -notmatch '^[1-9][0-9]*$') { throw 'Malformed release inputs.' }
+          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_RELEASE_ID -notmatch '^[1-9][0-9]*$' -or $env:PUBLISH_PRERELEASE -notin @('true', 'false')) { throw 'Malformed release inputs.' }
           if ($env:ACCEPTED_NAME_RISK -ne 'true') { throw 'Name-risk acceptance must be explicit.' }
+          $tagIsPrerelease = $env:TAG -match '-'
+          if (($env:PUBLISH_PRERELEASE -eq 'true') -ne $tagIsPrerelease) { throw 'Prerelease intent must match the semantic-version tag.' }
       - name: Download existing draft assets only
         shell: pwsh
         env:
@@ -76,6 +84,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
           EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}
+          PUBLISH_PRERELEASE: ${{ inputs.publish_prerelease }}
         run: |
           $ErrorActionPreference = 'Stop'
           function Resolve-ReleaseTagCommit {
@@ -98,7 +107,7 @@ jobs:
           $releaseJson = gh api "repos/${{ github.repository }}/releases/$env:EXPECTED_RELEASE_ID"
           if ($LASTEXITCODE -ne 0) { throw 'Draft release ID could not be fetched.' }
           $release = $releaseJson | ConvertFrom-Json
-          if ([string]$release.id -ne $env:EXPECTED_RELEASE_ID -or -not $release.draft -or $release.prerelease -or $release.tag_name -ne $env:TAG -or $release.target_commitish -ne $env:EXPECTED_COMMIT) { throw 'An exact-ID, exact-target non-prerelease draft release is required.' }
+          if ([string]$release.id -ne $env:EXPECTED_RELEASE_ID -or -not $release.draft -or [bool]$release.prerelease -ne ($env:PUBLISH_PRERELEASE -eq 'true') -or $release.tag_name -ne $env:TAG -or $release.target_commitish -ne $env:EXPECTED_COMMIT) { throw 'An exact-ID, exact-target draft release with matching prerelease intent is required.' }
           $version = $env:TAG.Substring(1)
           $expectedNames = @(
             "Eve.Web.Setup.$version.exe",
@@ -165,9 +174,10 @@ jobs:
           EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}
           EXPECTED_MANIFEST_SHA256: ${{ inputs.expected_manifest_sha256 }}
           ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
+          PUBLISH_PRERELEASE: ${{ inputs.publish_prerelease }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_RELEASE_ID -notmatch '^[1-9][0-9]*$' -or $env:EXPECTED_MANIFEST_SHA256 -notmatch '^[0-9a-fA-F]{64}$' -or $env:ALLOW_UNSIGNED -notin @('true', 'false')) { throw 'Malformed release inputs.' }
+          if ($env:TAG -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' -or $env:EXPECTED_COMMIT -notmatch '^[0-9a-f]{40}$' -or $env:EXPECTED_RELEASE_ID -notmatch '^[1-9][0-9]*$' -or $env:EXPECTED_MANIFEST_SHA256 -notmatch '^[0-9a-fA-F]{64}$' -or $env:ALLOW_UNSIGNED -notin @('true', 'false') -or $env:PUBLISH_PRERELEASE -notin @('true', 'false')) { throw 'Malformed release inputs.' }
           function Resolve-ReleaseTagCommit {
             $refJson = gh api "repos/${{ github.repository }}/git/ref/tags/$env:TAG"
             if ($LASTEXITCODE -ne 0) { throw 'Exact release tag does not exist.' }
@@ -188,7 +198,7 @@ jobs:
           $releaseJson = gh api "repos/${{ github.repository }}/releases/$env:EXPECTED_RELEASE_ID"
           if ($LASTEXITCODE -ne 0) { throw 'Draft release ID could not be re-fetched after approval.' }
           $release = $releaseJson | ConvertFrom-Json
-          if ([string]$release.id -ne $env:EXPECTED_RELEASE_ID -or -not $release.draft -or $release.prerelease -or $release.tag_name -ne $env:TAG -or $release.target_commitish -ne $env:EXPECTED_COMMIT) { throw 'Draft ID, target, or state changed after verification.' }
+          if ([string]$release.id -ne $env:EXPECTED_RELEASE_ID -or -not $release.draft -or [bool]$release.prerelease -ne ($env:PUBLISH_PRERELEASE -eq 'true') -or $release.tag_name -ne $env:TAG -or $release.target_commitish -ne $env:EXPECTED_COMMIT) { throw 'Draft ID, target, prerelease intent, or state changed after verification.' }
           $version = $env:TAG.Substring(1)
           $expectedNames = @(
             "Eve.Web.Setup.$version.exe",
@@ -220,4 +230,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
-        run: gh release edit $env:TAG --repo '${{ github.repository }}' --draft=false --prerelease=false --latest
+          PUBLISH_PRERELEASE: ${{ inputs.publish_prerelease }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:PUBLISH_PRERELEASE -eq 'true') {
+            gh release edit $env:TAG --repo '${{ github.repository }}' --draft=false --prerelease --latest=false
+          } else {
+            gh release edit $env:TAG --repo '${{ github.repository }}' --draft=false --prerelease=false --latest
+          }
+          if ($LASTEXITCODE -ne 0) { throw 'Release publication failed.' }

--- a/docs/architecture/eve-gate-6c-publication-runbook.md
+++ b/docs/architecture/eve-gate-6c-publication-runbook.md
@@ -4,11 +4,13 @@
 2. Run the single authorized final-head package and full lifecycle validation; stop on failure.
 3. Generate the seven-asset manifest/checksum set and rehash it independently.
 4. Create the exact annotated tag only after acceptance; tag pushes do not trigger a workflow.
-5. Manually create a draft release and upload exactly the manifest, SHA256/SHA512 sums,
-   third-party notice, wrapper, payload, and `latest.yml`.
+5. Manually create a draft release with prerelease state matching the semantic-version
+   tag and upload exactly the manifest, SHA256/SHA512 sums, third-party notice, wrapper,
+   payload, and `latest.yml`.
 6. Record the draft's immutable numeric REST release ID, then dispatch the verifier from
    `trunk` with that release ID, exact tag, release commit, manifest hash,
-   `allow_unsigned=true`, and `accepted_name_risk=true`. The immutable dispatch
+   `allow_unsigned=true`, `accepted_name_risk=true`, and prerelease intent matching the
+   tag. The immutable dispatch
    `github.sha` supplies the reviewed control-plane scripts; the release tag, draft
    `targetCommitish`, and manifest must independently identify the accepted release
    commit. The workflow fetches the draft by release ID and downloads each of the exact
@@ -16,7 +18,8 @@
    GitHub requires `contents: write` on this otherwise read/download/verify-only job to
    access an existing draft release; checkout credentials remain disabled.
 7. A configured `production-release` environment reviewer approves the promotion job.
-   The job re-downloads and re-verifies, then changes `draft=false`, `prerelease=false`,
-   and marks the verified release latest.
+   The job re-downloads and re-verifies, then publishes a hyphenated semantic-version
+   tag with `prerelease=true` and `latest=false`; a stable tag is published with
+   `prerelease=false` and marked latest.
 8. Download public assets and compare hashes. On any mismatch stop: never move the tag or
    replace assets. Preserve evidence and follow the incident withdrawal procedure.

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -146,20 +146,25 @@ def _create_release_fixture(directory: Path) -> subprocess.CompletedProcess[str]
 
 def test_release_workflow_is_manual_and_never_builds_or_uploads() -> None:
     workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
-    assert "workflow_dispatch:" in workflow
+    dispatch_block = workflow.split("workflow_dispatch:", 1)[1].split("permissions:", 1)[0]
+    risk_gate_step = workflow.split("- name: Require explicit risk gates", 1)[1].split(
+        "- name: Download existing draft assets only", 1
+    )[0]
+    assert dispatch_block
     assert "push:" not in workflow
     for forbidden in ("package:win", "electron-builder", "bun install", "softprops/action-gh-release", "gh release upload", "gh release create"):
         assert forbidden not in workflow
     assert "production-release" in workflow
     assert "allow_unsigned" in workflow
     assert "accepted_name_risk" in workflow
-    assert "publish_prerelease" in workflow
+    assert "publish_prerelease:" in dispatch_block
     allow_block = workflow.split("allow_unsigned:", 1)[1].split("accepted_name_risk:", 1)[0]
     name_block = workflow.split("accepted_name_risk:", 1)[1].split("permissions:", 1)[0]
     assert "default: false" in allow_block
     assert "default: false" in name_block
     assert "draft=false" in workflow
-    assert "Prerelease intent must match the semantic-version tag." in workflow
+    assert "PUBLISH_PRERELEASE: ${{ inputs.publish_prerelease }}" in risk_gate_step
+    assert "Prerelease intent must match the semantic-version tag." in risk_gate_step
 
 
 def test_release_asset_contract_and_notice_generator_are_tracked() -> None:
@@ -262,9 +267,12 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
     assert "gh release download" not in workflow
     assert "EXPECTED_MANIFEST_SHA256" in workflow
     assert "-AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')" in workflow
-    assert "gh release edit $env:TAG" in workflow
-    assert "--prerelease --latest=false" in workflow
-    assert "--prerelease=false --latest" in workflow
+    publish_step = workflow.split(
+        "- name: Publish the existing verified draft only", 1
+    )[1]
+    assert "gh release edit $env:TAG" in publish_step
+    assert "--draft=false --prerelease --latest=false" in publish_step
+    assert "--draft=false --prerelease=false --latest" in publish_step
     assert "gh release upload" not in workflow
     assert "gh release create" not in workflow
 

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -153,11 +153,13 @@ def test_release_workflow_is_manual_and_never_builds_or_uploads() -> None:
     assert "production-release" in workflow
     assert "allow_unsigned" in workflow
     assert "accepted_name_risk" in workflow
+    assert "publish_prerelease" in workflow
     allow_block = workflow.split("allow_unsigned:", 1)[1].split("accepted_name_risk:", 1)[0]
     name_block = workflow.split("accepted_name_risk:", 1)[1].split("permissions:", 1)[0]
     assert "default: false" in allow_block
     assert "default: false" in name_block
     assert "draft=false" in workflow
+    assert "Prerelease intent must match the semantic-version tag." in workflow
 
 
 def test_release_asset_contract_and_notice_generator_are_tracked() -> None:
@@ -229,6 +231,9 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
     assert workflow.count("[string]$release.id -ne $env:EXPECTED_RELEASE_ID") == 2
     assert workflow.count("$release.tag_name -ne $env:TAG") == 2
     assert workflow.count("$release.target_commitish -ne $env:EXPECTED_COMMIT") == 2
+    assert workflow.count(
+        "[bool]$release.prerelease -ne ($env:PUBLISH_PRERELEASE -eq 'true')"
+    ) == 2
     assert workflow.count("$assets.Count -ne $expectedNames.Count") == 2
     assert workflow.count("'Accept: application/octet-stream'") == 2
     assert workflow.count('"Authorization: Bearer $env:GH_TOKEN"') == 2
@@ -250,6 +255,7 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
     assert (
         "EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}" in promote_step
     )
+    assert "PUBLISH_PRERELEASE: ${{ inputs.publish_prerelease }}" in promote_step
     assert "$ErrorActionPreference = 'Stop'" in promote_step
     assert verifier in promote_step
     assert "gh release view" not in workflow
@@ -257,6 +263,8 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
     assert "EXPECTED_MANIFEST_SHA256" in workflow
     assert "-AllowUnsigned:($env:ALLOW_UNSIGNED -eq 'true')" in workflow
     assert "gh release edit $env:TAG" in workflow
+    assert "--prerelease --latest=false" in workflow
+    assert "--prerelease=false --latest" in workflow
     assert "gh release upload" not in workflow
     assert "gh release create" not in workflow
 

--- a/server/tests/test_gate6c_release_controls.py
+++ b/server/tests/test_gate6c_release_controls.py
@@ -236,9 +236,10 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
     assert workflow.count("[string]$release.id -ne $env:EXPECTED_RELEASE_ID") == 2
     assert workflow.count("$release.tag_name -ne $env:TAG") == 2
     assert workflow.count("$release.target_commitish -ne $env:EXPECTED_COMMIT") == 2
-    assert workflow.count(
+    prerelease_check = (
         "[bool]$release.prerelease -ne ($env:PUBLISH_PRERELEASE -eq 'true')"
-    ) == 2
+    )
+    assert verify_draft.count(prerelease_check) == 1
     assert workflow.count("$assets.Count -ne $expectedNames.Count") == 2
     assert workflow.count("'Accept: application/octet-stream'") == 2
     assert workflow.count('"Authorization: Bearer $env:GH_TOKEN"') == 2
@@ -261,6 +262,7 @@ def test_release_workflow_maps_inputs_and_preserves_release_boundaries() -> None
         "EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}" in promote_step
     )
     assert "PUBLISH_PRERELEASE: ${{ inputs.publish_prerelease }}" in promote_step
+    assert promote_step.count(prerelease_check) == 1
     assert "$ErrorActionPreference = 'Stop'" in promote_step
     assert verifier in promote_step
     assert "gh release view" not in workflow

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -234,11 +234,14 @@ def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:
     contents = workflow_path.read_text(encoding="utf-8")
     assert "workflow_dispatch:" in contents
     assert "production-release" in contents
+    assert "publish_prerelease" in contents
     assert "release-artifacts.ps1 -Mode Verify" in contents
     assert 'gh api "repos/${{ github.repository }}/releases/$env:EXPECTED_RELEASE_ID"' in contents
     assert "'Accept: application/octet-stream'" in contents
     assert "gh release download" not in contents
     assert "draft=false" in contents
+    assert "--prerelease --latest=false" in contents
+    assert "--prerelease=false --latest" in contents
     allow_block = contents.split("allow_unsigned:", 1)[1].split("accepted_name_risk:", 1)[0]
     name_block = contents.split("accepted_name_risk:", 1)[1].split("permissions:", 1)[0]
     assert "default: false" in allow_block

--- a/server/tests/test_release_config.py
+++ b/server/tests/test_release_config.py
@@ -232,6 +232,9 @@ def test_release_verification_requires_both_engine_discovery_properties() -> Non
 def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:
     workflow_path = ROOT / ".github" / "workflows" / "release.yml"
     contents = workflow_path.read_text(encoding="utf-8")
+    publish_step = contents.split(
+        "- name: Publish the existing verified draft only", 1
+    )[1]
     assert "workflow_dispatch:" in contents
     assert "production-release" in contents
     assert "publish_prerelease" in contents
@@ -240,8 +243,9 @@ def test_release_workflow_verifies_existing_draft_without_rebuilding() -> None:
     assert "'Accept: application/octet-stream'" in contents
     assert "gh release download" not in contents
     assert "draft=false" in contents
-    assert "--prerelease --latest=false" in contents
-    assert "--prerelease=false --latest" in contents
+    assert "PUBLISH_PRERELEASE: ${{ inputs.publish_prerelease }}" in publish_step
+    assert "--draft=false --prerelease --latest=false" in publish_step
+    assert "--draft=false --prerelease=false --latest" in publish_step
     allow_block = contents.split("allow_unsigned:", 1)[1].split("accepted_name_risk:", 1)[0]
     name_block = contents.split("accepted_name_risk:", 1)[1].split("permissions:", 1)[0]
     assert "default: false" in allow_block


### PR DESCRIPTION
## Summary
- add an explicit prerelease publication intent input
- require prerelease intent to match semantic-version tag shape
- verify draft prerelease state before and after environment approval
- publish alpha tags as prerelease and never latest
- document and test both prerelease and stable promotion paths

Tracks #76. This changes release control only and does not rebuild or modify the accepted alpha.3 application artifacts.

## Validation
- 31 focused release-control/config/docs tests passed
- full backend suite: 227 passed
- workflow YAML parsed successfully
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prerelease publishing support for hyphenated semantic-version tags.
  * Stable tags are published as the latest release, while prerelease tags remain excluded from latest.
  * Release verification now confirms that draft release status matches the requested prerelease intent.

* **Documentation**
  * Updated the release promotion runbook with prerelease requirements and verification steps.

* **Tests**
  * Expanded release workflow checks to validate prerelease intent and publication settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->